### PR TITLE
EKS + GKE examples: add HAProxy as an alternative ingress controller

### DIFF
--- a/examples/aws/eks-existing/README.md
+++ b/examples/aws/eks-existing/README.md
@@ -91,6 +91,24 @@ helm upgrade ingress-nginx nginx/ingress-nginx \
   --install
 ```
 
+#### (Alternative) Install the HAProxy ingress controller
+
+`ingress-nginx` is deprecated upstream; `haproxy-ingress` is a drop-in alternative. Use this section *instead of* the Nginx section above — install only one ingress controller.
+
+A sample file, `sample-values_haproxy.yaml` is provided. The sample sets two HAProxy ConfigMap keys: `proxy-body-size: 64m` (raises the body size limit from the 1m default) and `option accept-invalid-http-request` via `config-frontend` (accepts headers with underscores — equivalent to nginx-ingress' `underscores_in_headers on`).
+
+```shell
+helm repo add haproxy-ingress https://haproxy-ingress.github.io/charts
+helm upgrade haproxy-ingress haproxy-ingress/haproxy-ingress \
+  --version 0.14.7 \
+  --namespace haproxy-ingress \
+  --values sample-values_haproxy.yaml \
+  --create-namespace \
+  --install
+```
+
+> If you chose HAProxy, you'll need two extra `--set-string` flags on the Anyscale Operator helm install below — see the note at the end of the [Install the Anyscale Operator](#install-the-anyscale-operator) section.
+
 #### (Optional) Install the Nvidia device plugin
 
 A sample file, `sample-values_nvdp.yaml` has been provided in this repo. Please review for your requirements before using.
@@ -171,6 +189,18 @@ helm upgrade anyscale-operator anyscale/anyscale-operator \
   --create-namespace \
   --install
 ```
+
+> **Using HAProxy instead of Nginx?** Add these flags to the helm command above:
+>
+> ```shell
+> HAPROXY_LB=$(kubectl get svc -n haproxy-ingress haproxy-ingress \
+>   -o jsonpath='{.status.loadBalancer.ingress[0].hostname}{.status.loadBalancer.ingress[0].ip}')
+>
+>   --set-string networking.ingress.classNameOverride=haproxy \
+>   --set-string networking.ingress.address=$HAPROXY_LB
+> ```
+>
+> Without these, the operator defaults to `ingressClassName: nginx` and the AWS Load Balancer Controller's admission webhook rejects the Ingress with `IngressClass "nginx" not found`.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/examples/aws/eks-existing/sample-values_haproxy.yaml
+++ b/examples/aws/eks-existing/sample-values_haproxy.yaml
@@ -1,0 +1,26 @@
+controller:
+  service:
+    type: LoadBalancer
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+      service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+      service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+  ingressClassResource:
+    enabled: true
+    name: haproxy
+    default: true
+  config:
+    # Raise the body size limit from the 1m default.
+    proxy-body-size: "64m"
+    # Accept headers with underscores and other non-standard cases —
+    # equivalent to nginx-ingress' `underscores_in_headers on`.
+    config-frontend: |
+      option accept-invalid-http-request
+  replicaCount: 1
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 3
+defaultBackend:
+  enabled: true

--- a/examples/aws/eks-private/README.md
+++ b/examples/aws/eks-private/README.md
@@ -86,6 +86,24 @@ helm upgrade ingress-nginx nginx/ingress-nginx \
   --install
 ```
 
+#### (Alternative) Install the HAProxy ingress controller
+
+`ingress-nginx` is deprecated upstream; `haproxy-ingress` is a drop-in alternative. Use this section *instead of* the Nginx section above — install only one ingress controller.
+
+A sample file, `sample-values_haproxy.yaml` is provided. The sample sets two HAProxy ConfigMap keys: `proxy-body-size: 64m` (raises the body size limit from the 1m default) and `option accept-invalid-http-request` via `config-frontend` (accepts headers with underscores — equivalent to nginx-ingress' `underscores_in_headers on`).
+
+```shell
+helm repo add haproxy-ingress https://haproxy-ingress.github.io/charts
+helm upgrade haproxy-ingress haproxy-ingress/haproxy-ingress \
+  --version 0.14.7 \
+  --namespace haproxy-ingress \
+  --values sample-values_haproxy.yaml \
+  --create-namespace \
+  --install
+```
+
+> If you chose HAProxy, you'll need two extra `--set-string` flags on the Anyscale Operator helm install below — see the note at the end of the [Install the Anyscale Operator](#install-the-anyscale-operator) section.
+
 #### (Optional) Install the Nvidia device plugin
 
 A sample file, `sample-values_nvdp.yaml` has been provided in this repo. Please review for your requirements before using.
@@ -166,6 +184,18 @@ helm upgrade anyscale-operator anyscale/anyscale-operator \
   --create-namespace \
   --install
 ```
+
+> **Using HAProxy instead of Nginx?** Add these flags to the helm command above:
+>
+> ```shell
+> HAPROXY_LB=$(kubectl get svc -n haproxy-ingress haproxy-ingress \
+>   -o jsonpath='{.status.loadBalancer.ingress[0].hostname}{.status.loadBalancer.ingress[0].ip}')
+>
+>   --set-string networking.ingress.classNameOverride=haproxy \
+>   --set-string networking.ingress.address=$HAPROXY_LB
+> ```
+>
+> Without these, the operator defaults to `ingressClassName: nginx` and the AWS Load Balancer Controller's admission webhook rejects the Ingress with `IngressClass "nginx" not found`.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/examples/aws/eks-private/sample-values_haproxy.yaml
+++ b/examples/aws/eks-private/sample-values_haproxy.yaml
@@ -1,0 +1,26 @@
+controller:
+  service:
+    type: LoadBalancer
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
+      service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+      service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+  ingressClassResource:
+    enabled: true
+    name: haproxy
+    default: true
+  config:
+    # Raise the body size limit from the 1m default.
+    proxy-body-size: "64m"
+    # Accept headers with underscores and other non-standard cases —
+    # equivalent to nginx-ingress' `underscores_in_headers on`.
+    config-frontend: |
+      option accept-invalid-http-request
+  replicaCount: 1
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 3
+defaultBackend:
+  enabled: true

--- a/examples/aws/eks-public/README.md
+++ b/examples/aws/eks-public/README.md
@@ -96,6 +96,24 @@ helm upgrade ingress-nginx nginx/ingress-nginx \
   --install
 ```
 
+#### (Alternative) Install the HAProxy ingress controller
+
+`ingress-nginx` is deprecated upstream; `haproxy-ingress` is a drop-in alternative. Use this section *instead of* the Nginx section above — install only one ingress controller.
+
+A sample file, `sample-values_haproxy.yaml` is provided. The sample sets two HAProxy ConfigMap keys: `proxy-body-size: 64m` (raises the body size limit from the 1m default) and `option accept-invalid-http-request` via `config-frontend` (accepts headers with underscores — equivalent to nginx-ingress' `underscores_in_headers on`).
+
+```shell
+helm repo add haproxy-ingress https://haproxy-ingress.github.io/charts
+helm upgrade haproxy-ingress haproxy-ingress/haproxy-ingress \
+  --version 0.14.7 \
+  --namespace haproxy-ingress \
+  --values sample-values_haproxy.yaml \
+  --create-namespace \
+  --install
+```
+
+> If you chose HAProxy, you'll need two extra `--set-string` flags on the Anyscale Operator helm install below — see the note at the end of the [Install the Anyscale Operator](#install-the-anyscale-operator) section.
+
 #### (Optional) Install the Nvidia device plugin
 
 A sample file, `sample-values_nvdp.yaml` has been provided in this repo. Please review for your requirements before using.
@@ -176,6 +194,18 @@ helm upgrade anyscale-operator anyscale/anyscale-operator \
   --create-namespace \
   --install
 ```
+
+> **Using HAProxy instead of Nginx?** Add these flags to the helm command above:
+>
+> ```shell
+> HAPROXY_LB=$(kubectl get svc -n haproxy-ingress haproxy-ingress \
+>   -o jsonpath='{.status.loadBalancer.ingress[0].hostname}{.status.loadBalancer.ingress[0].ip}')
+>
+>   --set-string networking.ingress.classNameOverride=haproxy \
+>   --set-string networking.ingress.address=$HAPROXY_LB
+> ```
+>
+> Without these, the operator defaults to `ingressClassName: nginx` and the AWS Load Balancer Controller's admission webhook rejects the Ingress with `IngressClass "nginx" not found`.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/examples/aws/eks-public/sample-values_haproxy.yaml
+++ b/examples/aws/eks-public/sample-values_haproxy.yaml
@@ -1,0 +1,26 @@
+controller:
+  service:
+    type: LoadBalancer
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+      service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+      service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+  ingressClassResource:
+    enabled: true
+    name: haproxy
+    default: true
+  config:
+    # Raise the body size limit from the 1m default.
+    proxy-body-size: "64m"
+    # Accept headers with underscores and other non-standard cases —
+    # equivalent to nginx-ingress' `underscores_in_headers on`.
+    config-frontend: |
+      option accept-invalid-http-request
+  replicaCount: 1
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 3
+defaultBackend:
+  enabled: true

--- a/examples/gcp/gke-existing_cluster/README.md
+++ b/examples/gcp/gke-existing_cluster/README.md
@@ -102,6 +102,26 @@ Sample files, `sample-values_nginx_gke_private.yaml` and `sample-values_nginx_gk
       --install
     ```
 
+#### (Alternative) Install the HAProxy ingress controller
+
+`ingress-nginx` is deprecated upstream; `haproxy-ingress` is a drop-in alternative. Use this section *instead of* the Nginx section above — install only one ingress controller.
+
+Sample files, `sample-values_haproxy_gke_private.yaml` and `sample-values_haproxy_gke_public.yaml`, are provided. Each sample sets two HAProxy ConfigMap keys: `proxy-body-size: 64m` (raises the body size limit from the 1m default) and `option accept-invalid-http-request` via `config-frontend` (accepts headers with underscores — equivalent to nginx-ingress' `underscores_in_headers on`).
+
+Run the following, replacing `<private|public>` with the appropriate values file name:
+
+```shell
+helm repo add haproxy-ingress https://haproxy-ingress.github.io/charts
+helm upgrade haproxy-ingress haproxy-ingress/haproxy-ingress \
+  --version 0.14.7 \
+  --namespace haproxy-ingress \
+  --values sample-values_haproxy_gke_<private|public>.yaml \
+  --create-namespace \
+  --install
+```
+
+> If you chose HAProxy, you'll need two extra `--set-string` flags on the Anyscale Operator helm install below — see the note at the end of the [Install the Anyscale Operator](#install-the-anyscale-operator) section.
+
 ### Register the Anyscale Cloud
 
 Ensure that you are logged into Anyscale with valid CLI credentials. (`anyscale login`)
@@ -145,6 +165,18 @@ anyscale cloud register \
       --create-namespace \
       --install
     ```
+
+> **Using HAProxy instead of Nginx?** Add these flags to the helm command above:
+>
+> ```shell
+> HAPROXY_LB=$(kubectl get svc -n haproxy-ingress haproxy-ingress \
+>   -o jsonpath='{.status.loadBalancer.ingress[0].ip}{.status.loadBalancer.ingress[0].hostname}')
+>
+>   --set-string networking.ingress.classNameOverride=haproxy \
+>   --set-string networking.ingress.address=$HAPROXY_LB
+> ```
+>
+> Without these, the operator defaults to `ingressClassName: nginx` and Ingress creation will fail when no `nginx` IngressClass exists in the cluster.
 
 1. (Optional) For the L4 GPU instances (`g2-standard-16`) to work, modify the Anyscale Operator `instance-types` ConfigMap:
     ```

--- a/examples/gcp/gke-existing_cluster/sample-values_haproxy_gke_private.yaml
+++ b/examples/gcp/gke-existing_cluster/sample-values_haproxy_gke_private.yaml
@@ -1,0 +1,24 @@
+controller:
+  service:
+    type: LoadBalancer
+    annotations:
+      cloud.google.com/load-balancer-type: "Internal"
+      networking.gke.io/internal-load-balancer-allow-global-access: "true"
+  ingressClassResource:
+    enabled: true
+    name: haproxy
+    default: true
+  config:
+    # Raise the body size limit from the 1m default.
+    proxy-body-size: "64m"
+    # Accept headers with underscores and other non-standard cases —
+    # equivalent to nginx-ingress' `underscores_in_headers on`.
+    config-frontend: |
+      option accept-invalid-http-request
+  replicaCount: 1
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 3
+defaultBackend:
+  enabled: true

--- a/examples/gcp/gke-existing_cluster/sample-values_haproxy_gke_public.yaml
+++ b/examples/gcp/gke-existing_cluster/sample-values_haproxy_gke_public.yaml
@@ -1,0 +1,23 @@
+controller:
+  service:
+    type: LoadBalancer
+    annotations:
+      cloud.google.com/load-balancer-type: "External"
+  ingressClassResource:
+    enabled: true
+    name: haproxy
+    default: true
+  config:
+    # Raise the body size limit from the 1m default.
+    proxy-body-size: "64m"
+    # Accept headers with underscores and other non-standard cases —
+    # equivalent to nginx-ingress' `underscores_in_headers on`.
+    config-frontend: |
+      option accept-invalid-http-request
+  replicaCount: 1
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 3
+defaultBackend:
+  enabled: true

--- a/examples/gcp/gke-new_cluster/README.md
+++ b/examples/gcp/gke-new_cluster/README.md
@@ -108,6 +108,26 @@ Sample files, `sample-values_nginx_gke_private.yaml` and `sample-values_nginx_gk
       --install
     ```
 
+#### (Alternative) Install the HAProxy ingress controller
+
+`ingress-nginx` is deprecated upstream; `haproxy-ingress` is a drop-in alternative. Use this section *instead of* the Nginx section above — install only one ingress controller.
+
+Sample files, `sample-values_haproxy_gke_private.yaml` and `sample-values_haproxy_gke_public.yaml`, are provided. Each sample sets two HAProxy ConfigMap keys: `proxy-body-size: 64m` (raises the body size limit from the 1m default) and `option accept-invalid-http-request` via `config-frontend` (accepts headers with underscores — equivalent to nginx-ingress' `underscores_in_headers on`).
+
+Run the following, replacing `<private|public>` with the appropriate values file name:
+
+```shell
+helm repo add haproxy-ingress https://haproxy-ingress.github.io/charts
+helm upgrade haproxy-ingress haproxy-ingress/haproxy-ingress \
+  --version 0.14.7 \
+  --namespace haproxy-ingress \
+  --values sample-values_haproxy_gke_<private|public>.yaml \
+  --create-namespace \
+  --install
+```
+
+> If you chose HAProxy, you'll need two extra `--set-string` flags on the Anyscale Operator helm install below — see the note at the end of the [Install the Anyscale Operator](#install-the-anyscale-operator) section.
+
 ### Register the Anyscale Cloud
 
 Ensure that you are logged into Anyscale with valid CLI credentials. (`anyscale login`)
@@ -151,6 +171,18 @@ anyscale cloud register \
       --create-namespace \
       --install
     ```
+
+> **Using HAProxy instead of Nginx?** Add these flags to the helm command above:
+>
+> ```shell
+> HAPROXY_LB=$(kubectl get svc -n haproxy-ingress haproxy-ingress \
+>   -o jsonpath='{.status.loadBalancer.ingress[0].ip}{.status.loadBalancer.ingress[0].hostname}')
+>
+>   --set-string networking.ingress.classNameOverride=haproxy \
+>   --set-string networking.ingress.address=$HAPROXY_LB
+> ```
+>
+> Without these, the operator defaults to `ingressClassName: nginx` and Ingress creation will fail when no `nginx` IngressClass exists in the cluster.
 
 1. (Optional) For the L4 GPU instances (`g2-standard-16`) to work, modify the Anyscale Operator `instance-types` ConfigMap:
     ```

--- a/examples/gcp/gke-new_cluster/sample-values_haproxy_gke_private.yaml
+++ b/examples/gcp/gke-new_cluster/sample-values_haproxy_gke_private.yaml
@@ -1,0 +1,24 @@
+controller:
+  service:
+    type: LoadBalancer
+    annotations:
+      cloud.google.com/load-balancer-type: "Internal"
+      networking.gke.io/internal-load-balancer-allow-global-access: "true"
+  ingressClassResource:
+    enabled: true
+    name: haproxy
+    default: true
+  config:
+    # Raise the body size limit from the 1m default.
+    proxy-body-size: "64m"
+    # Accept headers with underscores and other non-standard cases —
+    # equivalent to nginx-ingress' `underscores_in_headers on`.
+    config-frontend: |
+      option accept-invalid-http-request
+  replicaCount: 1
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 3
+defaultBackend:
+  enabled: true

--- a/examples/gcp/gke-new_cluster/sample-values_haproxy_gke_public.yaml
+++ b/examples/gcp/gke-new_cluster/sample-values_haproxy_gke_public.yaml
@@ -1,0 +1,23 @@
+controller:
+  service:
+    type: LoadBalancer
+    annotations:
+      cloud.google.com/load-balancer-type: "External"
+  ingressClassResource:
+    enabled: true
+    name: haproxy
+    default: true
+  config:
+    # Raise the body size limit from the 1m default.
+    proxy-body-size: "64m"
+    # Accept headers with underscores and other non-standard cases —
+    # equivalent to nginx-ingress' `underscores_in_headers on`.
+    config-frontend: |
+      option accept-invalid-http-request
+  replicaCount: 1
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 3
+defaultBackend:
+  enabled: true


### PR DESCRIPTION
## Summary
`ingress-nginx` is deprecated upstream. Add `haproxy-ingress` as an alternative across all five examples (`aws/eks-{public,private,existing}`, `gcp/gke-{new,existing}_cluster`) without removing nginx — existing nginx setups stay intact.

- New `sample-values_haproxy*.yaml` per example.
- READMEs gain an "(Alternative) Install the HAProxy ingress controller" section after the existing Nginx section, plus a note on the Anyscale Operator helm install showing the two extra flags HAProxy users need (`classNameOverride=haproxy`, `address=$HAPROXY_LB`).

Each HAProxy sample sets `proxy-body-size: 64m` and `option accept-invalid-http-request` (via `config-frontend`) — the latter is the HAProxy equivalent of `underscores_in_headers on`.

## Test plan
- [ ] Fresh EKS cluster with HAProxy path end-to-end
- [ ] Verify nginx path still works (regression check)
- [ ] Smoke test private variants (EKS internal NLB, GKE Internal LB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)