### PR TITLE
eks: remove ALB comment

### DIFF
--- a/examples/aws/eks-private/sample-values_nginx.yaml
+++ b/examples/aws/eks-private/sample-values_nginx.yaml
@@ -2,7 +2,7 @@ controller:
   service:
     type: LoadBalancer
     annotations:
-      service.beta.kubernetes.io/aws-load-balancer-scheme: "internal" # This creates an internal ALB. To change to public, use `internet-facing`
+      service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
       service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
       service.beta.kubernetes.io/aws-load-balancer-type: nlb
   allowSnippetAnnotations: true


### PR DESCRIPTION
Removing this commend since we already have eks-public and its nginx values doesn't have this comment.