### PR TITLE
gke existing cluster: remove var existing_vpc_id and use name to query it

### DIFF
--- a/examples/gcp/gke-existing_cluster/README.md
+++ b/examples/gcp/gke-existing_cluster/README.md
@@ -21,7 +21,7 @@ anyscale_org_id     = "..." # Troubleshooting Org Id
 google_region     = "..."
 google_project_id = "..."
 existing_vpc_name            = "..."
-existing_subnet_name         = "..."
+existing_subnet_cidr         = "..."
 customer_ingress_cidr_ranges = "0.0.0.0/0"
 existing_gke_cluster_name    = "..."
 existing_gke_cluster_region  = "..."
@@ -41,8 +41,8 @@ existing_gke_cluster_region  = "..."
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 5.44.1 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.32.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 5.44.2 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.33.0 |
 
 ## Modules
 
@@ -62,6 +62,7 @@ existing_gke_cluster_region  = "..."
 | [google_service_account_iam_binding.workload_identity_bindings](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
 | [kubernetes_service_account.anyscale](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account) | resource |
 | [google_client_config.provider](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
+| [google_compute_network.existing_vpc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_network) | data source |
 | [google_container_cluster.anyscale](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/container_cluster) | data source |
 
 ## Inputs
@@ -69,18 +70,17 @@ existing_gke_cluster_region  = "..."
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_anyscale_org_id"></a> [anyscale\_org\_id](#input\_anyscale\_org\_id) | (Required) Anyscale Organization ID | `string` | n/a | yes |
-| <a name="input_customer_ingress_cidr_ranges"></a> [customer\_ingress\_cidr\_ranges](#input\_customer\_ingress\_cidr\_ranges) | The IPv4 CIDR blocks that allows access Anyscale clusters.<br/>These are added to the firewall and allows port 443 (https) and 22 (ssh) access.<br/>ex: `52.1.1.23/32,10.1.0.0/16'<br/>` | `string` | n/a | yes |
+| <a name="input_customer_ingress_cidr_ranges"></a> [customer\_ingress\_cidr\_ranges](#input\_customer\_ingress\_cidr\_ranges) | The IPv4 CIDR blocks that allows access Anyscale clusters.<br>These are added to the firewall and allows port 443 (https) and 22 (ssh) access.<br>ex: `52.1.1.23/32,10.1.0.0/16'<br>` | `string` | n/a | yes |
 | <a name="input_existing_gke_cluster_name"></a> [existing\_gke\_cluster\_name](#input\_existing\_gke\_cluster\_name) | The name of the existing GKE cluster | `string` | n/a | yes |
 | <a name="input_existing_gke_cluster_region"></a> [existing\_gke\_cluster\_region](#input\_existing\_gke\_cluster\_region) | The region of the existing GKE cluster | `string` | n/a | yes |
 | <a name="input_existing_subnet_cidr"></a> [existing\_subnet\_cidr](#input\_existing\_subnet\_cidr) | The CIDR range of the existing subnet | `string` | n/a | yes |
-| <a name="input_existing_vpc_id"></a> [existing\_vpc\_id](#input\_existing\_vpc\_id) | The ID of the existing VPC | `string` | n/a | yes |
 | <a name="input_existing_vpc_name"></a> [existing\_vpc\_name](#input\_existing\_vpc\_name) | The name of the existing VPC | `string` | n/a | yes |
 | <a name="input_google_project_id"></a> [google\_project\_id](#input\_google\_project\_id) | ID of the Project to put these resources in | `string` | n/a | yes |
 | <a name="input_google_region"></a> [google\_region](#input\_google\_region) | The Google region in which all resources will be created. | `string` | n/a | yes |
 | <a name="input_anyscale_cloud_id"></a> [anyscale\_cloud\_id](#input\_anyscale\_cloud\_id) | (Optional) Anyscale Cloud ID | `string` | `null` | no |
-| <a name="input_anyscale_deploy_env"></a> [anyscale\_deploy\_env](#input\_anyscale\_deploy\_env) | (Optional) Anyscale deploy environment. Used in resource names and tags.<br/><br/>ex:<pre>anyscale_deploy_env = "production"</pre> | `string` | `"production"` | no |
+| <a name="input_anyscale_deploy_env"></a> [anyscale\_deploy\_env](#input\_anyscale\_deploy\_env) | (Optional) Anyscale deploy environment. Used in resource names and tags.<br><br>ex:<pre>anyscale_deploy_env = "production"</pre> | `string` | `"production"` | no |
 | <a name="input_anyscale_k8s_namespace"></a> [anyscale\_k8s\_namespace](#input\_anyscale\_k8s\_namespace) | The Anyscale namespace to deploy the workload | `string` | `"anyscale-k8s"` | no |
-| <a name="input_labels"></a> [labels](#input\_labels) | (Optional) A map of labels to all resources that accept labels. | `map(string)` | <pre>{<br/>  "environment": "test",<br/>  "test": true<br/>}</pre> | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | (Optional) A map of labels to all resources that accept labels. | `map(string)` | <pre>{<br>  "environment": "test",<br>  "test": true<br>}</pre> | no |
 
 ## Outputs
 

--- a/examples/gcp/gke-existing_cluster/data.tf
+++ b/examples/gcp/gke-existing_cluster/data.tf
@@ -4,3 +4,7 @@ data "google_container_cluster" "anyscale" {
   name     = var.existing_gke_cluster_name
   location = var.existing_gke_cluster_region
 }
+
+data "google_compute_network" "existing_vpc" {
+  name = var.existing_vpc_name
+}

--- a/examples/gcp/gke-existing_cluster/main.tf
+++ b/examples/gcp/gke-existing_cluster/main.tf
@@ -71,7 +71,7 @@ module "anyscale_firewall" {
   module_enabled = true
 
   vpc_name = var.existing_vpc_name
-  vpc_id   = var.existing_vpc_id
+  vpc_id   = data.google_compute_network.existing_vpc.id
 
   ingress_with_self_cidr_range = [var.existing_subnet_cidr]
   ingress_from_cidr_map = [

--- a/examples/gcp/gke-existing_cluster/variables.tf
+++ b/examples/gcp/gke-existing_cluster/variables.tf
@@ -48,11 +48,6 @@ variable "existing_vpc_name" {
   type        = string
 }
 
-variable "existing_vpc_id" {
-  description = "The ID of the existing VPC"
-  type        = string
-}
-
 variable "existing_subnet_cidr" {
   description = "The CIDR range of the existing subnet"
   type        = string


### PR DESCRIPTION
As a follow up for https://github.com/anyscale/terraform-kubernetes-anyscale-foundation-modules/pull/6#discussion_r1802092665

Basically We don't need both existing_vpc_name and existing_vpc_id. Can use one to query the other.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] pre-commit has been run
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] All tests passing
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull Request Type

- [ ] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation change
- [ ] Other (please describe):

## Does this introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots. -->
