### PR TITLE
Add node_group_gpu_types option to dynamically define GPU nodegroups

### DIFF
--- a/examples/aws/eks-private/README.md
+++ b/examples/aws/eks-private/README.md
@@ -195,7 +195,7 @@ helm upgrade anyscale-private anyscale/anyscale-operator \
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.88.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.94.1 |
 
 ## Modules
 

--- a/examples/aws/eks-private/README.md
+++ b/examples/aws/eks-private/README.md
@@ -195,7 +195,7 @@ helm upgrade anyscale-private anyscale/anyscale-operator \
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.90.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.88.0 |
 
 ## Modules
 
@@ -220,16 +220,17 @@ helm upgrade anyscale-private anyscale/anyscale-operator \
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | (Optional) The AWS region in which all resources will be created.<br/><br/>ex:<pre>aws_region = "us-east-2"</pre> | `string` | `"us-east-2"` | no |
-| <a name="input_eks_cluster_name"></a> [eks\_cluster\_name](#input\_eks\_cluster\_name) | (Optional) The name of the EKS cluster.<br/><br/>This will be used for naming resources created by this module including the EKS cluster and the S3 bucket.<br/><br/>ex:<pre>eks_cluster_name = "anyscale-eks-public"</pre> | `string` | `"anyscale-eks-public"` | no |
-| <a name="input_eks_cluster_version"></a> [eks\_cluster\_version](#input\_eks\_cluster\_version) | (Optional) The Kubernetes version of the EKS cluster.<br/><br/>ex:<pre>eks_cluster_version = "1.31"</pre> | `string` | `"1.31"` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to all resources that accept tags.<br/><br/>ex:<pre>tags = {<br/>  Environment = "dev"<br/>  Repo        = "terraform-kubernetes-anyscale-foundation-modules",<br/>}</pre> | `map(string)` | <pre>{<br/>  "Environment": "dev",<br/>  "Example": "aws/eks-private",<br/>  "Repo": "terraform-kubernetes-anyscale-foundation-modules",<br/>  "Test": "true"<br/>}</pre> | no |
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | (Optional) The AWS region in which all resources will be created.<br><br>ex:<pre>aws_region = "us-east-2"</pre> | `string` | `"us-east-2"` | no |
+| <a name="input_eks_cluster_name"></a> [eks\_cluster\_name](#input\_eks\_cluster\_name) | (Optional) The name of the EKS cluster.<br><br>This will be used for naming resources created by this module including the EKS cluster and the S3 bucket.<br><br>ex:<pre>eks_cluster_name = "anyscale-eks-public"</pre> | `string` | `"anyscale-eks-public"` | no |
+| <a name="input_eks_cluster_version"></a> [eks\_cluster\_version](#input\_eks\_cluster\_version) | (Optional) The Kubernetes version of the EKS cluster.<br><br>ex:<pre>eks_cluster_version = "1.31"</pre> | `string` | `"1.31"` | no |
+| <a name="input_node_group_gpu_types"></a> [node\_group\_gpu\_types](#input\_node\_group\_gpu\_types) | (Optional) The GPU types of the EKS nodes.<br>Possible values: ["T4", "A10G"] | `list(string)` | <pre>[<br>  "T4"<br>]</pre> | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to all resources that accept tags.<br><br>ex:<pre>tags = {<br>  Environment = "dev"<br>  Repo        = "terraform-kubernetes-anyscale-foundation-modules",<br>}</pre> | `map(string)` | <pre>{<br>  "Environment": "dev",<br>  "Example": "aws/eks-private",<br>  "Repo": "terraform-kubernetes-anyscale-foundation-modules",<br>  "Test": "true"<br>}</pre> | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_anyscale_register_command"></a> [anyscale\_register\_command](#output\_anyscale\_register\_command) | Anyscale register command.<br/>This output can be used with the Anyscale CLI to register a new Anyscale Cloud.<br/>You will need to replace `<CUSTOMER_DEFINED_NAME>` with a name of your choosing before running the Anyscale CLI command. |
+| <a name="output_anyscale_register_command"></a> [anyscale\_register\_command](#output\_anyscale\_register\_command) | Anyscale register command.<br>This output can be used with the Anyscale CLI to register a new Anyscale Cloud.<br>You will need to replace `<CUSTOMER_DEFINED_NAME>` with a name of your choosing before running the Anyscale CLI command. |
 | <a name="output_aws_region"></a> [aws\_region](#output\_aws\_region) | The AWS region. This is used for Helm chart values. |
 | <a name="output_eks_cluster_name"></a> [eks\_cluster\_name](#output\_eks\_cluster\_name) | The name of the EKS cluster. This is used for Helm chart values. |
 <!-- END_TF_DOCS -->

--- a/examples/aws/eks-private/eks.tf
+++ b/examples/aws/eks-private/eks.tf
@@ -21,6 +21,86 @@ locals {
     anyscale_s3_policy = module.anyscale_iam_roles.anyscale_iam_s3_policy_arn,
     efs_client_policy  = "arn:aws:iam::aws:policy/AmazonElasticFileSystemClientReadWriteAccess",
   }
+
+  # Map of GPU types to their product names
+  gpu_product_names = {
+    "T4"   = "Tesla-T4",
+    "A10G" = "NVIDIA-A10G"
+  }
+
+  gpu_instance_types = {
+    "T4"   = ["g4dn.4xlarge"]
+    "A10G" = ["g5.4xlarge"]
+  }
+
+  # Base configuration for GPU node groups
+  gpu_node_group_base = {
+    ami_type                     = "AL2_x86_64_GPU"
+    min_size                     = 0
+    max_size                     = 10
+    desired_size                 = 0
+    iam_role_additional_policies = local.anyscale_iam
+    taints = [
+      {
+        key    = "nvidia.com/gpu",
+        value  = "present",
+        effect = "NO_SCHEDULE",
+      },
+      {
+        key    = "node.anyscale.com/accelerator-type",
+        value  = "GPU",
+        effect = "NO_SCHEDULE",
+      }
+    ]
+  }
+
+  # Create a map of GPU node groups based on node_group_gpu_types
+  gpu_node_groups = {
+    for gpu_type in var.node_group_gpu_types : gpu_type => {
+      ondemand = merge(
+        local.gpu_node_group_base,
+        {
+          instance_types = local.gpu_instance_types[gpu_type]
+          capacity_type  = "ON_DEMAND"
+          labels = {
+            "nvidia.com/gpu.product" = local.gpu_product_names[gpu_type]
+            "nvidia.com/gpu.count"   = "1"
+          }
+          taints = concat(
+            local.gpu_node_group_base.taints,
+            [
+              {
+                key    = "node.anyscale.com/capacity-type",
+                value  = "ON_DEMAND",
+                effect = "NO_SCHEDULE",
+              }
+            ]
+          )
+        }
+      )
+      spot = merge(
+        local.gpu_node_group_base,
+        {
+          instance_types = local.gpu_instance_types[gpu_type]
+          capacity_type  = "SPOT"
+          labels = {
+            "nvidia.com/gpu.product" = local.gpu_product_names[gpu_type]
+            "nvidia.com/gpu.count"   = "1"
+          }
+          taints = concat(
+            local.gpu_node_group_base.taints,
+            [
+              {
+                key    = "node.anyscale.com/capacity-type",
+                value  = "SPOT",
+                effect = "NO_SCHEDULE",
+              }
+            ]
+          )
+        }
+      )
+    }
+  }
 }
 
 #trivy:ignore:avd-aws-0038
@@ -70,146 +150,82 @@ module "eks" {
   # Managed Node Groups configuration example
   #############################################################
 
-  eks_managed_node_groups = {
-    # This node group is for management components such as CoreDNS, Cluster Autoscaler, AWS-LB controller, ingress-nginx, Anyscale Operator, etc.
-    # Note that small instance types of Anyscale workloads can still be scheduled onto this node group.
-    default = {
-      ami_type       = "AL2023_x86_64_STANDARD"
-      instance_types = ["t3.medium"]
+  eks_managed_node_groups = merge(
+    {
+      # This node group is for management components such as CoreDNS, Cluster Autoscaler, AWS-LB controller, ingress-nginx, Anyscale Operator, etc.
+      # Note that small instance types of Anyscale workloads can still be scheduled onto this node group.
+      default = {
+        ami_type       = "AL2023_x86_64_STANDARD"
+        instance_types = ["t3.medium"]
 
-      min_size     = 1
-      max_size     = 10
-      desired_size = 2
+        min_size     = 1
+        max_size     = 10
+        desired_size = 2
 
-      iam_role_additional_policies = merge(local.anyscale_iam, {
-        cluster_autoscaler_policy = aws_iam_policy.autoscaler_policy.arn
-        elb_policy                = aws_iam_policy.elb_policy.arn
-      })
-    }
-
-    ondemand_cpu = {
-      ami_type = "AL2023_x86_64_STANDARD"
-      instance_types = [
-        "m6a.4xlarge",
-        "m5a.4xlarge",
-        "m6i.4xlarge",
-        "m5.4xlarge",
-      ]
-
-      capacity_type = "ON_DEMAND"
-      min_size      = 0
-      max_size      = 10
-      desired_size  = 0
-
-      taints = [
-        {
-          key    = "node.anyscale.com/capacity-type",
-          value  = "ON_DEMAND",
-          effect = "NO_SCHEDULE",
-        }
-      ]
-
-      iam_role_additional_policies = local.anyscale_iam
-    }
-
-    spot_cpu = {
-      ami_type = "AL2023_x86_64_STANDARD"
-      instance_types = [
-        "m6a.4xlarge",
-        "m5a.4xlarge",
-        "m6i.4xlarge",
-        "m5.4xlarge",
-      ]
-
-      capacity_type = "SPOT"
-      min_size      = 0
-      max_size      = 10
-      desired_size  = 0
-
-      taints = [
-        {
-          key    = "node.anyscale.com/capacity-type",
-          value  = "SPOT",
-          effect = "NO_SCHEDULE",
-        }
-      ]
-
-      iam_role_additional_policies = local.anyscale_iam
-    }
-
-    ondemand_gpu = {
-      ami_type = "AL2_x86_64_GPU"
-      instance_types = [
-        "g5.4xlarge"
-      ]
-
-      capacity_type = "ON_DEMAND"
-      min_size      = 0
-      max_size      = 10
-      desired_size  = 0
-
-      labels = {
-        "nvidia.com/gpu.product" = "NVIDIA-A10G"
-        "nvidia.com/gpu.count"   = "1"
+        iam_role_additional_policies = merge(local.anyscale_iam, {
+          cluster_autoscaler_policy = aws_iam_policy.autoscaler_policy.arn
+          elb_policy                = aws_iam_policy.elb_policy.arn
+        })
       }
-      taints = [
-        {
-          key    = "nvidia.com/gpu",
-          value  = "present",
-          effect = "NO_SCHEDULE",
-        },
-        {
-          key    = "node.anyscale.com/capacity-type",
-          value  = "ON_DEMAND",
-          effect = "NO_SCHEDULE",
-        },
-        {
-          key    = "node.anyscale.com/accelerator-type",
-          value  = "GPU",
-          effect = "NO_SCHEDULE",
-        }
-      ]
 
-      iam_role_additional_policies = local.anyscale_iam
-    }
+      ondemand_cpu = {
+        ami_type = "AL2023_x86_64_STANDARD"
+        instance_types = [
+          "m6a.4xlarge",
+          "m5a.4xlarge",
+          "m6i.4xlarge",
+          "m5.4xlarge",
+        ]
 
-    spot_gpu = {
-      ami_type = "AL2_x86_64_GPU"
-      instance_types = [
-        "g5.4xlarge"
-      ]
+        capacity_type = "ON_DEMAND"
+        min_size      = 0
+        max_size      = 10
+        desired_size  = 0
 
-      capacity_type = "SPOT"
-      min_size      = 0
-      max_size      = 10
-      desired_size  = 0
+        taints = [
+          {
+            key    = "node.anyscale.com/capacity-type",
+            value  = "ON_DEMAND",
+            effect = "NO_SCHEDULE",
+          }
+        ]
 
-
-      labels = {
-        "nvidia.com/gpu.product" = "NVIDIA-A10G"
-        "nvidia.com/gpu.count"   = "1"
+        iam_role_additional_policies = local.anyscale_iam
       }
-      taints = [
-        {
-          key    = "nvidia.com/gpu",
-          value  = "present",
-          effect = "NO_SCHEDULE",
-        },
-        {
-          key    = "node.anyscale.com/capacity-type",
-          value  = "SPOT",
-          effect = "NO_SCHEDULE",
-        },
-        {
-          key    = "node.anyscale.com/accelerator-type",
-          value  = "GPU",
-          effect = "NO_SCHEDULE",
-        }
-      ]
 
-      iam_role_additional_policies = local.anyscale_iam
+      spot_cpu = {
+        ami_type = "AL2023_x86_64_STANDARD"
+        instance_types = [
+          "m6a.4xlarge",
+          "m5a.4xlarge",
+          "m6i.4xlarge",
+          "m5.4xlarge",
+        ]
+
+        capacity_type = "SPOT"
+        min_size      = 0
+        max_size      = 10
+        desired_size  = 0
+
+        taints = [
+          {
+            key    = "node.anyscale.com/capacity-type",
+            value  = "SPOT",
+            effect = "NO_SCHEDULE",
+          }
+        ]
+
+        iam_role_additional_policies = local.anyscale_iam
+      }
+    },
+    # Merge in GPU node groups based on node_group_gpu_types
+    {
+      for gpu_type in var.node_group_gpu_types : "ondemand_gpu_${lower(gpu_type)}" => local.gpu_node_groups[gpu_type].ondemand
+    },
+    {
+      for gpu_type in var.node_group_gpu_types : "spot_gpu_${lower(gpu_type)}" => local.gpu_node_groups[gpu_type].spot
     }
-  }
+  )
 
   tags = var.tags
 }

--- a/examples/aws/eks-private/variables.tf
+++ b/examples/aws/eks-private/variables.tf
@@ -77,3 +77,12 @@ variable "eks_cluster_version" {
   type        = string
   default     = "1.31"
 }
+
+variable "node_group_gpu_types" {
+  description = <<-EOT
+    (Optional) The GPU types of the EKS nodes.
+    Possible values: ["T4", "A10G"]
+  EOT
+  type        = list(string)
+  default     = ["T4"]
+}

--- a/examples/aws/eks-public/README.md
+++ b/examples/aws/eks-public/README.md
@@ -195,7 +195,7 @@ helm upgrade anyscale-public anyscale/anyscale-operator \
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.88.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.94.1 |
 
 ## Modules
 

--- a/examples/aws/eks-public/README.md
+++ b/examples/aws/eks-public/README.md
@@ -195,7 +195,7 @@ helm upgrade anyscale-public anyscale/anyscale-operator \
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.89.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.88.0 |
 
 ## Modules
 
@@ -220,16 +220,17 @@ helm upgrade anyscale-public anyscale/anyscale-operator \
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | (Optional) The AWS region in which all resources will be created.<br/><br/>ex:<pre>aws_region = "us-east-2"</pre> | `string` | `"us-east-2"` | no |
-| <a name="input_eks_cluster_name"></a> [eks\_cluster\_name](#input\_eks\_cluster\_name) | (Optional) The name of the EKS cluster.<br/><br/>This will be used for naming resources created by this module including the EKS cluster and the S3 bucket.<br/><br/>ex:<pre>eks_cluster_name = "anyscale-eks-public"</pre> | `string` | `"anyscale-eks-public"` | no |
-| <a name="input_eks_cluster_version"></a> [eks\_cluster\_version](#input\_eks\_cluster\_version) | (Optional) The Kubernetes version of the EKS cluster.<br/><br/>ex:<pre>eks_cluster_version = "1.31"</pre> | `string` | `"1.31"` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to all resources that accept tags.<br/><br/>ex:<pre>tags = {<br/>  Environment = "dev"<br/>  Repo        = "terraform-kubernetes-anyscale-foundation-modules",<br/>}</pre> | `map(string)` | <pre>{<br/>  "Environment": "dev",<br/>  "Example": "aws/eks-public",<br/>  "Repo": "terraform-kubernetes-anyscale-foundation-modules",<br/>  "Test": "true"<br/>}</pre> | no |
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | (Optional) The AWS region in which all resources will be created.<br><br>ex:<pre>aws_region = "us-east-2"</pre> | `string` | `"us-east-2"` | no |
+| <a name="input_eks_cluster_name"></a> [eks\_cluster\_name](#input\_eks\_cluster\_name) | (Optional) The name of the EKS cluster.<br><br>This will be used for naming resources created by this module including the EKS cluster and the S3 bucket.<br><br>ex:<pre>eks_cluster_name = "anyscale-eks-public"</pre> | `string` | `"anyscale-eks-public"` | no |
+| <a name="input_eks_cluster_version"></a> [eks\_cluster\_version](#input\_eks\_cluster\_version) | (Optional) The Kubernetes version of the EKS cluster.<br><br>ex:<pre>eks_cluster_version = "1.31"</pre> | `string` | `"1.31"` | no |
+| <a name="input_node_group_gpu_types"></a> [node\_group\_gpu\_types](#input\_node\_group\_gpu\_types) | (Optional) The GPU types of the EKS nodes.<br>Possible values: ["T4", "A10G"] | `list(string)` | <pre>[<br>  "T4"<br>]</pre> | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to all resources that accept tags.<br><br>ex:<pre>tags = {<br>  Environment = "dev"<br>  Repo        = "terraform-kubernetes-anyscale-foundation-modules",<br>}</pre> | `map(string)` | <pre>{<br>  "Environment": "dev",<br>  "Example": "aws/eks-public",<br>  "Repo": "terraform-kubernetes-anyscale-foundation-modules",<br>  "Test": "true"<br>}</pre> | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_anyscale_register_command"></a> [anyscale\_register\_command](#output\_anyscale\_register\_command) | Anyscale register command.<br/>This output can be used with the Anyscale CLI to register a new Anyscale Cloud.<br/>You will need to replace `<CUSTOMER_DEFINED_NAME>` with a name of your choosing before running the Anyscale CLI command. |
+| <a name="output_anyscale_register_command"></a> [anyscale\_register\_command](#output\_anyscale\_register\_command) | Anyscale register command.<br>This output can be used with the Anyscale CLI to register a new Anyscale Cloud.<br>You will need to replace `<CUSTOMER_DEFINED_NAME>` with a name of your choosing before running the Anyscale CLI command. |
 | <a name="output_aws_region"></a> [aws\_region](#output\_aws\_region) | The AWS region. This is used for Helm chart values. |
 | <a name="output_eks_cluster_name"></a> [eks\_cluster\_name](#output\_eks\_cluster\_name) | The name of the EKS cluster. This is used for Helm chart values. |
 <!-- END_TF_DOCS -->

--- a/examples/aws/eks-public/eks.tf
+++ b/examples/aws/eks-public/eks.tf
@@ -22,15 +22,16 @@ locals {
     efs_client_policy  = "arn:aws:iam::aws:policy/AmazonElasticFileSystemClientReadWriteAccess",
   }
 
-  # Map of GPU types to their product names
-  gpu_product_names = {
-    "T4"   = "Tesla-T4",
-    "A10G" = "NVIDIA-A10G"
-  }
-
-  gpu_instance_types = {
-    "T4"   = ["g4dn.4xlarge"]
-    "A10G" = ["g5.4xlarge"]
+  # Map of GPU types to their product names and instance types
+  gpu_types = {
+    "T4" = {
+      product_name   = "Tesla-T4"
+      instance_types = ["g4dn.4xlarge"]
+    }
+    "A10G" = {
+      product_name   = "NVIDIA-A10G"
+      instance_types = ["g5.4xlarge"]
+    }
   }
 
   # Base configuration for GPU node groups
@@ -77,10 +78,10 @@ locals {
       ondemand = merge(
         local.gpu_node_group_base,
         {
-          instance_types = local.gpu_instance_types[gpu_type]
+          instance_types = local.gpu_types[gpu_type].instance_types
           capacity_type  = "ON_DEMAND"
           labels = {
-            "nvidia.com/gpu.product" = local.gpu_product_names[gpu_type]
+            "nvidia.com/gpu.product" = local.gpu_types[gpu_type].product_name
             "nvidia.com/gpu.count"   = "1"
           }
           taints = local.gpu_node_taints_ondemand
@@ -89,10 +90,10 @@ locals {
       spot = merge(
         local.gpu_node_group_base,
         {
-          instance_types = local.gpu_instance_types[gpu_type]
+          instance_types = local.gpu_types[gpu_type].instance_types
           capacity_type  = "SPOT"
           labels = {
-            "nvidia.com/gpu.product" = local.gpu_product_names[gpu_type]
+            "nvidia.com/gpu.product" = local.gpu_types[gpu_type].product_name
             "nvidia.com/gpu.count"   = "1"
           }
           taints = local.gpu_node_taints_spot

--- a/examples/aws/eks-public/eks.tf
+++ b/examples/aws/eks-public/eks.tf
@@ -21,6 +21,85 @@ locals {
     anyscale_s3_policy = module.anyscale_iam_roles.anyscale_iam_s3_policy_arn,
     efs_client_policy  = "arn:aws:iam::aws:policy/AmazonElasticFileSystemClientReadWriteAccess",
   }
+
+  # Map of GPU types to their product names
+  gpu_product_names = {
+    "T4"   = "Tesla-T4",
+    "A10G" = "NVIDIA-A10G"
+  }
+
+  gpu_instance_types = {
+    "T4"   = ["g4dn.4xlarge"]
+    "A10G" = ["g5.4xlarge"]
+  }
+
+  # Base configuration for GPU node groups
+  gpu_node_group_base = {
+    ami_type                     = "AL2_x86_64_GPU"
+    min_size                     = 0
+    max_size                     = 10
+    desired_size                 = 0
+    iam_role_additional_policies = local.anyscale_iam
+  }
+
+  gpu_node_taints_base = [
+    {
+      key    = "nvidia.com/gpu",
+      value  = "present",
+      effect = "NO_SCHEDULE",
+    },
+    {
+      key    = "node.anyscale.com/accelerator-type",
+      value  = "GPU",
+      effect = "NO_SCHEDULE",
+    }
+  ]
+
+  gpu_node_taints_ondemand = concat(local.gpu_node_taints_base, [
+    {
+      key    = "node.anyscale.com/capacity-type",
+      value  = "ON_DEMAND",
+      effect = "NO_SCHEDULE",
+    }
+  ])
+
+  gpu_node_taints_spot = concat(local.gpu_node_taints_base, [
+    {
+      key    = "node.anyscale.com/capacity-type",
+      value  = "SPOT",
+      effect = "NO_SCHEDULE",
+    }
+  ])
+
+  # Create a map of GPU node groups based on node_group_gpu_types
+  gpu_node_groups = {
+    for gpu_type in var.node_group_gpu_types : gpu_type => {
+      ondemand = merge(
+        local.gpu_node_group_base,
+        {
+          instance_types = local.gpu_instance_types[gpu_type]
+          capacity_type  = "ON_DEMAND"
+          labels = {
+            "nvidia.com/gpu.product" = local.gpu_product_names[gpu_type]
+            "nvidia.com/gpu.count"   = "1"
+          }
+          taints = local.gpu_node_taints_ondemand
+        }
+      )
+      spot = merge(
+        local.gpu_node_group_base,
+        {
+          instance_types = local.gpu_instance_types[gpu_type]
+          capacity_type  = "SPOT"
+          labels = {
+            "nvidia.com/gpu.product" = local.gpu_product_names[gpu_type]
+            "nvidia.com/gpu.count"   = "1"
+          }
+          taints = local.gpu_node_taints_spot
+        }
+      )
+    }
+  }
 }
 
 #trivy:ignore:avd-aws-0038
@@ -70,146 +149,82 @@ module "eks" {
   # Managed Node Groups configuration example
   #############################################################
 
-  eks_managed_node_groups = {
-    # This node group is for management components such as CoreDNS, Cluster Autoscaler, AWS-LB controller, ingress-nginx, Anyscale Operator, etc.
-    # Note that small instance types of Anyscale workloads can still be scheduled onto this node group.
-    default = {
-      ami_type       = "AL2023_x86_64_STANDARD"
-      instance_types = ["t3.medium"]
+  eks_managed_node_groups = merge(
+    {
+      # This node group is for management components such as CoreDNS, Cluster Autoscaler, AWS-LB controller, ingress-nginx, Anyscale Operator, etc.
+      # Note that small instance types of Anyscale workloads can still be scheduled onto this node group.
+      default = {
+        ami_type       = "AL2023_x86_64_STANDARD"
+        instance_types = ["t3.medium"]
 
-      min_size     = 1
-      max_size     = 10
-      desired_size = 2
+        min_size     = 1
+        max_size     = 10
+        desired_size = 2
 
-      iam_role_additional_policies = merge(local.anyscale_iam, {
-        cluster_autoscaler_policy = aws_iam_policy.autoscaler_policy.arn
-        elb_policy                = aws_iam_policy.elb_policy.arn
-      })
-    }
-
-    ondemand_cpu = {
-      ami_type = "AL2023_x86_64_STANDARD"
-      instance_types = [
-        "m6a.4xlarge",
-        "m5a.4xlarge",
-        "m6i.4xlarge",
-        "m5.4xlarge",
-      ]
-
-      capacity_type = "ON_DEMAND"
-      min_size      = 0
-      max_size      = 10
-      desired_size  = 0
-
-      taints = [
-        {
-          key    = "node.anyscale.com/capacity-type",
-          value  = "ON_DEMAND",
-          effect = "NO_SCHEDULE",
-        }
-      ]
-
-      iam_role_additional_policies = local.anyscale_iam
-    }
-
-    spot_cpu = {
-      ami_type = "AL2023_x86_64_STANDARD"
-      instance_types = [
-        "m6a.4xlarge",
-        "m5a.4xlarge",
-        "m6i.4xlarge",
-        "m5.4xlarge",
-      ]
-
-      capacity_type = "SPOT"
-      min_size      = 0
-      max_size      = 10
-      desired_size  = 0
-
-      taints = [
-        {
-          key    = "node.anyscale.com/capacity-type",
-          value  = "SPOT",
-          effect = "NO_SCHEDULE",
-        }
-      ]
-
-      iam_role_additional_policies = local.anyscale_iam
-    }
-
-    ondemand_gpu = {
-      ami_type = "AL2_x86_64_GPU"
-      instance_types = [
-        "g5.4xlarge"
-      ]
-
-      capacity_type = "ON_DEMAND"
-      min_size      = 0
-      max_size      = 10
-      desired_size  = 0
-
-      labels = {
-        "nvidia.com/gpu.product" = "NVIDIA-A10G"
-        "nvidia.com/gpu.count"   = "1"
+        iam_role_additional_policies = merge(local.anyscale_iam, {
+          cluster_autoscaler_policy = aws_iam_policy.autoscaler_policy.arn
+          elb_policy                = aws_iam_policy.elb_policy.arn
+        })
       }
-      taints = [
-        {
-          key    = "nvidia.com/gpu",
-          value  = "present",
-          effect = "NO_SCHEDULE",
-        },
-        {
-          key    = "node.anyscale.com/capacity-type",
-          value  = "ON_DEMAND",
-          effect = "NO_SCHEDULE",
-        },
-        {
-          key    = "node.anyscale.com/accelerator-type",
-          value  = "GPU",
-          effect = "NO_SCHEDULE",
-        }
-      ]
 
-      iam_role_additional_policies = local.anyscale_iam
-    }
+      ondemand_cpu = {
+        ami_type = "AL2023_x86_64_STANDARD"
+        instance_types = [
+          "m6a.4xlarge",
+          "m5a.4xlarge",
+          "m6i.4xlarge",
+          "m5.4xlarge",
+        ]
 
-    spot_gpu = {
-      ami_type = "AL2_x86_64_GPU"
-      instance_types = [
-        "g5.4xlarge"
-      ]
+        capacity_type = "ON_DEMAND"
+        min_size      = 0
+        max_size      = 10
+        desired_size  = 0
 
-      capacity_type = "SPOT"
-      min_size      = 0
-      max_size      = 10
-      desired_size  = 0
+        taints = [
+          {
+            key    = "node.anyscale.com/capacity-type",
+            value  = "ON_DEMAND",
+            effect = "NO_SCHEDULE",
+          }
+        ]
 
-
-      labels = {
-        "nvidia.com/gpu.product" = "NVIDIA-A10G"
-        "nvidia.com/gpu.count"   = "1"
+        iam_role_additional_policies = local.anyscale_iam
       }
-      taints = [
-        {
-          key    = "nvidia.com/gpu",
-          value  = "present",
-          effect = "NO_SCHEDULE",
-        },
-        {
-          key    = "node.anyscale.com/capacity-type",
-          value  = "SPOT",
-          effect = "NO_SCHEDULE",
-        },
-        {
-          key    = "node.anyscale.com/accelerator-type",
-          value  = "GPU",
-          effect = "NO_SCHEDULE",
-        }
-      ]
 
-      iam_role_additional_policies = local.anyscale_iam
+      spot_cpu = {
+        ami_type = "AL2023_x86_64_STANDARD"
+        instance_types = [
+          "m6a.4xlarge",
+          "m5a.4xlarge",
+          "m6i.4xlarge",
+          "m5.4xlarge",
+        ]
+
+        capacity_type = "SPOT"
+        min_size      = 0
+        max_size      = 10
+        desired_size  = 0
+
+        taints = [
+          {
+            key    = "node.anyscale.com/capacity-type",
+            value  = "SPOT",
+            effect = "NO_SCHEDULE",
+          }
+        ]
+
+        iam_role_additional_policies = local.anyscale_iam
+      }
+    },
+    # Merge in GPU node groups based on node_group_gpu_types
+    {
+      for gpu_type in var.node_group_gpu_types : "ondemand_gpu_${lower(gpu_type)}" => local.gpu_node_groups[gpu_type].ondemand
+    },
+    {
+      for gpu_type in var.node_group_gpu_types : "spot_gpu_${lower(gpu_type)}" => local.gpu_node_groups[gpu_type].spot
     }
-  }
+  )
 
   tags = var.tags
 }

--- a/examples/aws/eks-public/variables.tf
+++ b/examples/aws/eks-public/variables.tf
@@ -72,3 +72,12 @@ variable "eks_cluster_version" {
   type        = string
   default     = "1.31"
 }
+
+variable "node_group_gpu_types" {
+  description = <<-EOT
+    (Optional) The GPU types of the EKS nodes.
+    Possible values: ["T4", "A10G"]
+  EOT
+  type        = list(string)
+  default     = ["T4"]
+}

--- a/examples/gcp/gke-new_cluster/README.md
+++ b/examples/gcp/gke-new_cluster/README.md
@@ -201,6 +201,7 @@ anyscale cloud register \
 | <a name="input_gke_cluster_name"></a> [gke\_cluster\_name](#input\_gke\_cluster\_name) | (Optional) GKE Cluster Name<br><br>The name of the GKE cluster to create.<br><br>ex:<pre>cluster_name = "anyscale-cluster"</pre> | `string` | `"anyscale-gke"` | no |
 | <a name="input_ingress_cidr_ranges"></a> [ingress\_cidr\_ranges](#input\_ingress\_cidr\_ranges) | (Optional) The IPv4 CIDR blocks that allows access Anyscale clusters.<br><br>These are added to the firewall and allows port 443 (https) and 22 (ssh) access.<br><br>ex:<pre>ingress_cidr_ranges=["52.1.1.23/32","10.1.0.0/16"]</pre> | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | (Optional) A map of labels to all resources that accept labels.<br><br>ex:<pre>labels = {<br>  "example" = true<br>  "environment" = "example"<br>}</pre> | `map(string)` | <pre>{<br>  "environment": "example",<br>  "example": true<br>}</pre> | no |
+| <a name="input_node_group_gpu_types"></a> [node\_group\_gpu\_types](#input\_node\_group\_gpu\_types) | (Optional) The GPU types of the GKE nodes.<br>Possible values: ["V100", "P100", "T4", "L4", "A100-40G", "A100-80G", "H100", "H100-MEGA"] | `list(string)` | <pre>[<br>  "T4"<br>]</pre> | no |
 
 ## Outputs
 

--- a/examples/gcp/gke-new_cluster/variables.tf
+++ b/examples/gcp/gke-new_cluster/variables.tf
@@ -99,6 +99,15 @@ variable "gke_cluster_name" {
     error_message = "Cluster name must not start with a number and must be under 23 characters."
   }
 }
+variable "node_group_gpu_types" {
+  description = <<-EOT
+    (Optional) The GPU types of the GKE nodes.
+    Possible values: ["V100", "P100", "T4", "L4", "A100-40G", "A100-80G", "H100", "H100-MEGA"]
+  EOT
+  type        = list(string)
+  default     = ["T4"]
+}
+
 
 variable "ingress_cidr_ranges" {
   description = <<-EOT


### PR DESCRIPTION
In `terraform.tfvars`, specify:

```
...
node_group_gpu_types = ["T4", "L4", "A100"]
```

Then it will dynamically create the corresponding GPU node groups.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] pre-commit has been run
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] All tests passing
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull Request Type

- [ ] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation change
- [ ] Other (please describe):

## Does this introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots. -->
