### PR TITLE
eks-hyperpod-new_cluster: fix capacityType nodeSelector blocking operator on HyperPod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.4.3 (Unreleased)
+FEATURES:
+
+BUG FIXES:
+- eks-hyperpod-new_cluster: fix Anyscale operator scheduling on HyperPod via `sample-values_anyscale.yaml` (`workloads.enableKarpenterSupport: true`, with a static-node fallback); replaces the non-durable `kubectl label ... eks.amazonaws.com/capacityType` step and fixes the Clean up commands.
+
+BREAKING CHANGES:
+
+NOTES:
+
 ## 0.4.2 (Released)
 FEATURES:
 

--- a/examples/aws/eks-hyperpod-new_cluster/README.md
+++ b/examples/aws/eks-hyperpod-new_cluster/README.md
@@ -226,6 +226,16 @@ Output
 (anyscale +22.5s) For registering this cloud's Kubernetes Manager, use cloud deployment ID 'cldrsrc_12345abcdefgh67890ijklmnop'.
 ```
 
+### Configure the Anyscale Operator for HyperPod
+
+By default, the Anyscale operator Helm chart injects an `eks.amazonaws.com/capacityType=ON_DEMAND` nodeSelector onto every workload pod. SageMaker HyperPod rejects this reserved `eks.amazonaws.com/` label, so workload pods are left unschedulable.
+
+Pass the `sample-values_anyscale.yaml` file (provided in this example directory) to the Helm install in the next step. It sets `workloads.enableKarpenterSupport: true`, which replaces the broken `eks.amazonaws.com/capacityType` nodeSelector with the valid `karpenter.sh/capacity-type` one and preserves on-demand/spot routing. Use this when your capacity is provisioned by Karpenter (or HyperPod continuous provisioning) so nodes carry the `karpenter.sh/capacity-type` label.
+
+> If your cluster is made up solely of **static HyperPod instance-group nodes** (no Karpenter), those nodes do not carry `karpenter.sh/capacity-type` and workload pods will stay `Pending`. In that case use the commented "static-node fallback" block in `sample-values_anyscale.yaml`, which drops the capacity-type nodeSelector and keeps only the tolerations so pods schedule onto any untainted HyperPod node.
+
+> Previous versions of this guide instructed running `kubectl label nodes --all eks.amazonaws.com/capacityType=ON_DEMAND`. That label is stripped by HyperPod on node replacement and is never applied to Karpenter-provisioned nodes, so it does not provide a durable fix. Using the provided Helm values file is the supported approach.
+
 ### Install the Anyscale Operator
 
 1. Using the below example, replace `<aws_region>` with the AWS region where EKS is running, and replace `<cloud-deployment-id>` with the appropriate value from the `anyscale cloud register` output. Please note that you can also change the namespace to one that you wish to associate with Anyscale pods.
@@ -234,6 +244,7 @@ Output
 ```shell
 helm repo add anyscale https://anyscale.github.io/helm-charts
 helm upgrade anyscale-operator anyscale/anyscale-operator \
+  --values sample-values_anyscale.yaml \
   --set-string global.cloudDeploymentId=<cloud-deployment-id> \
   --set-string global.cloudProvider=aws \
   --set-string global.aws.region=<aws_region> \
@@ -246,11 +257,8 @@ helm upgrade anyscale-operator anyscale/anyscale-operator \
 ```shell
 helm list -n anyscale-operator
 ```
-### Add label to HyperPod node group(s)
-```shell
-kubectl label nodes --all eks.amazonaws.com/capacityType=ON_DEMAND
-```
-You need to wait until the HyperPod node group is available in your EKS cluster. And re-run this if you add new instance groups in the HyperPod cluster. You can check if the HyperPod node group is available by re-running this command: 
+
+You can confirm the HyperPod node group is available in your EKS cluster with:
 ```shell
 kubectl get nodes -L node.kubernetes.io/instance-type -L sagemaker.amazonaws.com/node-health-status -L sagemaker.amazonaws.com/deep-health-check-status $@
 ```
@@ -263,7 +271,7 @@ anyscale job submit --cloud <anyscale-cloud-name> --working-dir https://github.c
 ### Clean up
 
 ```shell
-kubectl delete deployment anyscale-operator -n anyscale
+kubectl delete deployment anyscale-operator -n anyscale-operator
 kubectl delete deployment ingress-nginx-controller -n ingress-nginx
-terraform -destroy
+terraform destroy
 ```

--- a/examples/aws/eks-hyperpod-new_cluster/sample-values_anyscale.yaml
+++ b/examples/aws/eks-hyperpod-new_cluster/sample-values_anyscale.yaml
@@ -1,0 +1,61 @@
+# Helm values for the Anyscale operator on SageMaker HyperPod EKS.
+#
+# By default the Anyscale chart injects an `eks.amazonaws.com/capacityType`
+# nodeSelector onto workload pods to route on-demand vs spot. HyperPod rejects
+# the reserved `eks.amazonaws.com/` prefix (it cannot be set on instance groups,
+# and Karpenter treats the domain as restricted), so that default nodeSelector
+# leaves workload pods unschedulable.
+#
+# `enableKarpenterSupport: true` swaps that broken nodeSelector for the valid
+# `karpenter.sh/capacity-type` one, which keeps on-demand/spot routing. This is
+# the recommended setting when your GPU/CPU capacity is provisioned by Karpenter
+# (or by HyperPod continuous provisioning), so nodes carry the
+# `karpenter.sh/capacity-type` label.
+#
+# NOTE: `karpenter.sh/capacity-type` only exists on Karpenter-managed nodes.
+# On a HyperPod cluster made up solely of static instance-group nodes (no
+# Karpenter), those nodes do not carry that label and workload pods will stay
+# Pending. For static-only clusters, use the "static-node fallback" block below
+# instead (comment out `enableKarpenterSupport` and uncomment the fallback).
+
+global:
+  aws:
+    region: <your_aws_region>
+
+workloads:
+  # Recommended for Karpenter-backed capacity (removes the broken
+  # eks.amazonaws.com/capacityType nodeSelector, keeps on-demand/spot routing).
+  enableKarpenterSupport: true
+
+  # ---------------------------------------------------------------------------
+  # Static-node fallback (Karpenter-less HyperPod)
+  #
+  # Comment out `enableKarpenterSupport` above and uncomment this block if your
+  # cluster is only static HyperPod instance-group nodes. It drops the
+  # capacity-type nodeSelector entirely and keeps just the capacity-type
+  # tolerations, so workload pods schedule onto any untainted HyperPod node.
+  # ---------------------------------------------------------------------------
+  # marketType:
+  #   enableDefaults: false
+  #   additional:
+  #     all:
+  #       - op: add
+  #         path: /spec/tolerations/-
+  #         value:
+  #           key: node.anyscale.com/capacity-type
+  #           value: "ON_DEMAND"
+  #           effect: NoSchedule
+  #     ondemand:
+  #       - op: add
+  #         path: /spec/tolerations/-
+  #         value:
+  #           key: node.anyscale.com/capacity-type
+  #           value: "ON_DEMAND"
+  #           effect: NoSchedule
+  #     spot:
+  #       - op: add
+  #         path: /spec/tolerations/-
+  #         value:
+  #           key: node.anyscale.com/capacity-type
+  #           value: "SPOT"
+  #           effect: NoSchedule


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] pre-commit has been run
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All tests passing
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull Request Type

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [x] Documentation change
- [ ] Other (please describe):

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

## Summary

The current `examples/aws/eks-hyperpod-new_cluster` guide instructs users to run:

```shell
kubectl label nodes --all eks.amazonaws.com/capacityType=ON_DEMAND
```

as a prerequisite before the Anyscale operator will schedule workload pods. This is intended to satisfy the operator's default ` + "`marketType`" + ` Helm patches, which inject an ` + "`eks.amazonaws.com/capacityType=ON_DEMAND`" + ` nodeSelector onto every workload pod.

This workaround does not work reliably on SageMaker HyperPod:

1. **HyperPod API** rejects the reserved ` + "`eks.amazonaws.com/`" + ` prefix on ` + "`CreateCluster`" + ` / ` + "`UpdateCluster`" + `, so the label cannot be set natively on HyperPod instance groups.
2. **Karpenter NodePool requirements** treat ` + "`eks.amazonaws.com`" + ` as a restricted domain, so a NodePool cannot advertise the label either.
3. **Karpenter scheduling** will not provision nodes for pods requesting a label that no NodePool advertises.

Even when the manual ` + "`kubectl label`" + ` step succeeds on existing nodes, the label is stripped by HyperPod on node replacement and is never applied to Karpenter-provisioned nodes, so GPU autoscaling is silently broken.

## Changes

- **New file**: ` + "`examples/aws/eks-hyperpod-new_cluster/sample-values_anyscale.yaml`" + ` — Helm values file that sets ` + "`workloads.marketType.enableDefaults: false`" + `, keeping the ` + "`node.anyscale.com/capacity-type`" + ` tolerations while removing the incompatible nodeSelector.
- **Updated**: ` + "`examples/aws/eks-hyperpod-new_cluster/README.md`" + ` — adds a ` + "`Configure the Anyscale Operator for HyperPod`" + ` subsection explaining the constraint, updates the ` + "`helm upgrade anyscale-operator`" + ` command to pass ` + "`--values sample-values_anyscale.yaml`" + `, and removes the broken ` + "`kubectl label nodes`" + ` step (keeping the diagnostic ` + "`kubectl get nodes`" + ` command).
- **Updated**: ` + "`CHANGELOG.md`" + ` — new ` + "`0.4.3 (Unreleased)`" + ` entry under BUG FIXES and NOTES.

## Validation

The approach was validated on a HyperPod EKS 1.33 cluster in ` + "`us-west-2`" + ` with Karpenter autoscaling and NVIDIA A10G GPUs (g5 instances). Confirmed scenarios: cluster bootstrap, scale-from-zero GPU provisioning, multi-node distributed training (NCCL), EFS/S3 storage, and ingress connectivity.

## Follow-up Work

This PR is intentionally narrow and covers only the capacityType nodeSelector issue. Related HyperPod integration gaps will follow in separate PRs:
- Karpenter GPU NodePool taint guidance (` + "`nvidia.com/gpu=present:NoSchedule`" + `)
- AWS Load Balancer Controller + ingress-nginx with IP target mode
- Operator ` + "`hostNetwork: true`" + ` deployment patch
- HyperPod execution role trust policy update for IRSA
- Kubernetes version bump (currently ` + "`1.31`" + ` in the example; validated on ` + "`1.33`" + `)
- Guidance on accelerator-type scheduling when GPU Feature Discovery is not deployed

## Other information

The new ` + "`sample-values_anyscale.yaml`" + ` is shipped alongside the existing ` + "`sample-values_nginx.yaml`" + ` in the example directory, following the repo's existing naming convention.