### PR TITLE
eks-hyperpod-new_cluster: document hostNetwork patch for Anyscale Operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 FEATURES:
 
 BUG FIXES:
-- eks-hyperpod-new_cluster: document the `hostNetwork: true` operator patch for HyperPod clusters where the pod network cannot reach IMDS (operator fails to sign its identity and CrashLoopBackOffs).
+- eks-hyperpod-new_cluster: document the `hostNetwork: true` + `dnsPolicy: ClusterFirstWithHostNet` operator patch for HyperPod clusters where the pod network cannot reach IMDS (operator fails to sign its identity and CrashLoopBackOffs), including re-apply guidance after `helm upgrade`.
 
 BREAKING CHANGES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.4.3 (Unreleased)
+FEATURES:
+
+BUG FIXES:
+- eks-hyperpod-new_cluster: document the `hostNetwork: true` operator patch for HyperPod clusters where the pod network cannot reach IMDS (operator fails to sign its identity and CrashLoopBackOffs).
+
+BREAKING CHANGES:
+
+NOTES:
+
 ## 0.4.2 (Released)
 FEATURES:
 

--- a/examples/aws/eks-hyperpod-new_cluster/README.md
+++ b/examples/aws/eks-hyperpod-new_cluster/README.md
@@ -246,11 +246,36 @@ helm upgrade anyscale-operator anyscale/anyscale-operator \
 ```shell
 helm list -n anyscale-operator
 ```
+
+4. **Enable `hostNetwork` on the operator Deployment (required on some HyperPod clusters).**
+
+   On SageMaker HyperPod EKS, the operator can fail to register with the Anyscale control plane because it cannot obtain AWS credentials: the operator signs its identity using instance credentials from IMDS (`169.254.169.254`), and on HyperPod the pod network cannot reach IMDS. The operator then CrashLoopBackOffs with an error like:
+
+   ```
+   register to Anyscale control plane: get identity from cloud provider:
+   sign aws identity payload: getting credentials: failed to refresh cached
+   credentials, no EC2 IMDS role found, operation error ec2imds: GetMetadata,
+   request canceled, context deadline exceeded
+   ```
+
+   Running the Deployment with `hostNetwork: true` puts the operator in the node's network namespace, where IMDS is reachable via the node's primary ENI. The `anyscale/anyscale-operator` Helm chart does not expose `hostNetwork` as a value today, so apply it as a post-install patch:
+
+   ```shell
+   kubectl patch deployment anyscale-operator \
+     -n anyscale-operator \
+     --patch '{"spec":{"template":{"spec":{"hostNetwork":true}}}}'
+
+   kubectl rollout status deployment/anyscale-operator \
+     -n anyscale-operator --timeout=300s
+   ```
+
+   This triggers a second rolling update of the operator pod after the initial Helm-driven rollout. This patch is only needed on HyperPod clusters that hit the IMDS error above; if your operator pod already reaches `Running` and connects, it is not required (for example, clusters whose pod subnets route to IMDS/the internet). It is not needed on standard EKS clusters.
+
 ### Add label to HyperPod node group(s)
 ```shell
 kubectl label nodes --all eks.amazonaws.com/capacityType=ON_DEMAND
 ```
-You need to wait until the HyperPod node group is available in your EKS cluster. And re-run this if you add new instance groups in the HyperPod cluster. You can check if the HyperPod node group is available by re-running this command: 
+You need to wait until the HyperPod node group is available in your EKS cluster. And re-run this if you add new instance groups in the HyperPod cluster. You can check if the HyperPod node group is available by re-running this command:
 ```shell
 kubectl get nodes -L node.kubernetes.io/instance-type -L sagemaker.amazonaws.com/node-health-status -L sagemaker.amazonaws.com/deep-health-check-status $@
 ```

--- a/examples/aws/eks-hyperpod-new_cluster/README.md
+++ b/examples/aws/eks-hyperpod-new_cluster/README.md
@@ -258,18 +258,20 @@ helm list -n anyscale-operator
    request canceled, context deadline exceeded
    ```
 
-   Running the Deployment with `hostNetwork: true` puts the operator in the node's network namespace, where IMDS is reachable via the node's primary ENI. The `anyscale/anyscale-operator` Helm chart does not expose `hostNetwork` as a value today, so apply it as a post-install patch:
+   Running the Deployment with `hostNetwork: true` puts the operator in the node's network namespace, where IMDS is reachable via the node's primary ENI. Pair that with `dnsPolicy: ClusterFirstWithHostNet` so the operator still resolves in-cluster DNS (kube-dns / CoreDNS) from the host network namespace. The `anyscale/anyscale-operator` Helm chart does not expose `hostNetwork` or `dnsPolicy` as values today, so apply them as a post-install patch:
 
    ```shell
    kubectl patch deployment anyscale-operator \
      -n anyscale-operator \
-     --patch '{"spec":{"template":{"spec":{"hostNetwork":true}}}}'
+     --patch '{"spec":{"template":{"spec":{"hostNetwork":true,"dnsPolicy":"ClusterFirstWithHostNet"}}}}'
 
    kubectl rollout status deployment/anyscale-operator \
      -n anyscale-operator --timeout=300s
    ```
 
    This triggers a second rolling update of the operator pod after the initial Helm-driven rollout. This patch is only needed on HyperPod clusters that hit the IMDS error above; if your operator pod already reaches `Running` and connects, it is not required (for example, clusters whose pod subnets route to IMDS/the internet). It is not needed on standard EKS clusters.
+
+   > **Note:** A later `helm upgrade` of `anyscale-operator` will reset these fields unless you re-apply the patch (or fold them into the chart once it exposes the values). Re-run the `kubectl patch` and `kubectl rollout status` commands after every Helm upgrade until then.
 
 ### Add label to HyperPod node group(s)
 ```shell


### PR DESCRIPTION
## Problem

On SageMaker HyperPod EKS clusters, following the existing ``Install the Anyscale Operator`` section in ``examples/aws/eks-hyperpod-new_cluster/README.md`` results in an Anyscale Operator pod that starts successfully but cannot reach the Anyscale control plane. The operator is installed and ``helm list`` shows it deployed, but outbound connectivity from the pod network to the Anyscale SaaS endpoints fails, and the Anyscale cloud never transitions out of the pending / not-yet-connected state.

## Root cause

HyperPod EKS worker nodes run behind a SageMaker-managed networking layer. The default pod-network path to the internet is not reliable for the operator's outbound calls. Running the operator Deployment with ``hostNetwork: true`` routes egress via the node's primary ENI, which has working outbound connectivity, and the operator then connects to the control plane as expected.

The ``anyscale/anyscale-operator`` Helm chart does not currently expose ``hostNetwork`` as a value, so the fix has to be applied as a post-install ``kubectl patch``.

## Fix

Add a new step 4 to the ``Install the Anyscale Operator`` section documenting:

- The ``kubectl patch`` command that sets ``hostNetwork: true`` on the ``anyscale-operator`` Deployment in the ``anyscale-operator`` namespace (using an inline JSON patch, no extra files required).
- A follow-up ``kubectl rollout status`` command so customers know to wait for the second rolling update before moving on.
- A note that this step is HyperPod-specific and not needed on standard EKS clusters.

If a future release of ``anyscale/anyscale-operator`` exposes ``hostNetwork`` as a Helm value, this post-install patch step can be removed and the fix folded into the existing ``helm upgrade`` command.

## Validation

End-to-end validated on a SageMaker HyperPod EKS 1.33 cluster in ``us-west-2`` (GPU node group backed by ``ml.g5.8xlarge``). After the Helm install of ``anyscale/anyscale-operator``, the operator pod's logs showed failures reaching the Anyscale control plane; applying the ``hostNetwork: true`` patch triggered a second rolling update, after which the operator pod came up healthy, connected to the Anyscale control plane, and the cloud transitioned to Active.

## Checklist

- [x] Pre-commit hooks run on changed files
- [ ] Tests added (N/A -- README-only change; repo has no active unit tests)
- [ ] Tests passing (N/A)
- [x] Documentation updated

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Breaking change

No.