### PR TITLE
upd: GKE new_cluster - Add implicit depends_on for IAM binding

### DIFF
--- a/examples/gcp/gke-new_cluster/main.tf
+++ b/examples/gcp/gke-new_cluster/main.tf
@@ -85,4 +85,6 @@ resource "google_service_account_iam_binding" "workload_identity_bindings" {
   role               = "roles/iam.workloadIdentityUser"
   service_account_id = google_service_account.gke_nodes.id
   members            = ["serviceAccount:${var.google_project_id}.svc.id.goog[${var.anyscale_k8s_namespace}/anyscale-operator]"]
+
+  depends_on = [module.gke]
 }


### PR DESCRIPTION
In some scenarios, the IAM binding resource was being created before the GKE cluster, causing the binding to fail. This change adds an implicit depends_on relationship between the IAM binding and the GKE cluster resource.

On branch brent/iam-binding-depends-on
Changes to be committed:
	modified:   gcp/gke-new_cluster/main.tf

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] pre-commit has been run
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All tests passing
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull Request Type

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation change
- [ ] Other (please describe):

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

