### PR TITLE
eks-hyperpod-new_cluster: document GPU scheduling on HyperPod (no default GPU taints; optional GFD install for accelerator-type labels)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.3 (Unreleased)
+NOTES:
+- eks-hyperpod-new_cluster: document GPU scheduling on HyperPod (no default GPU taints; NVIDIA device plugin is preinstalled; optional GPU Feature Discovery install for accelerator-type labels).
+
 ## 0.4.2 (Released)
 FEATURES:
 

--- a/examples/aws/eks-hyperpod-new_cluster/README.md
+++ b/examples/aws/eks-hyperpod-new_cluster/README.md
@@ -192,6 +192,8 @@ helm upgrade ingress-nginx nginx/ingress-nginx \
 
 #### (Optional) Install the Nvidia device plugin
 
+> **HyperPod note:** you can skip this step on SageMaker HyperPod. The HyperPod dependencies Helm chart (installed as part of standard HyperPod EKS setup) already bundles the NVIDIA device plugin, so `nvidia.com/gpu` capacity is advertised on GPU nodes out of the box. See [Installing packages on the Amazon EKS cluster using Helm](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod-eks-install-packages-using-helm-chart.html). Install the plugin below only on non-HyperPod EKS clusters that do not already have it.
+
 If you intend to use NVIDIA GPUs in your Anyscale workloads, install the NVIDIA device plugin. A sample file, `sample-values_nvdp.yaml` has been provided in this repo. Please review for your requirements before using.
 
 ```shell
@@ -203,6 +205,36 @@ helm upgrade nvdp nvdp/nvidia-device-plugin \
   --create-namespace \
   --install
 ```
+
+#### GPU scheduling on HyperPod
+
+Two HyperPod-specific behaviors affect how Anyscale workloads request GPU capacity.
+
+**1. No default GPU taints.** HyperPod does not apply `NoSchedule` taints to GPU worker nodes, so no toleration is required by default. Only if you choose to taint your own GPU nodes (for example `nvidia.com/gpu=present:NoSchedule`) do you need to add a matching toleration to `global.tolerations` in the Anyscale operator Helm values.
+
+**2. No accelerator-type labels by default.** The HyperPod dependencies chart installs the NVIDIA device plugin but not GPU Feature Discovery (GFD), so accelerator-type labels (`nvidia.com/gpu.product`, `.memory`, `.count`, `.family`, plus CUDA/driver labels) are not present. You have two options:
+
+- **Default: generic GPU requests.** Use generic `GPU` requests in your Anyscale [declarative compute configs](https://docs.anyscale.com/configuration/compute/declarative). This works against any GPU node HyperPod provisions:
+
+  ```yaml
+  worker_nodes:
+    - required_resources:
+        GPU: 1
+        CPU: 8
+  ```
+
+- **Opt-in: install GFD for accelerator-type selectivity.** If you need to target specific accelerators (for example `accelerator_type: A10G`), install the NVIDIA GFD Helm chart. It bundles Node Feature Discovery, so a single install brings up the `nvidia.com/*` labels within ~30s:
+
+  ```shell
+  helm repo add nvidia https://nvidia.github.io/k8s-device-plugin
+  helm upgrade --install gpu-feature-discovery nvidia/gpu-feature-discovery \
+    --version 0.18.2 \
+    --namespace gpu-feature-discovery \
+    --create-namespace \
+    --wait
+  ```
+
+  If you already run NFD (for example via the GPU Operator), disable the bundled subchart with `--set node-feature-discovery.enabled=false`. AWS documents an equivalent static-manifest GFD install for HyperPod UltraServer clusters in [Using UltraServers in Amazon SageMaker HyperPod](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod-ultraserver.html).
 
 ### Register the Anyscale Cloud
 
@@ -250,7 +282,7 @@ helm list -n anyscale-operator
 ```shell
 kubectl label nodes --all eks.amazonaws.com/capacityType=ON_DEMAND
 ```
-You need to wait until the HyperPod node group is available in your EKS cluster. And re-run this if you add new instance groups in the HyperPod cluster. You can check if the HyperPod node group is available by re-running this command: 
+You need to wait until the HyperPod node group is available in your EKS cluster. And re-run this if you add new instance groups in the HyperPod cluster. You can check if the HyperPod node group is available by re-running this command:
 ```shell
 kubectl get nodes -L node.kubernetes.io/instance-type -L sagemaker.amazonaws.com/node-health-status -L sagemaker.amazonaws.com/deep-health-check-status $@
 ```


### PR DESCRIPTION
## Summary

Adds a **GPU scheduling on HyperPod** section to the `examples/aws/eks-hyperpod-new_cluster/README.md`. Documents two HyperPod-specific behaviors that affect how Anyscale workloads can request GPU capacity on a HyperPod EKS cluster, neither of which is covered in the current example:

1. **HyperPod does not apply default `NoSchedule` taints to GPU nodes.** Users only need a toleration in the Anyscale operator Helm values if they choose to taint their own Karpenter GPU NodePools (for example with `nvidia.com/gpu=present:NoSchedule`).
2. **HyperPod ships the NVIDIA device plugin without GPU Feature Discovery.** Accelerator-type labels (`nvidia.com/gpu.product`, `.memory`, `.count`, `.family`, plus CUDA and driver version labels) are not present on HyperPod GPU nodes by default.

The README now presents two supported paths for Anyscale compute configs:

- **Option A (default):** generic `GPU` requests (Anyscale [declarative compute configs](https://docs.anyscale.com/configuration/compute/declarative)). Works out of the box against any GPU node HyperPod provisions.
- **Option B (opt-in):** install the NVIDIA `gpu-feature-discovery` Helm chart (v0.18.2) to add accelerator-type labels and enable `accelerator_type: A10G`-style selectivity in compute configs.

## Validation

End-to-end tested on a HyperPod EKS 1.34 cluster in us-west-2 with an `ml.g5.8xlarge` (A10G) worker node:

- `helm install nvidia/gpu-feature-discovery --version 0.18.2` completed in ~30s.
- 26 `nvidia.com/*` labels landed on the HyperPod GPU node, including `gpu.product=NVIDIA-A10G`, `gpu.memory=23028`, `gpu.family=ampere`, `cuda.driver-version.full=580.126.09`.
- A test pod with `nodeSelector: {nvidia.com/gpu.product: NVIDIA-A10G}` and `resources.limits.nvidia.com/gpu: 1` scheduled on the HyperPod node and ran `nvidia-smi -L`, which reported `GPU 0: NVIDIA A10G`.
- `nvidia.com/gpu: 1` capacity from the pre-existing HyperPod NVIDIA device plugin was preserved throughout; no conflicts.
- Full cleanup (`helm uninstall` + namespace delete + CRD delete) returned the cluster to its pre-test state.

## Alignment with AWS guidance

AWS documents a functionally equivalent static-manifest procedure for installing GFD on HyperPod UltraServer clusters in [Using UltraServers in Amazon SageMaker HyperPod](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod-ultraserver.html) (install nvidia-device-plugin, NFD, and gpu-feature-discovery via three separate `kubectl apply` commands). The Helm path in this PR produces the same end state with a single command and matches the Helm-based install style this example already uses for ingress-nginx and the Anyscale operator.

## Changes

- `examples/aws/eks-hyperpod-new_cluster/README.md`: new "GPU scheduling on HyperPod" section inserted between "Verify your connection to the HyperPod cluster" and "Installing K8s Components". No other content in the example is altered.
- `CHANGELOG.md`: new `0.4.3 (Unreleased)` block with a NOTES entry summarizing the README addition.

## Pre-commit

Ran `pre-commit run --files` against the two touched files only. All checks pass (Terraform hooks skipped — no `.tf` changes).

## Type of change

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Does this PR introduce a breaking change?

No. Documentation-only addition. Does not alter any existing Terraform resources, Helm values, or install commands.