### PR TITLE
fix: Tolerances for EKS nodes need to be ON_DEMAND

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.1.1 (Released)
+FEATURES:
+
+BUG FIXES:
+- Switches the EKS Node Group tolerances from ANY to ON_DEMAND as taints must be unique to a tuple of (key, effect) in EKS.
+
+BREAKING CHANGES:
+
+NOTES:
+- Currently only tested with AWS EKS. Examples and testing for GCP GKE still to be completed.
+
+
 ## 0.1.0 (Released)
 FEATURES:
 - Initial Kubernetes Anyscale Terraform Module release

--- a/examples/aws/eks-private/main.tf
+++ b/examples/aws/eks-private/main.tf
@@ -230,7 +230,7 @@ module "anyscale_eks_nodegroups" {
       taints = [
         {
           key    = "node.anyscale.com/capacity-type",
-          value  = "ANY",
+          value  = "ON_DEMAND",
           effect = "NO_SCHEDULE",
         }
       ]
@@ -255,7 +255,7 @@ module "anyscale_eks_nodegroups" {
       taints = [
         {
           key    = "node.anyscale.com/capacity-type",
-          value  = "ANY",
+          value  = "ON_DEMAND",
           effect = "NO_SCHEDULE",
         }
       ]
@@ -309,7 +309,7 @@ module "anyscale_eks_nodegroups" {
         },
         {
           key    = "node.anyscale.com/capacity-type",
-          value  = "ANY",
+          value  = "ON_DEMAND",
           effect = "NO_SCHEDULE",
         },
         {
@@ -345,7 +345,7 @@ module "anyscale_eks_nodegroups" {
         },
         {
           key    = "node.anyscale.com/capacity-type",
-          value  = "ANY",
+          value  = "ON_DEMAND",
           effect = "NO_SCHEDULE",
         },
         {
@@ -382,7 +382,7 @@ module "anyscale_eks_nodegroups" {
         },
         {
           key    = "node.anyscale.com/capacity-type",
-          value  = "ANY",
+          value  = "SPOT",
           effect = "NO_SCHEDULE",
         },
         {

--- a/examples/aws/eks-private/main.tf
+++ b/examples/aws/eks-private/main.tf
@@ -403,6 +403,9 @@ module "anyscale_k8s_helm" {
 
   kubernetes_cluster_name = module.anyscale_eks_cluster.eks_cluster_name
 
+  # Set up NLB for internal traffic only.
+  anyscale_ingress_aws_nlb_internal = true
+
   depends_on = [module.anyscale_eks_nodegroups]
 }
 

--- a/examples/aws/eks-public/main.tf
+++ b/examples/aws/eks-public/main.tf
@@ -230,7 +230,7 @@ module "anyscale_eks_nodegroups" {
       taints = [
         {
           key    = "node.anyscale.com/capacity-type",
-          value  = "ANY",
+          value  = "ON_DEMAND",
           effect = "NO_SCHEDULE",
         }
       ]
@@ -255,7 +255,7 @@ module "anyscale_eks_nodegroups" {
       taints = [
         {
           key    = "node.anyscale.com/capacity-type",
-          value  = "ANY",
+          value  = "ON_DEMAND",
           effect = "NO_SCHEDULE",
         }
       ]
@@ -309,7 +309,7 @@ module "anyscale_eks_nodegroups" {
         },
         {
           key    = "node.anyscale.com/capacity-type",
-          value  = "ANY",
+          value  = "ON_DEMAND",
           effect = "NO_SCHEDULE",
         },
         {
@@ -345,7 +345,7 @@ module "anyscale_eks_nodegroups" {
         },
         {
           key    = "node.anyscale.com/capacity-type",
-          value  = "ANY",
+          value  = "ON_DEMAND",
           effect = "NO_SCHEDULE",
         },
         {
@@ -382,7 +382,7 @@ module "anyscale_eks_nodegroups" {
         },
         {
           key    = "node.anyscale.com/capacity-type",
-          value  = "ANY",
+          value  = "SPOT",
           effect = "NO_SCHEDULE",
         },
         {


### PR DESCRIPTION
Switches the ALL tolerance to ON_DEMAND, as taints must be unique to a tuple of (key, effect) in EKS, which wasn't possible with the ALL convention

Changes to be committed:
	modified:   eks-private/main.tf
	modified:   eks-public/main.tf

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] pre-commit has been run
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All tests passing
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull Request Type

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation change
- [ ] Other (please describe):

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

