### PR TITLE
Anyscale on Azure end-to-end automated deployment through Terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,14 @@ terraform.tfvars
 *.tfstate
 *.tfstate.*
 
+# Local kubeconfig written by examples (may contain cluster admin credentials)
+.kubeconfig
+*.kubeconfig
+
+# Saved terraform plan files
+*.tfplan
+tf.plan
+
 # Crash log files
 crash.log
 crash.*.log

--- a/examples/azure/anyscale-azure/README.md
+++ b/examples/azure/anyscale-azure/README.md
@@ -1,0 +1,243 @@
+# Anyscale on Azure
+
+This is a step-by-step guide that deploys **Anyscale on Azure**. It deploys Azure Resources such as AKS, VNets, subnet and storage and adds two **Azure Resource Provider** integrations that make the cluster a managed Anyscale cloud:
+
+1. **`Anyscale.Platform/clouds`** (deployed via `azapi_resource`) — registers the cloud with the Azure-hosted Anyscale control plane at `https://console.azure.anyscale.com` and produces a stable `cldrsrc_…` ID.
+2. **`Microsoft.KubernetesConfiguration/extensions`** of type `Anyscale.AKS.Operator` (deployed via `azurerm_kubernetes_cluster_extension`) — installs the operator marketplace extension into the AKS cluster's `anyscale-operator` namespace, wired to the cloud above.
+
+3. **Envoy Gateway** (Helm chart + `EnvoyProxy` + `GatewayClass` + `Gateway`) that the operator routes workspace and service traffic through — matching the upstream Anyscale-on-AKS quickstart.
+
+After the apply finishes, the cloud is visible at `https://console.azure.anyscale.com` under the cloud name you chose.
+
+## What this guide deploys
+
+| Type | Resource | Created by |
+|---|---|---|
+| Azure infra | Resource group, VNet, AKS subnet | `main.tf` |
+| Azure infra | Storage account + blob container | `main.tf` |
+| Azure infra | AKS cluster  | `aks.tf` |
+| Azure infra | User-assigned managed identity, federated credential, `Storage Blob Data Contributor` role assignment | `aks.tf` |
+| Azure infra | Azure Container Registry + kubelet `AcrPull` role assignment | `acr.tf` |
+| Anyscale | `Anyscale.Platform/clouds` ARM deployment via AzAPI | `anyscale.tf` |
+| Anyscale | `Anyscale.AKS.Operator` AKS extension | `anyscale.tf` |
+| In-cluster | Envoy Gateway Helm release (v1.7.0) | `envoy-gateway.tf` |
+| In-cluster | `EnvoyProxy` + `GatewayClass eg` + `Gateway` with TLS Secrets named from the cloud resource ID | `envoy-gateway.tf` |
+
+## Prerequisites
+
+### Azure permissions
+
+You need a Microsoft Entra account that can:
+
+1. **Sign in** to the target tenant and subscription.
+2. **Contribute** at the subscription (or target resource group) level — to create the resource group, networking, AKS, storage, identity, and role assignments.
+3. **Create service principals from external Microsoft Entra tenants** (Cloud Application Administrator / Application Administrator / Global Administrator). This is needed once per tenant for the Anyscale control plane SP:
+   ```bash
+   az ad sp create --id 086bc555-6989-4362-ba30-fded273e432b
+   ```
+4. **Accept Azure Marketplace terms** for the Anyscale operator plan, once per subscription:
+   ```bash
+   az vm image terms accept \
+     --publisher anyscale1750870039553 \
+     --offer anyscale-operator-aks \
+     --plan anyscale-operator
+   ```
+
+### Resource providers
+
+```bash
+for provider in \
+  Anyscale.Platform \
+  Microsoft.KubernetesConfiguration \
+  Microsoft.ContainerService \
+  Microsoft.ContainerRegistry \
+  Microsoft.ManagedIdentity \
+  Microsoft.Network \
+  Microsoft.OperationalInsights \
+  Microsoft.Resources \
+  Microsoft.Storage \
+  Microsoft.Authorization; do
+  az provider register --namespace "$provider"
+done
+```
+
+### Region
+
+`var.azure_location` must be one of the regions where `Anyscale.Platform/clouds` is supported:
+
+> `westcentralus`, `eastus`, `eastus2`, `westus2`, `westus3`, `southcentralus`, `westeurope`, `swedencentral`, `uksouth`, `australiaeast`, `southeastasia`, `northeurope`
+
+Default is `westus2`. Older regions like `westus` are **not** supported by the Anyscale RP.
+
+### Quota
+
+- `Microsoft.ContainerService/managedClusters` quota of **at least 1** in the chosen region (default cap is 10 per region).
+- VM family quota for `var.system_vm_size`, `var.cpu_vm_size`, and any `var.gpu_pool_configs` SKUs.
+
+### Local tools
+
+- Azure CLI (`az`) authenticated against the target tenant: `az login --tenant <tenant>`
+- Terraform `>= 1.5.0`
+- `kubectl`, `helm`, `bash` (Linux/macOS; WSL on Windows)
+
+## Deploy
+
+```bash
+# From the example directory
+terraform init
+terraform apply
+```
+
+`azure_resource_group_name` and `anyscale_cloud_name` have **no defaults**, so unless you supply them, `terraform apply` prompts for them at the start:
+
+```
+var.azure_resource_group_name
+  Resource group name. ...
+  Enter a value: my-rg
+
+var.anyscale_cloud_name
+  Anyscale cloud name as it appears in the Anyscale console. ...
+  Enter a value: my-cloud
+```
+
+Press Enter on an empty value to fall back to `<aks_cluster_name>-rg` / `<aks_cluster_name>-cloud`. To skip the prompts (e.g. CI/automation), supply them non-interactively via `terraform.tfvars`, `-var`, or `TF_VAR_azure_resource_group_name` / `TF_VAR_anyscale_cloud_name` — a non-interactive `terraform apply -auto-approve` will **fail** if these aren't provided some other way.
+
+That's it. Expect 15–20 minutes, dominated by AKS cluster creation (8 min) and the Anyscale extension reconciling the operator (~5 min). The apply orchestrates these phases automatically in a single command:
+
+1. Resource group, VNet, storage, UAMI, federated credential, role assignment
+2. AKS cluster + node pools
+3. The kubernetes/helm/kubectl providers authenticate directly from the AKS cluster's admin cert attributes (no kubeconfig file, no `az aks get-credentials` for the providers), so they connect to the freshly-created cluster within the same apply. `terraform_data.aks_credentials` additionally writes an isolated `./.kubeconfig` (gitignored) used only by the gateway-LB shell steps.
+4. `azapi_resource.anyscale_platform` runs the ARM template, producing `cldrsrc_…`
+5. Envoy Gateway Helm install → `EnvoyProxy` → `GatewayClass eg` → `Gateway` (HTTPS listeners reference TLS Secrets whose names are derived from `cldrsrc_…`; the Secrets don't exist yet — the operator will create them next)
+6. `terraform_data.wait_for_gateway_lb` polls `kubectl get gateway gateway -n anyscale-operator -o jsonpath='{.status.addresses[0].value}'` until the Azure LB hostname appears
+7. `azurerm_kubernetes_cluster_extension.anyscale_operator` installs the operator marketplace extension with `networking.gateway.hostname` set to the LB address from step 6. The operator authenticates via Microsoft Entra **workload identity** (no CLI token) and creates the TLS Secrets — at which point the Gateway listeners reconcile to `Programmed=True`.
+
+After the apply, useful Terraform outputs:
+
+```bash
+terraform output anyscale_cloud_name          # the cloud as it appears in the console
+terraform output anyscale_cloud_resource_id   # cldrsrc_…
+terraform output gateway_lb_hostname          # the public LB IP
+terraform output aks_get_credentials_command  # refresh kubeconfig manually
+```
+
+## Grant team access
+
+**Azure subscription Owner/Contributor does NOT let you (or your teammates) create Anyscale workspaces, jobs, or services.** Those workload operations require the **`Anyscale Platform Contributor Role`** assigned *on the Anyscale cloud resource itself* — permissions on the underlying Azure resources do not carry over to the Anyscale resource provider. (The Anyscale RP publishes three roles: `Anyscale Platform Administrator Role`, `Anyscale Platform Contributor Role`, `Anyscale Platform Reader Role`. The Azure portal's role-picker label may drop the trailing "Role", but the role definition keeps it — Terraform needs the exact name.)
+
+You can grant it two ways:
+
+**Terraform (recommended for repeatable setups)** — populate `var.anyscale_platform_contributors` with the object IDs of the users/groups/SPs that need access:
+
+```hcl
+anyscale_platform_contributors = [
+  { principal_id = "<user-object-id>",  principal_type = "User" },
+  { principal_id = "<group-object-id>", principal_type = "Group" },
+]
+```
+
+On the next `terraform apply`, Terraform assigns `Anyscale Platform Contributor Role` to each principal, scoped to the cloud resource (`azurerm_role_assignment.anyscale_platform_contributor` in `anyscale.tf`). Look up an object ID with `az ad user show --id <upn> --query id -o tsv` or `az ad group show --group <name> --query id -o tsv`.
+
+**Azure portal (manual / ad-hoc)** — navigate to your Anyscale cloud resource in the Azure portal, select **Access control (IAM) > Add > Add role assignment**, and assign **`Anyscale Platform Contributor`** to the appropriate users, groups, or service principals.
+
+> The cloud resource is at `<resource-group> > Anyscale.Platform/clouds/<cloud-name>` — `terraform output anyscale_cloud_arm_id` gives the full ID.
+
+## Verify
+
+### Cluster-side health
+
+```bash
+# Refresh kubeconfig (if needed)
+eval "$(terraform output -raw aks_get_credentials_command)"
+
+# Operator should be Running 3/3 with 0 restarts
+kubectl get pods -n anyscale-operator
+
+# GatewayClass should be Accepted=True; Gateway should have an ADDRESS and PROGRAMMED=True
+kubectl get gatewayclass eg
+kubectl get gateway -n anyscale-operator
+
+# The operator creates these two TLS Secrets after it comes up
+kubectl get secret -n anyscale-operator | grep certificate
+```
+
+### Anyscale-side health (`anyscale cloud verify`)
+
+The Anyscale CLI ships a one-shot cloud health check that validates the operator can talk to the control plane, reach storage, and serve the gateway. Run it once per cloud:
+
+```bash
+# Point the CLI at the Azure-hosted control plane (add to ~/.bashrc or ~/.zshrc to make permanent)
+export ANYSCALE_HOST=https://console.azure.anyscale.com
+anyscale login
+
+# Find the cloud ID (format cld_*). The Terraform output above is the
+# Anyscale RESOURCE ID (cldrsrc_*) — the CLI uses the shorter cld_* form.
+anyscale cloud list
+
+# Run the verification — picks up your current kubectl context
+anyscale cloud verify --id <cld_id>
+```
+
+A healthy cloud returns:
+
+```
+Overall Result: ALL 1 cloud resources verified successfully
+```
+
+If verify fails on instance-types, give the operator another minute to publish the default catalog and retry — that happens automatically after the operator pod transitions to Running.
+
+After verify succeeds, the cloud is ready for workspaces and jobs. Launch them from the [Anyscale console](https://console.azure.anyscale.com) under your cloud's name.
+
+## Authentication
+
+The Anyscale operator running in the cluster authenticates to `console.azure.anyscale.com` via **Microsoft Entra workload identity**:
+
+```
+K8s ServiceAccount: anyscale-operator/anyscale-operator
+        │ (OIDC token)
+        ▼
+AKS OIDC issuer (.oidc_issuer_url)
+        │
+        ▼
+azurerm_federated_identity_credential.anyscale_operator_fic
+        │
+        ▼
+azurerm_user_assigned_identity.anyscale_operator (UAMI)
+        │ (registered as the cloud's operator principal by the ARM template)
+        ▼
+Anyscale.Platform/clouds/<cloud-name>
+        │
+        ▼
+console.azure.anyscale.com (validates AAD token, accepts the operator)
+```
+
+## Destroy
+
+1. **Stop long-running workspaces / services first for a clean drain.** The hook waits up to 15 minutes (900s) for the control plane to drain sessions during the cloud delete. If you have heavy workloads running, terminating them in the console first makes teardown faster and avoids hitting that timeout.
+2. **`anyscale cloud delete` is not supported on Azure today.** Cloud deletion goes through the ARM provider — which is what the hook's `az resource delete` does.
+3. Run
+
+    ```bash
+    terraform destroy
+    ```
+
+## Customisation
+
+The new variables this example adds on top of `aks-new_cluster`:
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `azure_resource_group_name` | Override the resource group name. | `<aks_cluster_name>-rg` |
+| `anyscale_cloud_name` | Override the cloud name surfaced in the Anyscale console. | `<aks_cluster_name>-cloud` |
+| `anyscale_platform.control_plane_url` | Anyscale control plane URL. Override for staging/preview deployments. | `https://console.azure.anyscale.com` |
+| `anyscale_platform.release_train` | AKS extension release train: `stable` or `preview`. | `stable` |
+| `anyscale_platform.extension_configuration_settings` | Extra Helm values for the operator extension (e.g. custom instance-type defaults). Merged on top of the example's tolerations. | `{}` |
+| `envoy_gateway.chart_version` | Pinned Envoy Gateway Helm chart version. | `v1.7.0` |
+| `envoy_gateway.gateway_lb_wait_timeout_seconds` | Maximum seconds to wait for the LB allocation before terraform fails. | `600` |
+| `enable_acr` | Create a customer-owned ACR for workload images and grant kubelet `AcrPull`. Disable if you supply your own registry out-of-band. | `true` |
+| `acr_sku` | ACR SKU. Premium is only needed for Private Link / zone redundancy / customer-managed keys. | `Standard` |
+| `acr_zone_redundancy_enabled` | Enable zone redundancy. Premium-only; ignored otherwise. | `false` |
+| `acr_name` | Override the generated ACR name. Must be 5-50 alphanumeric chars and globally unique. | derived from `aks_cluster_name` |
+
+The Anyscale-specific variables defined in `variables.tf` are intentionally narrow — the deep tuning surface (compute configs, GPU node selectors, autoscaler bounds, instance-type catalogs) is handled inside the operator via Helm values, exposed through `anyscale_platform.extension_configuration_settings` if you need to override.
+

--- a/examples/azure/anyscale-azure/acr.tf
+++ b/examples/azure/anyscale-azure/acr.tf
@@ -1,0 +1,48 @@
+###############################################################################
+# Azure Container Registry — customer-owned registry for Anyscale workload
+# images (cluster envs, fine-tuned models, ad-hoc Dockerfiles produced by the
+# operator's image builder when `IMAGE_BUILD_BACKEND_ACR` is in effect).
+#
+# This is opt-in via `var.enable_acr` (default true). The AKS extension itself
+# pulls the operator image from `arcmktplaceprod.azurecr.io` regardless — this
+# ACR is for the workloads you launch from the Anyscale console, not for the
+# operator binary.
+###############################################################################
+
+locals {
+  acr_name_base = replace(var.aks_cluster_name, "-", "")
+  acr_name      = coalesce(var.acr_name, "${substr(local.acr_name_base, 0, 47)}acr")
+}
+
+resource "azurerm_container_registry" "acr" {
+  count = var.enable_acr ? 1 : 0
+
+  name                = local.acr_name
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  sku                 = var.acr_sku
+  admin_enabled       = false
+  # Public network access — match the example's overall public-networking
+  # posture. Premium SKU is required if you want to disable this and use
+  # Private Link.
+  public_network_access_enabled = true
+  # zone_redundancy_enabled is a Premium-only feature; AzureRM accepts the
+  # flag on lower SKUs but Azure ignores it. Force false on non-Premium so
+  # there is no apply-time confusion.
+  zone_redundancy_enabled = var.acr_sku == "Premium" ? var.acr_zone_redundancy_enabled : false
+
+  tags = var.tags
+}
+
+###############################################################################
+# Grant the AKS kubelet identity AcrPull on this registry so pods can pull
+# images. `anyscale.tf` passes `manageAksKubeletAcrPullRoleAssignment=false`
+# to the ARM template so we — not the Anyscale RP — own this role assignment.
+###############################################################################
+resource "azurerm_role_assignment" "kubelet_acr_pull" {
+  count = var.enable_acr ? 1 : 0
+
+  scope                = azurerm_container_registry.acr[0].id
+  role_definition_name = "AcrPull"
+  principal_id         = azurerm_kubernetes_cluster.aks.kubelet_identity[0].object_id
+}

--- a/examples/azure/anyscale-azure/aks.tf
+++ b/examples/azure/anyscale-azure/aks.tf
@@ -1,0 +1,304 @@
+###############################################################################
+# AKS CLUSTER – control-plane + "system" pool
+###############################################################################
+#trivy:ignore:avd-azu-0040
+#trivy:ignore:avd-azu-0041
+#trivy:ignore:avd-azu-0042
+resource "azurerm_kubernetes_cluster" "aks" {
+
+  #checkov:skip=CKV_AZURE_170: "Ensure that AKS use the Paid Sku for its SLA"
+  #checkov:skip=CKV_AZURE_172: "Ensure autorotation of Secrets Store CSI Driver secrets for AKS clusters"
+  #checkov:skip=CKV_AZURE_141: "Ensure AKS local admin account is disabled"
+  #checkov:skip=CKV_AZURE_115: "Ensure that AKS enables private clusters"
+  #checkov:skip=CKV_AZURE_117: "Ensure that AKS uses disk encryption set"
+  #checkov:skip=CKV_AZURE_232: "Ensure that only critical system pods run on system nodes"
+  #checkov:skip=CKV_AZURE_226: "Ensure ephemeral disks are used for OS disks"
+  #checkov:skip=CKV_AZURE_116: "Ensure that AKS uses Azure Policies Add-on"
+  #checkov:skip=CKV_AZURE_6: "Ensure AKS has an API Server Authorized IP Ranges enabled"
+  #checkov:skip=CKV_AZURE_171: "Ensure AKS cluster upgrade channel is chosen"
+  #checkov:skip=CKV_AZURE_168: "Ensure Azure Kubernetes Cluster (AKS) nodes should use a minimum number of 50 pods"
+  #checkov:skip=CKV_AZURE_4: "Ensure AKS logging to Azure Monitoring is Configured"
+  #checkov:skip=CKV_AZURE_227: "Ensure that the AKS cluster encrypt temp disks, caches, and data flows between Compute and Storage resources"
+
+  name                = var.aks_cluster_name
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  # lets kubectl talk to the API over the public FQDN
+  dns_prefix = "${var.aks_cluster_name}-dns"
+
+  # workload identity federation
+  oidc_issuer_enabled       = true # publishes an OIDC issuer URL
+  workload_identity_enabled = true # lets pods use AAD tokens
+
+  #########################################################################
+  # default (system) node‑pool
+  #########################################################################
+  default_node_pool {
+    name            = "sys"
+    vm_size         = var.system_vm_size
+    vnet_subnet_id  = azurerm_subnet.nodes.id
+    os_disk_size_gb = 64
+    type            = "VirtualMachineScaleSets"
+
+    # autoscaler
+    auto_scaling_enabled = true
+    min_count            = 1
+    max_count            = 3
+
+  }
+
+  #########################################################################
+  # identities, networking, tags
+  #########################################################################
+  identity {
+    type = "SystemAssigned"
+  }
+
+  network_profile {
+    network_plugin = "azure"
+    network_policy = "azure"
+    service_cidr   = var.aks_cluster_subnet_cidr
+    dns_service_ip = coalesce(var.aks_cluster_dns_address, cidrhost(var.aks_cluster_subnet_cidr, 2))
+  }
+
+  storage_profile {
+    blob_driver_enabled = var.enable_blob_driver
+  }
+
+  lifecycle {
+    ignore_changes = [default_node_pool[0].upgrade_settings]
+  }
+
+  tags = var.tags
+}
+
+###############################################################################
+# CPU NODE POOL – OnDemand
+###############################################################################
+resource "azurerm_kubernetes_cluster_node_pool" "ondemand_cpu" {
+
+  #checkov:skip=CKV_AZURE_168: "Ensure Azure Kubernetes Cluster (AKS) nodes should use a minimum number of 50 pods"
+  #checkov:skip=CKV_AZURE_227: "Ensure that the AKS cluster encrypt temp disks, caches, and data flows between Compute and Storage resources"
+
+  name                  = "cpu16"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.aks.id
+
+  vm_size        = var.cpu_vm_size
+  mode           = "User"
+  vnet_subnet_id = azurerm_subnet.nodes.id
+
+  auto_scaling_enabled = true
+  min_count            = 0
+  max_count            = 10
+
+  node_taints = [
+    "node.anyscale.com/capacity-type=ON_DEMAND:NoSchedule"
+  ]
+
+  lifecycle {
+    ignore_changes = [upgrade_settings]
+  }
+
+  tags = var.tags
+}
+
+###############################################################################
+# CPU NODE POOL – Spot
+###############################################################################
+resource "azurerm_kubernetes_cluster_node_pool" "spot_cpu" {
+
+  #checkov:skip=CKV_AZURE_168: "Ensure Azure Kubernetes Cluster (AKS) nodes should use a minimum number of 50 pods"
+  #checkov:skip=CKV_AZURE_227: "Ensure that the AKS cluster encrypt temp disks, caches, and data flows between Compute and Storage resources"
+
+  name                  = "cpu16spot"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.aks.id
+
+  vm_size        = var.cpu_vm_size
+  mode           = "User"
+  vnet_subnet_id = azurerm_subnet.nodes.id
+
+  auto_scaling_enabled = true
+  min_count            = 0
+  max_count            = 10
+
+  node_taints = [
+    "node.anyscale.com/capacity-type=SPOT:NoSchedule",
+    "kubernetes.azure.com/scalesetpriority=spot:NoSchedule",
+  ]
+
+  node_labels = {
+    "kubernetes.azure.com/scalesetpriority" = "spot"
+  }
+  priority        = "Spot"
+  eviction_policy = "Delete"
+
+  lifecycle {
+    ignore_changes = [upgrade_settings]
+  }
+
+  tags = var.tags
+}
+
+###############################################################################
+# GPU NODE POOLS – OnDemand
+###############################################################################
+
+#trivy:ignore:avd-azu-0168
+#trivy:ignore:avd-azu-0227
+resource "azurerm_kubernetes_cluster_node_pool" "gpu_ondemand" {
+  #checkov:skip=CKV_AZURE_168
+  #checkov:skip=CKV_AZURE_227
+
+  for_each = var.gpu_pool_configs
+
+  name                  = each.value.name
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.aks.id
+
+  vm_size        = each.value.vm_size
+  mode           = "User"
+  vnet_subnet_id = azurerm_subnet.nodes.id
+
+  # ── autoscaling (shared across all pools) ───────────────────────────────────
+  auto_scaling_enabled = true
+  min_count            = 0
+  max_count            = 10
+
+  upgrade_settings { max_surge = "1" }
+
+  # ── labels & taints ────────────────────────────────────────────────────────
+  node_labels = {
+    "nvidia.com/gpu.product" = each.value.product_name
+    "nvidia.com/gpu.count"   = each.value.gpu_count
+  }
+
+  node_taints = [
+    "node.anyscale.com/capacity-type=ON_DEMAND:NoSchedule",
+    "nvidia.com/gpu=present:NoSchedule",
+    "node.anyscale.com/accelerator-type=GPU:NoSchedule",
+  ]
+
+  lifecycle {
+    ignore_changes = [upgrade_settings]
+  }
+
+  tags = var.tags
+}
+
+###############################################################################
+# GPU NODE POOLS – Spot
+###############################################################################
+#trivy:ignore:avd-azu-0168
+#trivy:ignore:avd-azu-0227
+resource "azurerm_kubernetes_cluster_node_pool" "gpu_spot" {
+  #checkov:skip=CKV_AZURE_168
+  #checkov:skip=CKV_AZURE_227
+
+  for_each = var.gpu_pool_configs
+
+  name                  = "${each.value.name}spot"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.aks.id
+
+  vm_size        = each.value.vm_size
+  mode           = "User"
+  vnet_subnet_id = azurerm_subnet.nodes.id
+
+  # ── autoscaling (shared across all pools) ───────────────────────────────────
+  auto_scaling_enabled = true
+  min_count            = 0
+  max_count            = 10
+
+  # ── labels & taints ────────────────────────────────────────────────────────
+  node_labels = {
+    "nvidia.com/gpu.product"                = each.value.product_name
+    "nvidia.com/gpu.count"                  = each.value.gpu_count
+    "kubernetes.azure.com/scalesetpriority" = "spot"
+  }
+
+  node_taints = [
+    "node.anyscale.com/capacity-type=SPOT:NoSchedule",
+    "nvidia.com/gpu=present:NoSchedule",
+    "node.anyscale.com/accelerator-type=GPU:NoSchedule",
+    "kubernetes.azure.com/scalesetpriority=spot:NoSchedule",
+  ]
+
+  priority        = "Spot"
+  eviction_policy = "Delete"
+
+  lifecycle {
+    ignore_changes = [upgrade_settings]
+  }
+
+  tags = var.tags
+}
+
+##############################################################################
+# MANAGED IDENTITY FOR ANYSCALE OPERATOR
+###############################################################################
+moved {
+  from = azurerm_user_assigned_identity.anyscale_operator
+  to   = azurerm_user_assigned_identity.anyscale_operator[0]
+}
+
+resource "azurerm_user_assigned_identity" "anyscale_operator" {
+  count               = var.enable_operator_infrastructure ? 1 : 0
+  name                = "${var.aks_cluster_name}-anyscale-operator-mi"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+}
+
+###############################################################################
+# FEDERATED‑IDENTITY CREDENTIAL  (ServiceAccount --> User‑Assigned Identity)
+###############################################################################
+moved {
+  from = azurerm_federated_identity_credential.anyscale_operator_fic
+  to   = azurerm_federated_identity_credential.anyscale_operator_fic[0]
+}
+
+resource "azurerm_federated_identity_credential" "anyscale_operator_fic" {
+  count               = var.enable_operator_infrastructure ? 1 : 0
+  name                = "anyscale-operator-fic"
+  resource_group_name = azurerm_resource_group.rg.name
+
+  parent_id = azurerm_user_assigned_identity.anyscale_operator[0].id # user assigned identity
+  issuer    = azurerm_kubernetes_cluster.aks.oidc_issuer_url         # OIDC issuer from AKS
+  subject   = "system:serviceaccount:${var.anyscale_operator_namespace}:${var.anyscale_operator_serviceaccount}"
+  audience  = ["api://AzureADTokenExchange"] # fixed value for AAD tokens
+}
+
+###############################################################################
+# ROLE ASSIGNMENTS (IDENTITY ←→ STORAGE ACCOUNT)
+###############################################################################
+moved {
+  from = azurerm_role_assignment.anyscale_blob_contrib
+  to   = azurerm_role_assignment.anyscale_blob_contrib[0]
+}
+
+resource "azurerm_role_assignment" "anyscale_blob_contrib" {
+  count                = var.enable_operator_infrastructure ? 1 : 0
+  scope                = azurerm_storage_account.sa[0].id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_user_assigned_identity.anyscale_operator[0].principal_id
+}
+
+###############################################################################
+# HOW TO BIND KUBERNETES SERVICE ACCOUNT
+###############################################################################
+#
+# apiVersion: v1
+# kind: ServiceAccount
+# metadata:
+#   name: anyscale-operator
+#   namespace: anyscale-system
+#   annotations:
+#     azure.workload.identity/client-id: "${azurerm_user_assigned_identity.anyscale_operator[0].client_id}"
+#
+# ================================
+# apiVersion: v1
+# kind: Pod
+# metadata:
+#   name: sample-pod
+#   labels:
+#     azure.workload.identity/use: "true"
+# spec:
+#   serviceAccountName: anyscale-operator

--- a/examples/azure/anyscale-azure/anyscale.tf
+++ b/examples/azure/anyscale-azure/anyscale.tf
@@ -1,0 +1,281 @@
+###############################################################################
+# Anyscale Azure-managed control plane.
+#
+# This file is the only thing that materially distinguishes this example from
+# `examples/azure/aks-new_cluster` — it adds the two Azure Resource Providers
+# that turn the underlying AKS cluster into an Anyscale-managed cloud:
+#
+#   1. `Anyscale.Platform/clouds` (via AzAPI) — registers the cloud with the
+#      Azure-hosted Anyscale control plane at https://console.azure.anyscale.com
+#      and produces a stable `cldrsrc_…` resource ID.
+#
+#   2. `Microsoft.KubernetesConfiguration/extensions` with extension type
+#      `Anyscale.AKS.Operator` — installs the operator marketplace extension
+#      into the AKS cluster's `anyscale-operator` namespace and wires it to
+#      the cloud above. The operator authenticates to the control plane via
+#      Microsoft Entra workload identity, NOT a CLI token.
+###############################################################################
+
+locals {
+  anyscale_cloud_name = coalesce(var.anyscale_cloud_name, "${var.aks_cluster_name}-cloud")
+
+  # ARM resource ID of the Anyscale.Platform/clouds resource the deployment
+  # below creates. Used by the destroy-ordering hook so the cloud is removed
+  # before the AKS cluster (see terraform_data.anyscale_cloud_predelete).
+  anyscale_cloud_arm_id = "${azurerm_resource_group.rg.id}/providers/Anyscale.Platform/clouds/${local.anyscale_cloud_name}"
+
+  anyscale_deployments = {
+    top_level    = "dep-anyscale-${var.aks_cluster_name}"
+    blob         = "dep-anyblob-${var.aks_cluster_name}"
+    fic          = "dep-anyfic-${var.aks_cluster_name}"
+    storage_rbac = "dep-anystoragerbac-${var.aks_cluster_name}"
+    acr_rbac     = "dep-anyacrrbac-${var.aks_cluster_name}"
+  }
+
+  # Common operator-side extension settings. The toleration defaults match
+  # the node taints set by aks.tf for the ON_DEMAND CPU pool and GPU pools.
+  anyscale_extension_configuration_defaults = {
+    "workloads.accelerator.tolerations.default[0].key"      = "node.anyscale.com/accelerator-type"
+    "workloads.accelerator.tolerations.default[0].value"    = "GPU"
+    "workloads.accelerator.tolerations.default[0].effect"   = "NoSchedule"
+    "workloads.accelerator.tolerations.default[1].key"      = "nvidia.com/gpu"
+    "workloads.accelerator.tolerations.default[1].operator" = "Exists"
+    "workloads.accelerator.tolerations.default[1].effect"   = "NoSchedule"
+    "workloads.instanceTypes.enableDefaults"                = "true"
+  }
+
+  anyscale_extension_configuration_settings = merge(
+    local.anyscale_extension_configuration_defaults,
+    var.anyscale_platform.extension_configuration_settings,
+  )
+
+  anyscale_extension_release_train = contains(["stable", "preview"], lower(var.anyscale_platform.release_train)) ? title(lower(var.anyscale_platform.release_train)) : var.anyscale_platform.release_train
+}
+
+###############################################################################
+# Step 1: deploy the Anyscale.Platform/clouds ARM resource.
+# The body of the template is the exact JSON the Azure portal exports for the
+# managed cloud onboarding flow — see `templates/anyscale-platform-cloud.template.json`.
+# Storage and identity are passed as `existing` so the template binds to the
+# resources aks.tf created rather than provisioning new ones.
+###############################################################################
+resource "azapi_resource" "anyscale_platform" {
+  type                      = "Microsoft.Resources/deployments@2022-09-01"
+  name                      = local.anyscale_deployments.top_level
+  parent_id                 = azurerm_resource_group.rg.id
+  schema_validation_enabled = false
+  response_export_values = {
+    cloud_deployment_id = "properties.outputs.cloudResourceId.value"
+    provisioning_state  = "properties.provisioningState"
+  }
+  body = {
+    properties = {
+      mode     = "Incremental"
+      template = jsondecode(file("${path.module}/templates/anyscale-platform-cloud.template.json"))
+      parameters = {
+        location                 = { value = azurerm_resource_group.rg.location }
+        cloudName                = { value = local.anyscale_cloud_name }
+        storageAccountName       = { value = azurerm_storage_account.sa[0].name }
+        storageMode              = { value = "existing" }
+        storageAccountResourceId = { value = azurerm_storage_account.sa[0].id }
+        storageContainerName     = { value = azurerm_storage_container.blob[0].name }
+        workloadIdentityName     = { value = azurerm_user_assigned_identity.anyscale_operator[0].name }
+        identityMode             = { value = "existing" }
+        identityResourceId       = { value = azurerm_user_assigned_identity.anyscale_operator[0].id }
+        tagsByResource           = { value = var.anyscale_platform.tags_by_resource }
+        acrMode                  = { value = var.enable_acr ? "existing" : "none" }
+        acrName                  = { value = var.enable_acr ? azurerm_container_registry.acr[0].name : "" }
+        acrResourceId            = { value = var.enable_acr ? azurerm_container_registry.acr[0].id : "" }
+        aksKubeletPrincipalId    = { value = azurerm_kubernetes_cluster.aks.kubelet_identity[0].object_id }
+        # Terraform owns the kubelet AcrPull assignment (acr.tf). Tell the
+        # ARM template not to create a duplicate one.
+        manageAksKubeletAcrPullRoleAssignment = { value = false }
+        storageBlobServiceDeploymentName      = { value = local.anyscale_deployments.blob }
+        federatedIdentityDeploymentName       = { value = local.anyscale_deployments.fic }
+        storageRoleAssignmentDeploymentName   = { value = local.anyscale_deployments.storage_rbac }
+        acrRoleAssignmentsDeploymentName      = { value = local.anyscale_deployments.acr_rbac }
+      }
+    }
+  }
+
+  depends_on = [
+    azurerm_kubernetes_cluster.aks,
+    azurerm_storage_container.blob,
+    azurerm_user_assigned_identity.anyscale_operator,
+    azurerm_federated_identity_credential.anyscale_operator_fic,
+    azurerm_role_assignment.anyscale_blob_contrib,
+    azurerm_container_registry.acr,
+    azurerm_role_assignment.kubelet_acr_pull,
+  ]
+}
+
+# The ARM template exports `cloudResourceId` (e.g. `cldrsrc_abcd…`). The
+# Anyscale operator names its TLS Secret resources using the hyphenated form
+# of this ID, so we keep both available for downstream use.
+locals {
+  anyscale_cloud_resource_id            = azapi_resource.anyscale_platform.output.cloud_deployment_id
+  anyscale_cloud_resource_id_hyphenated = replace(local.anyscale_cloud_resource_id, "_", "-")
+
+  anyscale_gateway_certificate_secret_name         = "anyscale-${local.anyscale_cloud_resource_id_hyphenated}-certificate"
+  anyscale_gateway_service_certificate_secret_name = "anyscale-svc-${local.anyscale_cloud_resource_id_hyphenated}-certificate"
+}
+
+###############################################################################
+# Team access: "Anyscale Platform Contributor" on the cloud resource.
+#
+# Azure subscription Owner/Contributor does NOT grant the ability to create
+# Anyscale workspaces/jobs/services — that requires this Anyscale-provider
+# role assigned ON the Anyscale.Platform/clouds resource itself. Optional:
+# populate var.anyscale_platform_contributors to assign it from Terraform,
+# or do it later via the portal (cloud resource > Access control (IAM)).
+#
+# NOTE: "Anyscale Platform Contributor" is a role definition published by the
+# Anyscale.Platform RP and resolved by name at the cloud scope. If name
+# resolution ever fails in your tenant, swap role_definition_name for
+# role_definition_id with the role's full definition ID.
+###############################################################################
+resource "azurerm_role_assignment" "anyscale_platform_contributor" {
+  for_each = { for c in var.anyscale_platform_contributors : c.principal_id => c }
+
+  scope = local.anyscale_cloud_arm_id
+  # Exact role definition name published by the Anyscale.Platform RP — note the
+  # trailing "Role" (the portal label drops it, but the role definition keeps it).
+  # Other options: "Anyscale Platform Administrator Role", "Anyscale Platform Reader Role".
+  role_definition_name = "Anyscale Platform Contributor Role"
+  principal_id         = each.value.principal_id
+  principal_type       = each.value.principal_type
+
+  depends_on = [azapi_resource.anyscale_platform]
+}
+
+###############################################################################
+# Step 2: install the Anyscale.AKS.Operator marketplace extension.
+#
+# The extension is installed AFTER the Envoy Gateway has an LB address
+# (see envoy-gateway.tf) so we can bake the gateway hostname directly into
+# the operator's configuration_settings. This avoids the
+# `az k8s-extension update ...` step the Anyscale quickstart documents.
+#
+# IMPORTANT: configuration_protected_settings explicitly sets the CLI token
+# to the empty string. Omitting the key entirely is NOT enough — the AKS
+# extension PATCH semantics treat a missing key as "leave previous value in
+# place", so any earlier value would persist in the Helm release. With this
+# field forced empty, the operator falls through to the Microsoft Entra
+# workload-identity exchange (UAMI federated to the AKS OIDC issuer,
+# registered as the cloud's operator principal by the ARM template above).
+###############################################################################
+resource "azurerm_kubernetes_cluster_extension" "anyscale_operator" {
+  name              = var.anyscale_platform.extension_resource_name
+  cluster_id        = azurerm_kubernetes_cluster.aks.id
+  extension_type    = "Anyscale.AKS.Operator"
+  release_train     = local.anyscale_extension_release_train
+  release_namespace = var.anyscale_operator_namespace
+
+  plan {
+    name      = var.anyscale_platform.plan_name
+    publisher = var.anyscale_platform.plan_publisher
+    product   = var.anyscale_platform.plan_product
+  }
+
+  configuration_settings = merge(
+    {
+      "global.cloudDeploymentId"      = local.anyscale_cloud_resource_id
+      "global.controlPlaneURL"        = var.anyscale_platform.control_plane_url
+      "global.auth.iamIdentity"       = azurerm_user_assigned_identity.anyscale_operator[0].client_id
+      "global.auth.audience"          = var.anyscale_platform.auth_audience
+      "workloads.serviceAccount.name" = var.anyscale_operator_serviceaccount
+
+      # Envoy Gateway integration — these come from envoy-gateway.tf.
+      "networking.gateway.enabled"    = "true"
+      "networking.gateway.name"       = var.envoy_gateway.gateway_name
+      "networking.gateway.className"  = var.envoy_gateway.gateway_class_name
+      "networking.gateway.namespace"  = var.anyscale_operator_namespace
+      "networking.gateway.apiVersion" = "gateway.networking.k8s.io/v1"
+      "networking.gateway.hostname"   = data.external.gateway_lb.result.address
+    },
+    local.anyscale_extension_configuration_settings,
+  )
+
+  configuration_protected_settings = {
+    "global.auth.anyscaleCliToken" = ""
+  }
+
+  depends_on = [
+    azapi_resource.anyscale_platform,
+    data.external.gateway_lb,
+    kubectl_manifest.gateway,
+  ]
+}
+
+###############################################################################
+# Destroy ordering: delete the Anyscale cloud BEFORE the AKS cluster.
+#
+# WHY THIS EXISTS
+# azapi_resource.anyscale_platform is a Microsoft.Resources/deployments record.
+# Destroying it removes the deployment bookkeeping but NOT the
+# Anyscale.Platform/clouds resource it created. Left to its own devices,
+# Terraform would tear down AKS + the operator extension while the cloud
+# resource still lives, and the cloud would only be removed later by the
+# resource-group cascade — at which point the operator is already gone and the
+# Anyscale control plane rejects the cloud delete with a 409 ("has N
+# associated Clusters that are still active"), wedging the whole resource
+# group in a Deleting state.
+#
+# This resource forces the correct order. Because it depends_on the AKS
+# cluster AND the operator extension, Terraform destroys it FIRST (running the
+# when=destroy provisioner) and only then tears down the extension and the
+# cluster. The operator is therefore still alive to drain its sessions while
+# the cloud is being deleted.
+#
+# The provisioner deletes the cloudResources/default child first (the parent
+# cannot be removed while nested resources exist), then the cloud itself,
+# retrying until the control plane finishes draining or the timeout elapses.
+# Authentication uses the same `az` login Terraform already relies on.
+###############################################################################
+resource "terraform_data" "anyscale_cloud_predelete" {
+  input = {
+    cloud_arm_id    = local.anyscale_cloud_arm_id
+    timeout_seconds = 900
+    poll_interval   = 20
+  }
+
+  provisioner "local-exec" {
+    when        = destroy
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-EOT
+      set -uo pipefail
+      CLOUD="${self.input.cloud_arm_id}"
+      echo "[anyscale] Deleting Anyscale cloud before AKS teardown: $CLOUD"
+      deadline=$(( $(date +%s) + ${self.input.timeout_seconds} ))
+      err="$(mktemp)"
+      while :; do
+        # Child must go before the parent cloud resource.
+        az resource delete --ids "$CLOUD/cloudResources/default" --only-show-errors >/dev/null 2>&1 || true
+        if az resource delete --ids "$CLOUD" --only-show-errors >/dev/null 2>"$err"; then
+          echo "[anyscale] Cloud deleted."
+          break
+        fi
+        if grep -qiE "not.?found|does not exist|could not be found" "$err"; then
+          echo "[anyscale] Cloud already gone."
+          break
+        fi
+        if [ "$(date +%s)" -ge "$deadline" ]; then
+          echo "[anyscale] ERROR: timed out deleting cloud after ${self.input.timeout_seconds}s" >&2
+          cat "$err" >&2
+          exit 1
+        fi
+        echo "[anyscale] Cloud delete pending (control plane draining sessions); retry in ${self.input.poll_interval}s..."
+        sleep ${self.input.poll_interval}
+      done
+    EOT
+  }
+
+  # depends_on makes Terraform destroy THIS resource (running the hook) before
+  # the extension and the cluster — keeping the operator alive during the
+  # cloud delete.
+  depends_on = [
+    azurerm_kubernetes_cluster.aks,
+    azurerm_kubernetes_cluster_extension.anyscale_operator,
+    azapi_resource.anyscale_platform,
+  ]
+}

--- a/examples/azure/anyscale-azure/envoy-gateway.tf
+++ b/examples/azure/anyscale-azure/envoy-gateway.tf
@@ -1,0 +1,286 @@
+###############################################################################
+# Envoy Gateway bootstrap.
+#
+# The Anyscale Azure-managed control plane routes workspace and service
+# traffic through an in-cluster Envoy Gateway exposed via an Azure Standard
+# LoadBalancer. The Anyscale operator (installed by anyscale.tf) creates the
+# TLS Secret resources the Gateway listeners reference; the Gateway in turn
+# tells the operator extension which LB hostname to register with the
+# control plane (see `networking.gateway.hostname` in anyscale.tf).
+#
+# The kubernetes/helm/kubectl providers authenticate via the AKS cluster's
+# admin cert attributes (versions.tf), so every in-cluster resource implicitly
+# waits for the cluster and nothing reads a kubeconfig file at plan time. This
+# makes the whole thing a true single `terraform apply`:
+#
+#   aks ─► helm envoy-gateway ─► EnvoyProxy ─► GatewayClass
+#                                                  │
+#   azapi anyscale_platform (publishes cloud_resource_id) ─┤
+#                                                  ▼
+#                                              Gateway (references future TLS secret names)
+#                                                  │
+#                                                  ▼
+#                                       wait_for_gateway_lb (kubectl poll, uses the
+#                                       isolated .kubeconfig from aks_credentials)
+#                                                  │
+#                                                  ▼
+#                                       data.external.gateway_lb
+#                                                  │
+#                                                  ▼
+#                                       azurerm_kubernetes_cluster_extension
+#                                       .anyscale_operator (installs operator → operator
+#                                       creates TLS secrets → listeners reconcile)
+###############################################################################
+
+###############################################################################
+# Write an ISOLATED kubeconfig for the gateway-LB shell calls only.
+#
+# The kubernetes / helm / kubectl PROVIDERS no longer use a kubeconfig file at
+# all — they authenticate via the AKS admin cert attributes directly (see
+# versions.tf), which sidesteps the stale-context problem entirely. But the two
+# LB-address steps below (wait_for_gateway_lb, data.external.gateway_lb) shell
+# out to `kubectl`, which needs a kubeconfig. We write a dedicated one to
+# ${path.module}/.kubeconfig (NOT ~/.kube/config) so it only ever contains this
+# cluster's context — freshly written each apply, no other contexts to go
+# stale. `.kubeconfig` is gitignored.
+###############################################################################
+resource "terraform_data" "aks_credentials" {
+  triggers_replace = {
+    cluster_id = azurerm_kubernetes_cluster.aks.id
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-EOT
+      set -euo pipefail
+      az aks get-credentials \
+        --resource-group "${azurerm_resource_group.rg.name}" \
+        --name "${azurerm_kubernetes_cluster.aks.name}" \
+        --file "${path.module}/.kubeconfig" \
+        --overwrite-existing \
+        --only-show-errors
+    EOT
+  }
+
+  depends_on = [
+    azurerm_kubernetes_cluster.aks,
+    azurerm_kubernetes_cluster_node_pool.ondemand_cpu,
+  ]
+}
+
+###############################################################################
+# Envoy Gateway Helm release (v1.7.0 from docker.io OCI registry).
+###############################################################################
+resource "helm_release" "envoy_gateway" {
+  name             = var.envoy_gateway.release_name
+  repository       = "oci://docker.io/envoyproxy"
+  chart            = "gateway-helm"
+  version          = var.envoy_gateway.chart_version
+  namespace        = var.envoy_gateway.namespace
+  create_namespace = true
+  wait             = true
+  atomic           = true
+  cleanup_on_fail  = true
+  timeout          = 600
+
+  # The helm provider authenticates via the AKS cluster's kube_config
+  # attributes, so this release implicitly depends on the cluster existing —
+  # no kubeconfig-file dependency needed.
+}
+
+###############################################################################
+# EnvoyProxy — wires the GatewayClass to an external Azure Standard LB.
+# `azure-load-balancer-internal: "false"` forces a public LB; flip to "true"
+# if you want the Anyscale data plane reachable only from the VNet.
+###############################################################################
+resource "kubectl_manifest" "envoy_proxy" {
+  yaml_body = yamlencode({
+    apiVersion = "gateway.envoyproxy.io/v1alpha1"
+    kind       = "EnvoyProxy"
+    metadata = {
+      name      = "envoy-proxy"
+      namespace = var.envoy_gateway.namespace
+    }
+    spec = {
+      provider = {
+        type = "Kubernetes"
+        kubernetes = {
+          envoyService = {
+            type = "LoadBalancer"
+            annotations = {
+              "service.beta.kubernetes.io/azure-load-balancer-internal" = "false"
+            }
+          }
+        }
+      }
+    }
+  })
+
+  depends_on = [helm_release.envoy_gateway]
+}
+
+###############################################################################
+# GatewayClass — named `eg` to match the Anyscale quickstart.
+###############################################################################
+resource "kubectl_manifest" "gateway_class" {
+  yaml_body = yamlencode({
+    apiVersion = "gateway.networking.k8s.io/v1"
+    kind       = "GatewayClass"
+    metadata = {
+      name = var.envoy_gateway.gateway_class_name
+    }
+    spec = {
+      controllerName = "gateway.envoyproxy.io/gatewayclass-controller"
+      parametersRef = {
+        group     = "gateway.envoyproxy.io"
+        kind      = "EnvoyProxy"
+        name      = "envoy-proxy"
+        namespace = var.envoy_gateway.namespace
+      }
+    }
+  })
+
+  depends_on = [kubectl_manifest.envoy_proxy]
+}
+
+###############################################################################
+# Operator namespace (the Gateway lives here, alongside the operator the
+# AKS extension is about to install).
+###############################################################################
+resource "kubernetes_namespace_v1" "anyscale_operator" {
+  metadata {
+    name = var.anyscale_operator_namespace
+  }
+  # Implicitly ordered after the cluster via the kubernetes provider's
+  # kube_config-based auth.
+}
+
+###############################################################################
+# Gateway — three listeners (HTTP, HTTPS workspace, HTTPS service).
+# The TLS Secrets the HTTPS listeners reference are created by the Anyscale
+# operator AFTER azurerm_kubernetes_cluster_extension.anyscale_operator is
+# installed. Listeners will be Programmed=False until then; the Standard LB
+# is still allocated as soon as the Gateway resource exists, which is the
+# value we hand back to the operator extension via
+# `networking.gateway.hostname`.
+###############################################################################
+resource "kubectl_manifest" "gateway" {
+  yaml_body = yamlencode({
+    apiVersion = "gateway.networking.k8s.io/v1"
+    kind       = "Gateway"
+    metadata = {
+      name      = var.envoy_gateway.gateway_name
+      namespace = var.anyscale_operator_namespace
+    }
+    spec = {
+      gatewayClassName = var.envoy_gateway.gateway_class_name
+      listeners = [
+        {
+          name     = "http"
+          port     = 80
+          protocol = "HTTP"
+          allowedRoutes = {
+            namespaces = { from = "Same" }
+          }
+        },
+        {
+          name     = "https"
+          port     = 443
+          protocol = "HTTPS"
+          hostname = "*.i.azure.anyscaleuserdata.com"
+          tls = {
+            mode = "Terminate"
+            certificateRefs = [{
+              kind = "Secret"
+              name = local.anyscale_gateway_certificate_secret_name
+            }]
+          }
+          allowedRoutes = {
+            namespaces = { from = "Same" }
+          }
+        },
+        {
+          name     = "https-session"
+          port     = 443
+          protocol = "HTTPS"
+          hostname = "*.s.azure.anyscaleuserdata.com"
+          tls = {
+            mode = "Terminate"
+            certificateRefs = [{
+              kind = "Secret"
+              name = local.anyscale_gateway_service_certificate_secret_name
+            }]
+          }
+          allowedRoutes = {
+            namespaces = { from = "Same" }
+          }
+        },
+      ]
+    }
+  })
+
+  depends_on = [
+    kubectl_manifest.gateway_class,
+    kubernetes_namespace_v1.anyscale_operator,
+    azapi_resource.anyscale_platform,
+  ]
+}
+
+###############################################################################
+# Poll the Gateway until its `status.addresses[0].value` is populated by the
+# Envoy Gateway controller. Times out after gateway_lb_wait_timeout_seconds.
+###############################################################################
+resource "terraform_data" "wait_for_gateway_lb" {
+  input = {
+    namespace        = var.anyscale_operator_namespace
+    gateway_name     = var.envoy_gateway.gateway_name
+    timeout_seconds  = var.envoy_gateway.gateway_lb_wait_timeout_seconds
+    poll_interval    = var.envoy_gateway.gateway_lb_poll_interval_seconds
+    kubeconfig       = "${path.module}/.kubeconfig"
+    gateway_manifest = kubectl_manifest.gateway.id
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-EOT
+      set -euo pipefail
+      export KUBECONFIG="${self.input.kubeconfig}"
+      deadline=$(( $(date +%s) + ${self.input.timeout_seconds} ))
+      while :; do
+        addr="$(kubectl get gateway ${self.input.gateway_name} -n ${self.input.namespace} \
+          -o jsonpath='{.status.addresses[0].value}' 2>/dev/null || true)"
+        if [ -n "$addr" ]; then
+          echo "Gateway LB address: $addr"
+          exit 0
+        fi
+        if [ "$(date +%s)" -ge "$deadline" ]; then
+          echo "Timed out waiting for Gateway LB address after ${self.input.timeout_seconds}s" >&2
+          kubectl describe gateway ${self.input.gateway_name} -n ${self.input.namespace} >&2 || true
+          exit 1
+        fi
+        sleep ${self.input.poll_interval}
+      done
+    EOT
+  }
+
+  depends_on = [
+    kubectl_manifest.gateway,
+    terraform_data.aks_credentials,
+  ]
+}
+
+###############################################################################
+# Read the Gateway LB address back into Terraform state so the Anyscale
+# operator extension can consume it as a configuration_settings value.
+# Using the external data source plus the same kubectl/jsonpath the wait
+# loop ran keeps this resilient across kubernetes-provider versions.
+###############################################################################
+data "external" "gateway_lb" {
+  program = [
+    "bash",
+    "-c",
+    "value=\"$(KUBECONFIG=${path.module}/.kubeconfig kubectl get gateway ${var.envoy_gateway.gateway_name} -n ${var.anyscale_operator_namespace} -o jsonpath='{.status.addresses[0].value}' 2>/dev/null || true)\"; printf '{\"address\":\"%s\"}' \"$value\"",
+  ]
+
+  depends_on = [terraform_data.wait_for_gateway_lb]
+}

--- a/examples/azure/anyscale-azure/main.tf
+++ b/examples/azure/anyscale-azure/main.tf
@@ -1,0 +1,125 @@
+locals {
+  storage_account_name_base     = replace(var.aks_cluster_name, "-", "")
+  storage_account_name_base_sa  = length(local.storage_account_name_base) > 22 ? substr(local.storage_account_name_base, 0, 22) : local.storage_account_name_base
+  storage_account_name_base_nfs = length(local.storage_account_name_base) > 21 ? substr(local.storage_account_name_base, 0, 21) : local.storage_account_name_base
+  storage_account_name          = coalesce(var.storage_account_name, "${local.storage_account_name_base_sa}sa")
+  storage_account_name_nfs      = coalesce(var.storage_account_name_nfs, "${local.storage_account_name_base_nfs}nfs")
+}
+
+############################################
+# resource group
+############################################
+resource "azurerm_resource_group" "rg" {
+  name     = coalesce(var.azure_resource_group_name, "${var.aks_cluster_name}-rg")
+  location = var.azure_location
+  tags     = var.tags
+}
+
+############################################
+# storage (blob)
+############################################
+moved {
+  from = azurerm_storage_account.sa
+  to   = azurerm_storage_account.sa[0]
+}
+
+resource "azurerm_storage_account" "sa" {
+  count = var.enable_operator_infrastructure ? 1 : 0
+
+  #checkov:skip=CKV_AZURE_33: "Ensure Storage logging is enabled for Queue service for read, write and delete requests"
+  #checkov:skip=CKV_AZURE_59: "Ensure that Storage accounts disallow public access"
+  #checkov:skip=CKV_AZURE_244: "Avoid the use of local users for Azure Storage unless necessary"
+  #checkov:skip=CKV_AZURE_44: "Ensure Storage Account is using the latest version of TLS encryption"
+  #checkov:skip=CKV_AZURE_206: "Ensure that Storage Accounts use replication"
+  #checkov:skip=CKV2_AZURE_41: "Ensure storage account is configured with SAS expiration policy"
+  #checkov:skip=CKV2_AZURE_38: "Ensure soft-delete is enabled on Azure storage account"
+  #checkov:skip=CKV2_AZURE_1: "Ensure storage for critical data are encrypted with Customer Managed Key"
+  #checkov:skip=CKV2_AZURE_33: "Ensure storage account is configured with private endpoint"
+  #checkov:skip=CKV2_AZURE_40: "Ensure storage account is not configured with Shared Key authorization"
+  #checkov:skip=CKV2_AZURE_21: "Ensure Storage logging is enabled for Blob service for read requests"
+  #checkov:skip=CKV2_AZURE_31: "Ensure VNET subnet is configured with a Network Security Group (NSG)"
+
+  name                     = local.storage_account_name
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = azurerm_resource_group.rg.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  # still blocks "anonymous blob" catches
+  allow_nested_items_to_be_public = false
+  tags                            = var.tags
+
+  blob_properties {
+    cors_rule {
+      allowed_headers    = var.cors_rule.allowed_headers
+      allowed_methods    = var.cors_rule.allowed_methods
+      allowed_origins    = var.cors_rule.allowed_origins
+      exposed_headers    = var.cors_rule.expose_headers
+      max_age_in_seconds = var.cors_rule.max_age_in_seconds
+    }
+  }
+}
+
+# Storage bucket (similar to S3)
+moved {
+  from = azurerm_storage_container.blob
+  to   = azurerm_storage_container.blob[0]
+}
+
+resource "azurerm_storage_container" "blob" {
+  count = var.enable_operator_infrastructure ? 1 : 0
+
+  #checkov:skip=CKV2_AZURE_21: "Ensure Storage logging is enabled for Blob service for read requests"
+
+  name                  = "${var.aks_cluster_name}-blob"
+  storage_account_id    = azurerm_storage_account.sa[0].id
+  container_access_type = "private" # blobs are private but reachable via the public endpoint
+}
+
+############################################
+# storage (nfs) - optional
+############################################
+resource "azurerm_storage_account" "nfs" {
+  count = var.enable_nfs ? 1 : 0
+
+  name                       = local.storage_account_name_nfs
+  resource_group_name        = azurerm_resource_group.rg.name
+  location                   = azurerm_resource_group.rg.location
+  account_kind               = "FileStorage"
+  account_tier               = "Premium"
+  account_replication_type   = "ZRS"
+  https_traffic_only_enabled = false
+
+  allow_nested_items_to_be_public = false
+
+  network_rules {
+    default_action             = "Deny"
+    virtual_network_subnet_ids = [azurerm_subnet.nodes.id]
+    bypass                     = ["AzureServices"]
+  }
+
+  tags = var.tags
+}
+
+############################################
+# networking (vnet and subnet)
+############################################
+resource "azurerm_virtual_network" "vnet" {
+  name                = "${var.aks_cluster_name}-vnet"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  address_space       = [var.vnet_cidr]
+  tags                = var.tags
+}
+
+# Subnet for AKS nodes
+resource "azurerm_subnet" "nodes" {
+
+  #checkov:skip=CKV2_AZURE_31: "Ensure VNET subnet is configured with a Network Security Group (NSG)"
+
+  name                 = "aks-nodes"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = [var.nodes_subnet_cidr]
+  service_endpoints    = ["Microsoft.Storage"]
+}

--- a/examples/azure/anyscale-azure/outputs.tf
+++ b/examples/azure/anyscale-azure/outputs.tf
@@ -1,0 +1,116 @@
+###############################################################################
+# Azure infra outputs (mirrors examples/azure/aks-new_cluster)
+###############################################################################
+output "azure_resource_group_name" {
+  value       = azurerm_resource_group.rg.name
+  description = "Name of the Azure Resource Group."
+}
+
+output "azure_storage_account_name" {
+  value       = var.enable_operator_infrastructure ? azurerm_storage_account.sa[0].name : null
+  description = "Name of the Azure Storage Account."
+}
+
+output "azure_storage_container_name" {
+  value       = var.enable_operator_infrastructure ? azurerm_storage_container.blob[0].name : null
+  description = "Name of the Azure Storage Container."
+}
+
+output "azure_nfs_storage_account_name" {
+  value       = var.enable_nfs ? azurerm_storage_account.nfs[0].name : null
+  description = "Name of the optional Azure NFS Storage Account."
+}
+
+output "azure_aks_cluster_name" {
+  value       = azurerm_kubernetes_cluster.aks.name
+  description = "Name of the AKS cluster."
+}
+
+output "azure_aks_oidc_issuer_url" {
+  value       = azurerm_kubernetes_cluster.aks.oidc_issuer_url
+  description = "OIDC issuer URL of the AKS cluster (used by workload-identity federation)."
+}
+
+output "acr_id" {
+  value       = var.enable_acr ? azurerm_container_registry.acr[0].id : null
+  description = "Full resource ID of the customer-owned ACR. Null when enable_acr=false."
+}
+
+output "acr_name" {
+  value       = var.enable_acr ? azurerm_container_registry.acr[0].name : null
+  description = "Name of the customer-owned ACR. Null when enable_acr=false."
+}
+
+output "acr_login_server" {
+  value       = var.enable_acr ? azurerm_container_registry.acr[0].login_server : null
+  description = "Login server (e.g. myacr.azurecr.io) for the customer-owned ACR. Null when enable_acr=false."
+}
+
+output "anyscale_operator_client_id" {
+  value       = var.enable_operator_infrastructure ? azurerm_user_assigned_identity.anyscale_operator[0].client_id : null
+  description = "Client ID of the Anyscale operator user-assigned managed identity."
+}
+
+output "anyscale_operator_principal_id" {
+  value       = var.enable_operator_infrastructure ? azurerm_user_assigned_identity.anyscale_operator[0].principal_id : null
+  description = "Principal ID of the Anyscale operator user-assigned managed identity."
+}
+
+###############################################################################
+# Anyscale Azure-managed cloud outputs
+###############################################################################
+output "anyscale_cloud_name" {
+  value       = local.anyscale_cloud_name
+  description = "Name of the registered Anyscale cloud (visible in console.azure.anyscale.com)."
+}
+
+output "anyscale_cloud_arm_id" {
+  value       = "${azurerm_resource_group.rg.id}/providers/Anyscale.Platform/clouds/${local.anyscale_cloud_name}"
+  description = "Full ARM resource ID of the Anyscale.Platform/clouds resource."
+}
+
+output "anyscale_cloud_resource_id" {
+  value       = local.anyscale_cloud_resource_id
+  description = "Anyscale cloud resource ID (`cldrsrc_…`). Surfaced in the Anyscale console's cloud settings page."
+}
+
+output "anyscale_extension_resource_id" {
+  value       = azurerm_kubernetes_cluster_extension.anyscale_operator.id
+  description = "Full resource ID of the Anyscale.AKS.Operator AKS extension."
+}
+
+output "anyscale_operator_namespace" {
+  value       = var.anyscale_operator_namespace
+  description = "Kubernetes namespace where the Anyscale operator runs."
+}
+
+###############################################################################
+# Envoy Gateway outputs
+###############################################################################
+output "gateway_lb_hostname" {
+  value       = data.external.gateway_lb.result.address
+  description = "Address (DNS or IP) assigned to the Envoy Gateway LoadBalancer. Baked into the operator extension's networking.gateway.hostname."
+}
+
+output "gateway_certificate_secret_name" {
+  value       = local.anyscale_gateway_certificate_secret_name
+  description = "Name of the TLS Secret the operator creates for `*.i.azure.anyscaleuserdata.com`."
+}
+
+output "gateway_service_certificate_secret_name" {
+  value       = local.anyscale_gateway_service_certificate_secret_name
+  description = "Name of the TLS Secret the operator creates for `*.s.azure.anyscaleuserdata.com`."
+}
+
+###############################################################################
+# Convenience commands
+###############################################################################
+output "aks_get_credentials_command" {
+  value       = "az aks get-credentials --resource-group ${azurerm_resource_group.rg.name} --name ${azurerm_kubernetes_cluster.aks.name} --overwrite-existing"
+  description = "Refresh local kubeconfig against the deployed AKS cluster."
+}
+
+output "anyscale_console_url" {
+  value       = var.anyscale_platform.control_plane_url
+  description = "URL of the Anyscale console where the registered cloud is visible."
+}

--- a/examples/azure/anyscale-azure/templates/anyscale-platform-cloud.template.json
+++ b/examples/azure/anyscale-azure/templates/anyscale-platform-cloud.template.json
@@ -1,0 +1,431 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "metadata": {
+        "description": "The Azure region for deployment, inferred from the selected AKS cluster."
+      }
+    },
+    "cloudName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the Anyscale cloud."
+      }
+    },
+    "storageAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the storage account to create."
+      }
+    },
+    "storageMode": {
+      "type": "string",
+      "defaultValue": "managed",
+      "allowedValues": [
+        "managed",
+        "existing"
+      ],
+      "metadata": {
+        "description": "Storage account mode: 'managed' = create new, 'existing' = use existing."
+      }
+    },
+    "storageAccountResourceId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The full resource ID of an existing storage account (only for 'existing' mode)."
+      }
+    },
+    "storageContainerName": {
+      "type": "string",
+      "metadata": {
+        "description": "The blob container name Anyscale will use inside the selected storage account."
+      }
+    },
+    "workloadIdentityName": {
+      "type": "string",
+      "defaultValue": "[concat(parameters('cloudName'), '-wi-', newGuid())]",
+      "metadata": {
+        "description": "The name of the managed identity for workload identity."
+      }
+    },
+    "identityMode": {
+      "type": "string",
+      "defaultValue": "managed",
+      "allowedValues": [
+        "managed",
+        "existing"
+      ],
+      "metadata": {
+        "description": "Identity mode: 'managed' = create new, 'existing' = use existing."
+      }
+    },
+    "identityResourceId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The full resource ID of an existing managed identity (only for 'existing' mode)."
+      }
+    },
+    "tagsByResource": {
+      "type": "object",
+      "defaultValue": {},
+      "metadata": {
+        "description": "Optional tags provided by the user, keyed by resource type."
+      }
+    },
+    "acrMode": {
+      "type": "string",
+      "defaultValue": "none",
+      "allowedValues": [
+        "managed",
+        "existing",
+        "none"
+      ],
+      "metadata": {
+        "description": "ACR mode: 'managed' = create new ACR, 'existing' = use existing ACR, 'none' = no ACR."
+      }
+    },
+    "acrName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The name of the Azure Container Registry to create (only for 'managed' mode)."
+      }
+    },
+    "acrResourceId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The full resource ID of an existing ACR (only for 'existing' mode)."
+      }
+    },
+    "aksKubeletPrincipalId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The principal ID of the AKS kubelet identity for AcrPull role assignment."
+      }
+    },
+    "manageAksKubeletAcrPullRoleAssignment": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Whether the template should manage the kubelet AcrPull assignment. Disable this when Terraform already owns that role assignment."
+      }
+    },
+    "storageBlobServiceDeploymentName": {
+      "type": "string",
+      "defaultValue": "[concat('StorageBlobServiceDeployment-', utcNow('yyyyMMddHHmmss'))]",
+      "metadata": {
+        "description": "The name for the storage blob service nested deployment."
+      }
+    },
+    "federatedIdentityDeploymentName": {
+      "type": "string",
+      "defaultValue": "[concat('FederatedIdentityDeployment-', utcNow('yyyyMMddHHmmss'))]",
+      "metadata": {
+        "description": "The name for the federated identity nested deployment."
+      }
+    },
+    "storageRoleAssignmentDeploymentName": {
+      "type": "string",
+      "defaultValue": "[concat('StorageRoleAssignmentDeployment-', utcNow('yyyyMMddHHmmss'))]",
+      "metadata": {
+        "description": "The name for the storage role assignment nested deployment."
+      }
+    },
+    "acrRoleAssignmentsDeploymentName": {
+      "type": "string",
+      "defaultValue": "[concat('AcrRoleAssignmentsDeployment-', utcNow('yyyyMMddHHmmss'))]",
+      "metadata": {
+        "description": "The name for the ACR role assignments nested deployment."
+      }
+    }
+  },
+  "variables": {
+    "containerName": "[parameters('storageContainerName')]",
+    "storageBlobDataOwnerRoleId": "b7e6dc6d-f1e8-4753-8033-0f276bb0955b",
+    "abfssUrl": "[concat('abfss://', variables('containerName'), '@', parameters('storageAccountName'), '.dfs.core.windows.net')]",
+    "blobEndpoint": "[concat('https://', parameters('storageAccountName'), '.blob.core.windows.net')]",
+    "effectiveStorageResourceId": "[if(equals(parameters('storageMode'), 'managed'), resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), parameters('storageAccountResourceId'))]",
+    "effectiveBlobServicesResourceId": "[concat(variables('effectiveStorageResourceId'), '/blobServices/default')]",
+    "effectiveIdentityResourceId": "[if(equals(parameters('identityMode'), 'managed'), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('workloadIdentityName')), parameters('identityResourceId'))]",
+    "storageResourceGroup": "[split(variables('effectiveStorageResourceId'), '/')[4]]",
+    "identityResourceGroup": "[split(variables('effectiveIdentityResourceId'), '/')[4]]",
+    "acrSafeName": "[if(empty(parameters('acrName')), 'placeholder', parameters('acrName'))]",
+    "acrPushRoleId": "8311e382-0749-4cb8-b61a-304f252e45ec",
+    "acrTaskContributorRoleId": "fb382eab-e894-4461-af04-94435c366c3f",
+    "acrPullRoleId": "7f951dda-4ed3-4680-a7ca-43fe172d538d",
+    "acrResourceId": "[if(equals(parameters('acrMode'), 'managed'), resourceId('Microsoft.ContainerRegistry/registries', variables('acrSafeName')), if(equals(parameters('acrMode'), 'existing'), parameters('acrResourceId'), ''))]",
+    "acrResourceGroup": "[if(not(equals(parameters('acrMode'), 'none')), split(variables('acrResourceId'), '/')[4], '')]"
+  },
+  "resources": [
+    {
+      "condition": "[equals(parameters('storageMode'), 'managed')]",
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2023-01-01",
+      "name": "[parameters('storageAccountName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard_LRS"
+      },
+      "kind": "StorageV2",
+      "properties": {
+        "accessTier": "Hot",
+        "supportsHttpsTrafficOnly": true,
+        "isHnsEnabled": true,
+        "minimumTlsVersion": "TLS1_2",
+        "defaultToOAuthAuthentication": true,
+        "allowSharedKeyAccess": false
+      },
+      "tags": "[union(if(contains(parameters('tagsByResource'), 'Microsoft.Storage/storageAccounts'), parameters('tagsByResource')['Microsoft.Storage/storageAccounts'], json('{}')), createObject('anyscale-cloud', parameters('cloudName')))]"
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "[parameters('storageBlobServiceDeploymentName')]",
+      "resourceGroup": "[variables('storageResourceGroup')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": [
+            {
+              "type": "Microsoft.Storage/storageAccounts/blobServices",
+              "apiVersion": "2023-01-01",
+              "name": "[concat(parameters('storageAccountName'), '/default')]",
+              "properties": {
+                "cors": {
+                  "corsRules": "[if(equals(parameters('storageMode'), 'existing'), if(contains(string(reference(variables('effectiveBlobServicesResourceId'), '2023-01-01').cors.corsRules), 'https://*.anyscale.com'), reference(variables('effectiveBlobServicesResourceId'), '2023-01-01').cors.corsRules, concat(reference(variables('effectiveBlobServicesResourceId'), '2023-01-01').cors.corsRules, createArray(createObject('allowedOrigins', createArray('https://*.anyscale.com'), 'allowedMethods', createArray('GET', 'HEAD', 'PUT', 'POST', 'DELETE'), 'allowedHeaders', createArray('*'), 'exposedHeaders', createArray('*'), 'maxAgeInSeconds', 3600)))), createArray(createObject('allowedOrigins', createArray('https://*.anyscale.com'), 'allowedMethods', createArray('GET', 'HEAD', 'PUT', 'POST', 'DELETE'), 'allowedHeaders', createArray('*'), 'exposedHeaders', createArray('*'), 'maxAgeInSeconds', 3600)))]"
+                }
+              }
+            },
+            {
+              "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+              "apiVersion": "2023-01-01",
+              "name": "[concat(parameters('storageAccountName'), '/default/', variables('containerName'))]",
+              "dependsOn": [
+                "[variables('effectiveBlobServicesResourceId')]"
+              ],
+              "properties": {
+                "publicAccess": "None"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "condition": "[equals(parameters('identityMode'), 'managed')]",
+      "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+      "apiVersion": "2023-01-31",
+      "name": "[parameters('workloadIdentityName')]",
+      "location": "[parameters('location')]",
+      "tags": "[union(if(contains(parameters('tagsByResource'), 'Microsoft.ManagedIdentity/userAssignedIdentities'), parameters('tagsByResource')['Microsoft.ManagedIdentity/userAssignedIdentities'], json('{}')), createObject('anyscale-cloud', parameters('cloudName')))]"
+    },
+    {
+      "condition": "[equals(parameters('identityMode'), 'managed')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "[parameters('federatedIdentityDeploymentName')]",
+      "resourceGroup": "[variables('identityResourceGroup')]",
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": [
+            {
+              "type": "Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials",
+              "apiVersion": "2023-01-31",
+              "name": "[concat(parameters('workloadIdentityName'), '/kubernetes-federated-credential')]",
+              "properties": {
+                "issuer": "[reference(parameters('aksClusterResourceId'), '2025-10-01').oidcIssuerProfile.issuerUrl]",
+                "subject": "[concat('system:serviceaccount:', variables('kubernetesServiceAccountNamespace'), ':', variables('kubernetesServiceAccountName'))]",
+                "audiences": [
+                  "api://AzureADTokenExchange"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('workloadIdentityName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "[parameters('storageRoleAssignmentDeploymentName')]",
+      "resourceGroup": "[variables('storageResourceGroup')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('workloadIdentityName'))]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": [
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(variables('effectiveStorageResourceId'), variables('effectiveIdentityResourceId'), variables('storageBlobDataOwnerRoleId'))]",
+              "scope": "[variables('effectiveStorageResourceId')]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('storageBlobDataOwnerRoleId'))]",
+                "principalId": "[reference(variables('effectiveIdentityResourceId'), '2023-01-31').principalId]",
+                "principalType": "ServicePrincipal"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "condition": "[not(equals(parameters('acrMode'), 'none'))]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "[parameters('acrRoleAssignmentsDeploymentName')]",
+      "resourceGroup": "[variables('acrResourceGroup')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('workloadIdentityName'))]",
+        "[resourceId('Microsoft.ContainerRegistry/registries', variables('acrSafeName'))]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": [
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(variables('acrResourceId'), variables('effectiveIdentityResourceId'), variables('acrPushRoleId'))]",
+              "scope": "[variables('acrResourceId')]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('acrPushRoleId'))]",
+                "principalId": "[reference(variables('effectiveIdentityResourceId'), '2023-01-31').principalId]",
+                "principalType": "ServicePrincipal"
+              }
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(variables('acrResourceId'), variables('effectiveIdentityResourceId'), variables('acrTaskContributorRoleId'))]",
+              "scope": "[variables('acrResourceId')]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('acrTaskContributorRoleId'))]",
+                "principalId": "[reference(variables('effectiveIdentityResourceId'), '2023-01-31').principalId]",
+                "principalType": "ServicePrincipal"
+              }
+            },
+            {
+              "condition": "[parameters('manageAksKubeletAcrPullRoleAssignment')]",
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(variables('acrResourceId'), parameters('aksKubeletPrincipalId'), variables('acrPullRoleId'))]",
+              "scope": "[variables('acrResourceId')]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('acrPullRoleId'))]",
+                "principalId": "[parameters('aksKubeletPrincipalId')]",
+                "principalType": "ServicePrincipal"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "condition": "[equals(parameters('acrMode'), 'managed')]",
+      "type": "Microsoft.ContainerRegistry/registries",
+      "apiVersion": "2023-07-01",
+      "name": "[variables('acrSafeName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard"
+      },
+      "properties": {
+        "adminUserEnabled": false
+      },
+      "tags": "[union(if(contains(parameters('tagsByResource'), 'Microsoft.ContainerRegistry/registries'), parameters('tagsByResource')['Microsoft.ContainerRegistry/registries'], json('{}')), createObject('anyscale-cloud', parameters('cloudName')))]"
+    },
+    {
+      "type": "Anyscale.Platform/clouds",
+      "apiVersion": "2026-02-01-preview",
+      "name": "[parameters('cloudName')]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.ContainerRegistry/registries', variables('acrSafeName'))]"
+      ],
+      "properties": {
+        "acrResourceId": "[if(equals(parameters('acrMode'), 'none'), null(), variables('acrResourceId'))]"
+      },
+      "tags": "[union(if(contains(parameters('tagsByResource'), 'Anyscale.Platform/clouds'), parameters('tagsByResource')['Anyscale.Platform/clouds'], json('{}')), createObject('anyscale-cloud', parameters('cloudName')))]"
+    },
+    {
+      "type": "Anyscale.Platform/clouds/cloudResources",
+      "apiVersion": "2026-02-01-preview",
+      "name": "[concat(parameters('cloudName'), '/default')]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Anyscale.Platform/clouds', parameters('cloudName'))]",
+        "[parameters('storageBlobServiceDeploymentName')]",
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('workloadIdentityName'))]"
+      ],
+      "properties": {
+        "provider": "Azure",
+        "computeStack": "K8S",
+        "cloudStorageBucketName": "[variables('abfssUrl')]",
+        "cloudStorageBucketEndpoint": "[variables('blobEndpoint')]",
+        "anyscaleOperatorIamIdentity": "[reference(variables('effectiveIdentityResourceId'), '2023-01-31').principalId]"
+      },
+      "tags": "[union(if(contains(parameters('tagsByResource'), 'Anyscale.Platform/clouds/cloudResources'), parameters('tagsByResource')['Anyscale.Platform/clouds/cloudResources'], json('{}')), createObject('anyscale-cloud', parameters('cloudName')))]"
+    }
+  ],
+  "outputs": {
+    "cloudResourceId": {
+      "type": "string",
+      "value": "[reference(resourceId('Anyscale.Platform/clouds/cloudResources', parameters('cloudName'), 'default'), '2026-02-01-preview').cloudResourceId]"
+    },
+    "storageAccountName": {
+      "type": "string",
+      "value": "[parameters('storageAccountName')]"
+    },
+    "managedIdentityClientId": {
+      "type": "string",
+      "value": "[reference(variables('effectiveIdentityResourceId'), '2023-01-31').clientId]"
+    },
+    "managedIdentityPrincipalId": {
+      "type": "string",
+      "value": "[reference(variables('effectiveIdentityResourceId'), '2023-01-31').principalId]"
+    },
+    "abfssUrl": {
+      "type": "string",
+      "value": "[variables('abfssUrl')]"
+    },
+    "blobEndpoint": {
+      "type": "string",
+      "value": "[variables('blobEndpoint')]"
+    },
+    "acrResourceId": {
+      "condition": "[not(equals(parameters('acrMode'), 'none'))]",
+      "type": "string",
+      "value": "[variables('acrResourceId')]"
+    },
+    "acrLoginServer": {
+      "condition": "[equals(parameters('acrMode'), 'managed')]",
+      "type": "string",
+      "value": "[if(equals(parameters('acrMode'), 'managed'), reference(resourceId('Microsoft.ContainerRegistry/registries', variables('acrSafeName')), '2023-07-01').loginServer, '')]"
+    }
+  }
+}

--- a/examples/azure/anyscale-azure/variables.tf
+++ b/examples/azure/anyscale-azure/variables.tf
@@ -1,0 +1,372 @@
+variable "azure_subscription_id" {
+  description = "(Required) Azure subscription ID"
+  type        = string
+}
+
+variable "azure_location" {
+  description = "(Optional) Azure region for all resources."
+  type        = string
+  default     = "West US"
+}
+
+variable "azure_tenant_id" {
+  description = "Azure tenant ID. Can be found by running `az account show --query tenantId -o tsv`."
+  type        = string
+}
+
+variable "tags" {
+  description = "(Optional) Tags applied to all taggable resources."
+  type        = map(string)
+  default = {
+    Test        = "true"
+    Environment = "dev"
+  }
+}
+
+variable "aks_cluster_name" {
+  description = "(Optional) Name of the AKS cluster (and related resources)."
+  type        = string
+  default     = "anyscale-demo"
+}
+
+variable "azure_resource_group_name" {
+  description = <<-EOT
+    Resource group name. This variable has no default, so `terraform plan`/`apply`
+    prompts for it interactively unless you supply it via terraform.tfvars, -var,
+    or TF_VAR_azure_resource_group_name. Enter an empty value to fall back to
+    "<aks_cluster_name>-rg".
+  EOT
+  type        = string
+  nullable    = false
+}
+
+variable "anyscale_cloud_name" {
+  description = <<-EOT
+    Anyscale cloud name as it appears in the Anyscale console. This variable has
+    no default, so `terraform plan`/`apply` prompts for it interactively unless
+    you supply it via terraform.tfvars, -var, or TF_VAR_anyscale_cloud_name.
+    Enter an empty value to fall back to "<aks_cluster_name>-cloud".
+  EOT
+  type        = string
+  nullable    = false
+}
+
+variable "anyscale_operator_namespace" {
+  description = "(Optional) Kubernetes namespace for the Anyscale operator."
+  type        = string
+  default     = "anyscale-operator"
+}
+
+variable "vnet_cidr" {
+  description = "(Optional) CIDR block for the VNet."
+  type        = string
+  nullable    = false
+  default     = "10.42.0.0/16"
+}
+
+variable "nodes_subnet_cidr" {
+  description = "(Optional) CIDR block for the AKS nodes subnet."
+  type        = string
+  nullable    = false
+  default     = "10.42.1.0/24"
+}
+
+variable "aks_cluster_subnet_cidr" {
+  description = "(Optional) CIDR block for the AKS cluster service subnet. Cannot overlap with vnet_cidr or nodes_subnet_cidr."
+  type        = string
+  nullable    = false
+  default     = "10.0.0.0/16"
+}
+
+variable "aks_cluster_dns_address" {
+  description = "(Optional) DNS address for the AKS cluster. If not set, a default will be generated from aks_cluster_subnet_cidr."
+  type        = string
+  nullable    = true
+  default     = null
+}
+
+variable "enable_blob_driver" {
+  description = "(Optional) Enable the Azure Blob CSI driver on the AKS cluster. Required for mounting blob storage from pods."
+  type        = bool
+  nullable    = false
+  default     = false
+}
+
+variable "enable_operator_infrastructure" {
+  description = <<-EOT
+    (Optional) Enable blob storage, managed identity, federated identity credential,
+    role assignment, and output registration/helm commands for the Anyscale operator.
+    Set to false when using the Azure control plane, which provisions these via ARM templates.
+  EOT
+  type        = bool
+  nullable    = false
+  default     = true
+}
+
+variable "storage_account_name" {
+  description = "(Optional) Name of the Azure Storage account to create for cloud storage. May be needed if generated name is already taken."
+  type        = string
+  nullable    = true
+  default     = null
+
+  validation {
+    condition     = var.storage_account_name == null || can(regex("^[a-z0-9]{3,24}$", var.storage_account_name))
+    error_message = "Storage account name must be between 3 and 24 characters long and contain only lowercase letters and numbers."
+  }
+}
+
+variable "enable_nfs" {
+  description = <<-EOT
+    (Optional) Enable provisioning of an Azure NFS (Network File System) storage account.
+    This NFS storage can be used for file-based persistent storage needs, mounting shared volumes to AKS nodes and pods.
+  EOT
+  type        = bool
+  nullable    = false
+  default     = false
+}
+
+variable "storage_account_name_nfs" {
+  description = "(Optional) Name of the Azure NFS storage account to create. May be needed if generated name is already taken."
+  type        = string
+  nullable    = true
+  default     = null
+
+  validation {
+    condition     = var.storage_account_name_nfs == null || can(regex("^[a-z0-9]{3,24}$", var.storage_account_name_nfs))
+    error_message = "NFS storage account name must be between 3 and 24 characters long and contain only lowercase letters and numbers."
+  }
+}
+
+variable "system_vm_size" {
+  description = "VM size for the default system node pool."
+  type        = string
+  default     = "Standard_D2s_v5"
+}
+
+variable "cpu_vm_size" {
+  description = "VM size for the CPU node pools (on-demand and spot)."
+  type        = string
+  default     = "Standard_D16s_v5"
+}
+
+variable "gpu_pool_configs" {
+  description = <<-EOT
+    (Optional) Full configuration for GPU node pools. The map key is a logical label
+    (e.g. "T4", "A100"). The `name` field is used as the AKS node pool name and must
+    be lowercase alphanumeric, max 8 chars (spot pools append "spot").
+  EOT
+  type = map(object({
+    name         = string
+    vm_size      = string
+    product_name = string
+    gpu_count    = string
+  }))
+  default = {
+    T4 = {
+      name         = "gput4"
+      vm_size      = "Standard_NC16as_T4_v3"
+      product_name = "NVIDIA-T4"
+      gpu_count    = "1"
+    }
+    A100 = {
+      name         = "gpua100"
+      vm_size      = "Standard_NC24ads_A100_v4"
+      product_name = "NVIDIA-A100"
+      gpu_count    = "1"
+    }
+    # Example of adding new GPU pools:
+    # A10 = {
+    #   name         = "gpua10"
+    #   vm_size      = "Standard_NV36ads_A10_v5"
+    #   product_name = "NVIDIA-A10"
+    #   gpu_count    = "1"
+    # }
+    # H100 = {
+    #   name         = "h100x8"
+    #   vm_size      = "Standard_ND96isr_H100_v5"
+    #   product_name = "NVIDIA-H100"
+    #   gpu_count    = "8"
+    # }
+  }
+
+  validation {
+    condition = alltrue([
+      for k, v in var.gpu_pool_configs : can(regex("^[a-z0-9]{1,8}$", v.name))
+    ])
+    error_message = "gpu_pool_configs name must be lowercase alphanumeric, max 8 characters (spot pools append 'spot' for a 12-char AKS limit)."
+  }
+
+  validation {
+    condition = alltrue([
+      for k, v in var.gpu_pool_configs : can(regex("^[1-9][0-9]*$", v.gpu_count))
+    ])
+    error_message = "gpu_pool_configs gpu_count must be a positive integer string (e.g. \"1\", \"8\")."
+  }
+}
+
+variable "cors_rule" {
+  description = <<-EOT
+    (Optional)
+    Object containing a rule of Cross-Origin Resource Sharing.
+    The default allows GET, POST, PUT, HEAD, and DELETE
+    access for the purpose of viewing logs and other functionality
+    from within the Anyscale Web UI (*.anyscale.com).
+
+    ex:
+    ```
+    cors_rule = {
+      allowed_headers = ["*"]
+      allowed_methods = ["GET", "POST", "PUT", "HEAD", "DELETE"]
+      allowed_origins = ["https://*.anyscale.com"]
+      expose_headers  = ["Accept-Ranges", "Content-Range", "Content-Length"]
+    }
+    ```
+  EOT
+  type = object({
+    allowed_headers    = list(string)
+    allowed_methods    = list(string)
+    allowed_origins    = list(string)
+    expose_headers     = list(string)
+    max_age_in_seconds = optional(number, 0)
+  })
+  default = {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET", "POST", "PUT", "HEAD", "DELETE"]
+    allowed_origins = ["https://*.anyscale.com"]
+    expose_headers  = ["Accept-Ranges", "Content-Range", "Content-Length"]
+  }
+}
+
+variable "storage_use_azuread" {
+  description = "(Optional) Determines whether the provider uses AzureAD or the SharedKey from the Storage Account to connect to the Storage Blob & Queue APIs"
+  type        = bool
+  nullable    = false
+  default     = false
+}
+
+variable "anyscale_operator_serviceaccount" {
+  description = "(Optional) Kubernetes service account name the Anyscale operator runs as. The federated identity credential in aks.tf is bound to this service account name."
+  type        = string
+  default     = "anyscale-operator"
+}
+
+###############################################################################
+# Azure Container Registry — for Anyscale workload images
+###############################################################################
+variable "enable_acr" {
+  description = "(Optional) Create a customer-owned ACR for Anyscale workload images and grant the AKS kubelet identity AcrPull. Disable if you supply your own registry out-of-band."
+  type        = bool
+  nullable    = false
+  default     = true
+}
+
+variable "acr_name" {
+  description = "(Optional) Override the generated ACR name. Globally unique; 5-50 alphanumeric chars."
+  type        = string
+  nullable    = true
+  default     = null
+
+  validation {
+    condition     = var.acr_name == null || can(regex("^[a-zA-Z0-9]{5,50}$", var.acr_name))
+    error_message = "ACR name must be 5-50 alphanumeric characters."
+  }
+}
+
+variable "acr_sku" {
+  description = "(Optional) ACR SKU. Premium is only required for Private Link / zone redundancy / customer-managed keys."
+  type        = string
+  nullable    = false
+  default     = "Standard"
+
+  validation {
+    condition     = contains(["Basic", "Standard", "Premium"], var.acr_sku)
+    error_message = "acr_sku must be one of Basic, Standard, or Premium."
+  }
+}
+
+variable "acr_zone_redundancy_enabled" {
+  description = "(Optional) Enable zone redundancy on the ACR. Premium SKU only; ignored on Basic/Standard."
+  type        = bool
+  nullable    = false
+  default     = false
+}
+
+###############################################################################
+# Anyscale platform (Azure-managed control plane)
+# These inputs drive the ARM `Anyscale.Platform/clouds` deployment and the
+# `Anyscale.AKS.Operator` AKS extension. Defaults target
+# https://console.azure.anyscale.com and the marketplace `anyscale-operator`
+# plan — only override if you are testing against a non-default control plane.
+###############################################################################
+variable "anyscale_platform" {
+  description = "(Optional) Tunables for the Anyscale.Platform/clouds ARM deployment and the Anyscale.AKS.Operator AKS extension."
+  type = object({
+    extension_resource_name          = optional(string, "anyscaleoperator")
+    control_plane_url                = optional(string, "https://console.azure.anyscale.com")
+    auth_audience                    = optional(string, "api://086bc555-6989-4362-ba30-fded273e432b/.default")
+    extension_configuration_settings = optional(map(string), {})
+    plan_name                        = optional(string, "anyscale-operator")
+    plan_publisher                   = optional(string, "anyscale1750870039553")
+    plan_product                     = optional(string, "anyscale-operator-aks")
+    release_train                    = optional(string, "stable")
+    tags_by_resource                 = optional(map(map(string)), {})
+  })
+  default = {}
+}
+
+variable "anyscale_platform_contributors" {
+  description = <<-EOT
+    (Optional) Principals (users, groups, or service principals) to grant the
+    "Anyscale Platform Contributor" role on the Anyscale cloud resource.
+
+    IMPORTANT: Subscription Owner/Contributor on the underlying Azure resources
+    does NOT carry over to the Anyscale resource provider. Creating Anyscale
+    workspaces, jobs, or services requires this explicit Anyscale platform role
+    on the cloud resource itself.
+
+    Each entry needs the principal's object (principal) ID and its type
+    (User | Group | ServicePrincipal). Example:
+
+      anyscale_platform_contributors = [
+        { principal_id = "00000000-0000-0000-0000-000000000000", principal_type = "User" },
+        { principal_id = "11111111-1111-1111-1111-111111111111", principal_type = "Group" },
+      ]
+  EOT
+  type = list(object({
+    principal_id   = string
+    principal_type = optional(string, "User")
+  }))
+  default = []
+
+  validation {
+    condition     = alltrue([for c in var.anyscale_platform_contributors : contains(["User", "Group", "ServicePrincipal"], c.principal_type)])
+    error_message = "principal_type must be one of: User, Group, ServicePrincipal."
+  }
+}
+
+###############################################################################
+# Envoy Gateway bootstrap
+# Anyscale routes workspace and service traffic through an in-cluster Envoy
+# Gateway. Defaults match the upstream Anyscale quickstart for AKS.
+###############################################################################
+variable "envoy_gateway" {
+  description = "(Optional) Envoy Gateway install knobs."
+  type = object({
+    namespace                        = optional(string, "envoy-gateway-system")
+    release_name                     = optional(string, "eg")
+    chart_version                    = optional(string, "v1.7.0")
+    gateway_class_name               = optional(string, "eg")
+    gateway_name                     = optional(string, "gateway")
+    gateway_lb_wait_timeout_seconds  = optional(number, 600)
+    gateway_lb_poll_interval_seconds = optional(number, 10)
+  })
+  default = {}
+}
+
+# NOTE: there is intentionally no kubeconfig_path variable. The
+# kubernetes/helm/kubectl providers authenticate directly from the AKS
+# cluster's admin cert attributes (see versions.tf), and the gateway-LB shell
+# steps use an isolated ${path.module}/.kubeconfig written by
+# terraform_data.aks_credentials. Nothing depends on ~/.kube/config, so the
+# whole stack deploys in a single `terraform apply` regardless of what other
+# kube contexts exist on the workstation.

--- a/examples/azure/anyscale-azure/versions.tf
+++ b/examples/azure/anyscale-azure/versions.tf
@@ -1,0 +1,81 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "4.26.0"
+    }
+    # azapi installs the Anyscale.Platform/clouds ARM resource directly
+    # (the same ARM template the Azure portal exports for the managed path).
+    azapi = {
+      source  = "azure/azapi"
+      version = "~> 2.0"
+    }
+    # helm + kubernetes + kubectl drive the in-cluster bootstrap of Envoy
+    # Gateway and the Gateway-API resources the Anyscale operator routes
+    # through. They consume a kubeconfig produced by `az aks get-credentials`
+    # — see README for the two-stage deploy workflow.
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 3.0"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "~> 1.19"
+    }
+    # external is used to read the Gateway LoadBalancer address back into
+    # Terraform after the Envoy Gateway controller programs it.
+    external = {
+      source  = "hashicorp/external"
+      version = "~> 2.3"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  subscription_id                 = var.azure_subscription_id
+  resource_provider_registrations = "none"
+  storage_use_azuread             = var.storage_use_azuread
+}
+
+provider "azapi" {
+  subscription_id = var.azure_subscription_id
+}
+
+# Authenticate the in-cluster providers using the AKS cluster's admin
+# kube_config attributes directly (cert-based; available because the cluster
+# keeps local accounts enabled and does not use AAD RBAC). This is the
+# canonical "create AKS + deploy into it in one apply" pattern: the provider
+# config is computed from the azurerm_kubernetes_cluster resource, so Terraform
+# defers the kubernetes/helm/kubectl resources until the cluster exists — and
+# nothing reads a kubeconfig file at plan time, so a stale ~/.kube/config
+# context (old cluster, Lens proxy, etc.) can never be picked up. True single
+# `terraform apply`, no `az aks get-credentials` for the providers.
+provider "kubernetes" {
+  host                   = azurerm_kubernetes_cluster.aks.kube_config[0].host
+  client_certificate     = base64decode(azurerm_kubernetes_cluster.aks.kube_config[0].client_certificate)
+  client_key             = base64decode(azurerm_kubernetes_cluster.aks.kube_config[0].client_key)
+  cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.aks.kube_config[0].cluster_ca_certificate)
+}
+
+provider "helm" {
+  kubernetes = {
+    host                   = azurerm_kubernetes_cluster.aks.kube_config[0].host
+    client_certificate     = base64decode(azurerm_kubernetes_cluster.aks.kube_config[0].client_certificate)
+    client_key             = base64decode(azurerm_kubernetes_cluster.aks.kube_config[0].client_key)
+    cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.aks.kube_config[0].cluster_ca_certificate)
+  }
+}
+
+provider "kubectl" {
+  host                   = azurerm_kubernetes_cluster.aks.kube_config[0].host
+  client_certificate     = base64decode(azurerm_kubernetes_cluster.aks.kube_config[0].client_certificate)
+  client_key             = base64decode(azurerm_kubernetes_cluster.aks.kube_config[0].client_key)
+  cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.aks.kube_config[0].cluster_ca_certificate)
+  load_config_file       = false
+}


### PR DESCRIPTION
This PR creates an end-to-end deployment of all Azure infrastructure including AKS, VNET, Subnets and the Anyscale components - Operator and Cloud through a single Terraform deployment.

## Validation
  End-to-end on real Azure (westus2):
  - Single `terraform apply` brought up RG, AKS, ACR, storage, identity, cloud, operator extension, and Envoy Gateway.
  - Sample Ray job (`anyscale job submit`) ran to `SUCCEEDED` with the expected output.
  - `Anyscale Platform Contributor Role` assignment landed on the cloud resource.
  - `terraform destroy` removed the cloud before AKS; the RG fully deleted without wedging.
