### PR TITLE
aws efa nodegroup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The examples folder has a couple common use cases that have been tested. These i
   * [aks-new](https://github.com/anyscale/terraform-kubernetes-anyscale-foundation-modules/tree/main/examples/azure/aks-new_cluster) - Build everything - create a new AKS cluster and connect it to Anyscale
 * Anyscale - AWS & EKS
   * [eks-public](https://github.com/anyscale/terraform-kubernetes-anyscale-foundation-modules/tree/main/examples/aws/eks-public) - Build everything - use a common name for all resources, public networking
+  * [eks-public-efa](https://github.com/anyscale/terraform-kubernetes-anyscale-foundation-modules/tree/main/examples/aws/eks-public-efa) - Build everything - public networking with an additional P5/H100 EFA node group
   * [eks-private](https://github.com/anyscale/terraform-kubernetes-anyscale-foundation-modules/tree/main/examples/aws/eks-private) - Build everything - use a common name for all resources, private networking
 * Anyscale - GCP & GKE
   * [gke-existing_cluster](https://github.com/anyscale/terraform-kubernetes-anyscale-foundation-modules/tree/main/examples/gcp/gke-existing_cluster) - Use an existing GKE cluster, build additional resources such as object storage, service accounts, filestore.

--- a/examples/aws/eks-public-efa/README.md
+++ b/examples/aws/eks-public-efa/README.md
@@ -1,0 +1,257 @@
+[![Terraform Version][badge-terraform]](https://github.com/hashicorp/terraform/releases)
+[![AWS Provider Version][badge-tf-aws]](https://github.com/terraform-providers/terraform-provider-aws/releases)
+
+# Anyscale AWS EKS Example - Public Networking With P5/H100 EFA
+This example creates the resources to run Anyscale on AWS EKS with public networking and an additional `p5.48xlarge` H100 EFA node group.
+
+The content of this module should be used as a starting point and modified to your own security and infrastructure
+requirements.
+
+## Getting Started
+
+### Claude Code Guided Deployment
+
+If you have [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed, you can use the built-in skill to get interactive, step-by-step deployment guidance:
+
+```shell
+claude
+# Then type: /deploy-aws-eks
+```
+
+This will walk you through the full deployment process, check your prerequisites, and help you configure variables. You can also jump to a specific step (e.g., `/deploy-aws-eks nginx` or `/deploy-aws-eks register`).
+
+### Prerequisites
+
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+* [AWS Credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)
+* [kubectl CLI](https://kubernetes.io/docs/tasks/tools/)
+* [helm CLI](https://helm.sh/docs/intro/install/)
+* [Anyscale CLI](https://docs.anyscale.com/reference/quickstart-cli/)
+
+### Creating Anyscale Resources
+
+Steps for deploying Anyscale resources via Terraform:
+
+* Review variables.tf and (optionally) create a `terraform.tfvars` file to override any of the defaults.
+* Review `variables_efa.tf` if you plan to use the P5/H100 EFA node group. For targeted EC2 Capacity Reservations, set both of the following values:
+
+```hcl
+efa_capacity_reservation_id    = "cr-xxxxxxxxxxxxxxxxx"
+efa_capacity_reservation_az_id = "use1-az3"
+```
+
+The AZ ID must match the reservation. AZ names can differ between AWS accounts, while AZ IDs are stable.
+* Apply the terraform
+
+```shell
+terraform init
+terraform plan
+terraform apply
+```
+
+If you are using a `tfvars` file, you will need to update the above commands accordingly.
+Note the output from Terraform which includes an example cloud registration command you will use below.
+
+### Install the Kubernetes Requirements
+
+The Anyscale Operator requires the following components:
+* [Cluster autoscaler](https://github.com/kubernetes/autoscaler/tree/master/charts/cluster-autoscaler)
+* [AWS LBC (Load Balancer controller)](https://github.com/kubernetes-sigs/aws-load-balancer-controller/tree/main/helm/aws-load-balancer-controller)
+* [Nginx Ingress Controller](https://kubernetes.github.io/ingress-nginx/deploy/) (other ingress controllers may be possible but are untested)
+* (Optional) [Nvidia device plugin](https://github.com/NVIDIA/k8s-device-plugin/tree/main?tab=readme-ov-file#deployment-via-helm) (required if utilizing GPU nodes)
+* (Optional) [AWS EFA Kubernetes device plugin](https://github.com/aws/eks-charts/tree/master/stable/aws-efa-k8s-device-plugin) or EFA DRA driver (required if Pods request EFA devices)
+
+**Note:** Ensure that you are [authenticated to the EKS cluster](https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html) for the remaining steps.
+
+#### Install the Cluster autoscaler
+
+1. Run the following to install the Kubernetes Autoscaler helm chart:
+
+```shell
+helm repo add autoscaler https://kubernetes.github.io/autoscaler
+helm upgrade cluster-autoscaler autoscaler/cluster-autoscaler \
+  --version 9.46.0 \
+  --namespace kube-system \
+  --set awsRegion=<aws_region> \
+  --set 'autoDiscovery.clusterName'=<eks_cluster_name> \
+  --install
+```
+
+#### Install the AWS LBC (load balancer controller)
+1. Run the following to install the AWS Load Balancer Controller helm chart:
+
+```shell
+helm repo add eks https://aws.github.io/eks-charts
+helm upgrade aws-load-balancer-controller eks/aws-load-balancer-controller \
+  --version 1.13.2 \
+  --namespace kube-system \
+  --set clusterName=<eks_cluster_name> \
+  --install
+```
+
+#### Install the Nginx ingress controller
+
+A sample file, `sample-values_nginx.yaml` has been provided in this repo. Please review for your requirements before using.
+
+Run:
+
+```shell
+helm repo add nginx https://kubernetes.github.io/ingress-nginx
+helm upgrade ingress-nginx nginx/ingress-nginx \
+  --version 4.12.1 \
+  --namespace ingress-nginx \
+  --values sample-values_nginx.yaml \
+  --create-namespace \
+  --install
+```
+
+#### (Optional) Install the Nvidia device plugin
+
+A sample file, `sample-values_nvdp.yaml` has been provided in this repo. Please review for your requirements before using.
+
+1. Create a YAML values file named: `values_nvdp.yaml`
+2. Update the content with the following:
+
+```yaml
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        # We allow a GPU deployment to be forced by setting the following label to "true"
+        - key: "nvidia.com/gpu.product"
+          operator: Exists
+tolerations:
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule
+  - key: node.anyscale.com/capacity-type
+    operator: Exists
+    effect: NoSchedule
+  - key: node.anyscale.com/accelerator-type
+    operator: Exists
+    effect: NoSchedule
+```
+
+3. Run:
+
+```shell
+helm repo add nvdp https://nvidia.github.io/k8s-device-plugin
+helm upgrade nvdp nvdp/nvidia-device-plugin \
+  --namespace nvidia-device-plugin \
+  --version 0.17.1 \
+  --values values_nvdp.yaml \
+  --create-namespace \
+  --install
+```
+
+### Register the Anyscale Cloud
+
+Ensure that you are logged into Anyscale with valid CLI credentials. (`anyscale login`)
+
+1. Using the output from the Terraform modules, register the Anyscale Cloud. It should look sonething like:
+
+```shell
+anyscale cloud register --provider aws \
+  --name my_kubernetes_cloud \
+  --compute-stack k8s \
+  --region us-east-2 \
+  --s3-bucket-id anyscale_example_bucket \
+  --efs-id fs-abcdefgh01234567 \
+  --kubernetes-zones us-east-2a,us-east-2b,us-east-2c \
+  --anyscale-operator-iam-identity arn:aws:iam::123456789012:role/my-kubernetes-cloud-node-group-role
+```
+**Please note:** You must change the cloud name to a name that you choose. You will not be able to register a cloud with a name of `<CUSTOMER_DEFINED_NAME>`.
+
+2. Note the Cloud Deployment ID which will be used in the next step. The Anyscale CLI will return it as one of the outputs. Example:
+```shell
+Output
+(anyscale +22.5s) For registering this cloud's Kubernetes Manager, use cloud deployment ID '<cloud-deployment-id>'.
+```
+
+### Install the Anyscale Operator
+
+1. Using the below example, replace `<aws_region>` with the AWS region where EKS is running, and replace `<cloud-deployment-id>` with the appropriate value from the `anyscale cloud register` output. Please note that you can also change the namespace to one that you wish to associate with Anyscale pods.
+2. Using your updated helm upgrade command, install the Anyscale Operator.
+
+```shell
+helm repo add anyscale https://anyscale.github.io/helm-charts
+helm upgrade anyscale-operator anyscale/anyscale-operator \
+  --set-string global.cloudDeploymentId=<cloud-deployment-id> \
+  --set-string global.cloudProvider=aws \
+  --set-string global.aws.region=<aws_region> \
+  --set-string workloads.serviceAccount.name=anyscale-operator \
+  --namespace anyscale-operator \
+  --create-namespace \
+  --install
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_anyscale_efs"></a> [anyscale\_efs](#module\_anyscale\_efs) | github.com/anyscale/terraform-aws-anyscale-cloudfoundation-modules//modules/aws-anyscale-efs | n/a |
+| <a name="module_anyscale_iam_roles"></a> [anyscale\_iam\_roles](#module\_anyscale\_iam\_roles) | github.com/anyscale/terraform-aws-anyscale-cloudfoundation-modules//modules/aws-anyscale-iam | n/a |
+| <a name="module_anyscale_s3"></a> [anyscale\_s3](#module\_anyscale\_s3) | github.com/anyscale/terraform-aws-anyscale-cloudfoundation-modules//modules/aws-anyscale-s3 | n/a |
+| <a name="module_anyscale_vpc"></a> [anyscale\_vpc](#module\_anyscale\_vpc) | github.com/anyscale/terraform-aws-anyscale-cloudfoundation-modules//modules/aws-anyscale-vpc | n/a |
+| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 20.33.1 |
+| <a name="module_h100_efa_nodegroup"></a> [h100\_efa\_nodegroup](#module\_h100\_efa\_nodegroup) | ../../../modules/aws-efa-nodegroup | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_policy.autoscaler_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.elb_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_route_table_association.efa_private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
+| [aws_security_group.allow_all_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_subnet.efa_private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_iam_role.default_nodegroup](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | (Optional) The AWS region in which all resources will be created.<br/><br/>ex:<pre>aws_region = "us-east-2"</pre> | `string` | `"us-east-2"` | no |
+| <a name="input_efa_capacity_reservation_az_id"></a> [efa\_capacity\_reservation\_az\_id](#input\_efa\_capacity\_reservation\_az\_id) | (Optional) Availability Zone ID for the targeted EFA capacity reservation, for example use1-az3. | `string` | `null` | no |
+| <a name="input_efa_capacity_reservation_id"></a> [efa\_capacity\_reservation\_id](#input\_efa\_capacity\_reservation\_id) | (Optional) Targeted EC2 Capacity Reservation ID for the p5.48xlarge EFA node group. | `string` | `null` | no |
+| <a name="input_efa_private_subnet_cidr"></a> [efa\_private\_subnet\_cidr](#input\_efa\_private\_subnet\_cidr) | (Optional) CIDR block for the private EFA subnet created in the capacity reservation AZ. | `string` | `"172.24.22.0/24"` | no |
+| <a name="input_efa_workload_name"></a> [efa\_workload\_name](#input\_efa\_workload\_name) | (Optional) Workload name used for the P5/H100 EFA node group name, labels, taints, and Cluster Autoscaler template tags. | `string` | `"h100-efa"` | no |
+| <a name="input_eks_cluster_name"></a> [eks\_cluster\_name](#input\_eks\_cluster\_name) | (Optional) The name of the EKS cluster.<br/><br/>This will be used for naming resources created by this module including the EKS cluster and the S3 bucket.<br/><br/>ex:<pre>eks_cluster_name = "anyscale-eks-public-efa"</pre> | `string` | `"anyscale-eks-public-efa"` | no |
+| <a name="input_eks_cluster_version"></a> [eks\_cluster\_version](#input\_eks\_cluster\_version) | (Optional) The Kubernetes version of the EKS cluster.<br/><br/>ex:<pre>eks_cluster_version = "1.32"</pre> | `string` | `"1.32"` | no |
+| <a name="input_enable_efs"></a> [enable\_efs](#input\_enable\_efs) | (Optional) Enable the creation of an EFS instance.<br/><br/>This is optional for Anyscale deployments. EFS is used for shared storage between nodes.<br/><br/>ex:<pre>enable_efs = true</pre> | `bool` | `false` | no |
+| <a name="input_gpu_instance_types"></a> [gpu\_instance\_types](#input\_gpu\_instance\_types) | (Optional) GPU types configuration for the EKS cluster.<br/>See gpu\_instances.tfvars.example for additional GPU types.<br/><br/>ex:<pre>gpu_instance_types = {<br/>  "T4" = {<br/>    product_name   = "Tesla-T4"<br/>    instance_types = ["g4dn.xlarge", "g4dn.2xlarge", "g4dn.4xlarge"]<br/>  }<br/>  "A10G" = {<br/>    product_name   = "NVIDIA-A10G"<br/>    instance_types = ["g5.4xlarge"]<br/>  }<br/>}</pre> | <pre>map(object({<br/>    product_name   = string<br/>    instance_types = list(string)<br/>  }))</pre> | <pre>{<br/>  "T4": {<br/>    "instance_types": [<br/>      "g4dn.4xlarge"<br/>    ],<br/>    "product_name": "Tesla-T4"<br/>  }<br/>}</pre> | no |
+| <a name="input_node_group_disk_size"></a> [node\_group\_disk\_size](#input\_node\_group\_disk\_size) | (Optional) The disk size (GB) of the EKS nodes.<br/>Possible values: [500, 1000]<br/><br/>ex:<pre>node_group_disk_size = 1000</pre> | `number` | `500` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to all resources that accept tags.<br/><br/>ex:<pre>tags = {<br/>  Environment = "dev"<br/>  Repo        = "terraform-kubernetes-anyscale-foundation-modules",<br/>}</pre> | `map(string)` | <pre>{<br/>  "Environment": "dev",<br/>  "Example": "aws/eks-public-efa",<br/>  "Repo": "terraform-kubernetes-anyscale-foundation-modules",<br/>  "Test": "true"<br/>}</pre> | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_anyscale_registration_command"></a> [anyscale\_registration\_command](#output\_anyscale\_registration\_command) | The Anyscale registration command. |
+| <a name="output_aws_region"></a> [aws\_region](#output\_aws\_region) | The AWS region. This is used for Helm chart values. |
+| <a name="output_eks_cluster_name"></a> [eks\_cluster\_name](#output\_eks\_cluster\_name) | The name of the EKS cluster. This is used for Helm chart values. |
+| <a name="output_helm_upgrade_command"></a> [helm\_upgrade\_command](#output\_helm\_upgrade\_command) | The helm upgrade command. |
+<!-- END_TF_DOCS -->
+
+<!-- References -->
+[Terraform]: https://www.terraform.io
+[Issues]: https://github.com/anyscale/sa-sandbox-terraform/issues
+<!-- [badge-build]: https://github.com/anyscale/sa-sandbox-terraform/workflows/CI/CD%20Pipeline/badge.svg -->
+[badge-terraform]: https://img.shields.io/badge/terraform-1.x%20-623CE4.svg?logo=terraform
+[badge-tf-aws]: https://img.shields.io/badge/AWS-5.+-F8991D.svg?logo=terraform
+[build-status]: https://github.com/anyscale/sa-sandbox-terraform/actions

--- a/examples/aws/eks-public-efa/README.md
+++ b/examples/aws/eks-public-efa/README.md
@@ -250,8 +250,8 @@ helm upgrade anyscale-operator anyscale/anyscale-operator \
 
 <!-- References -->
 [Terraform]: https://www.terraform.io
-[Issues]: https://github.com/anyscale/sa-sandbox-terraform/issues
-<!-- [badge-build]: https://github.com/anyscale/sa-sandbox-terraform/workflows/CI/CD%20Pipeline/badge.svg -->
+[Issues]: https://github.com/anyscale/terraform-kubernetes-anyscale-foundation-modules/issues
+<!-- [badge-build]: https://github.com/anyscale/terraform-kubernetes-anyscale-foundation-modules/workflows/CI/CD%20Pipeline/badge.svg -->
 [badge-terraform]: https://img.shields.io/badge/terraform-1.x%20-623CE4.svg?logo=terraform
 [badge-tf-aws]: https://img.shields.io/badge/AWS-5.+-F8991D.svg?logo=terraform
-[build-status]: https://github.com/anyscale/sa-sandbox-terraform/actions
+[build-status]: https://github.com/anyscale/terraform-kubernetes-anyscale-foundation-modules/actions

--- a/examples/aws/eks-public-efa/efa_capacity.tf
+++ b/examples/aws/eks-public-efa/efa_capacity.tf
@@ -1,0 +1,32 @@
+locals {
+  efa_capacity_reservation_enabled = var.efa_capacity_reservation_id != null && var.efa_capacity_reservation_id != ""
+  efa_node_subnet_id               = local.efa_capacity_reservation_enabled ? aws_subnet.efa_private[0].id : module.anyscale_vpc.private_subnet_ids[0]
+  efa_node_availability_zone       = local.efa_capacity_reservation_enabled ? aws_subnet.efa_private[0].availability_zone : module.anyscale_vpc.availability_zones[0]
+}
+
+resource "aws_subnet" "efa_private" {
+  count = local.efa_capacity_reservation_enabled ? 1 : 0
+
+  vpc_id               = module.anyscale_vpc.vpc_id
+  cidr_block           = var.efa_private_subnet_cidr
+  availability_zone_id = var.efa_capacity_reservation_az_id
+
+  tags = merge(var.tags, {
+    "Name"                            = "anyscale-${var.eks_cluster_name}-private-efa"
+    "kubernetes.io/role/internal-elb" = "1"
+  })
+
+  lifecycle {
+    precondition {
+      condition     = var.efa_capacity_reservation_az_id != null && var.efa_capacity_reservation_az_id != ""
+      error_message = "efa_capacity_reservation_az_id is required when efa_capacity_reservation_id is set."
+    }
+  }
+}
+
+resource "aws_route_table_association" "efa_private" {
+  count = local.efa_capacity_reservation_enabled ? 1 : 0
+
+  subnet_id      = aws_subnet.efa_private[0].id
+  route_table_id = module.anyscale_vpc.private_route_table_ids[0]
+}

--- a/examples/aws/eks-public-efa/efa_nodegroup.tf
+++ b/examples/aws/eks-public-efa/efa_nodegroup.tf
@@ -1,0 +1,39 @@
+# This EFA worker pool extends the standard Anyscale EKS public example with a
+# p5.48xlarge H100 node group.
+module "h100_efa_nodegroup" {
+  source = "../../../modules/aws-efa-nodegroup"
+
+  cluster_name  = var.eks_cluster_name
+  vpc_id        = module.anyscale_vpc.vpc_id
+  subnet_id     = local.efa_node_subnet_id
+  node_role_arn = data.aws_iam_role.default_nodegroup.arn
+
+  availability_zone = local.efa_node_availability_zone
+  workload_name     = var.efa_workload_name
+
+  cluster_security_group_ids = [
+    module.eks.cluster_security_group_id,
+  ]
+
+  additional_security_group_ids = [
+    module.eks.node_security_group_id,
+  ]
+
+  instance_type = "p5.48xlarge"
+  ami_type      = "AL2023_x86_64_NVIDIA"
+
+  capacity_type           = "ON_DEMAND"
+  capacity_reservation_id = var.efa_capacity_reservation_id
+
+  min_size     = 0
+  desired_size = 0
+  max_size     = 4
+
+  root_volume_size_gb = var.node_group_disk_size
+
+  tags = var.tags
+
+  depends_on = [
+    module.eks,
+  ]
+}

--- a/examples/aws/eks-public-efa/eks.tf
+++ b/examples/aws/eks-public-efa/eks.tf
@@ -1,0 +1,516 @@
+#################################################################
+# Terraform configuration to create a new Amazon EKS cluster
+#
+# This example uses the official EKS module:
+# https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest
+#
+# It demonstrated creation of different kinds of managed node groups:
+# - on-demand CPU
+# - on-demand GPU
+# - spot CPU
+# - spot GPU
+# - custom AMI with launch template
+#
+# For capacity reservations, refer to:
+# https://aws-ia.github.io/terraform-aws-eks-blueprints/patterns/machine-learning/targeted-odcr/
+#
+#################################################################
+
+locals {
+  anyscale_iam = merge(
+    {
+      anyscale_s3_policy = module.anyscale_iam_roles.anyscale_iam_s3_policy_arn,
+    },
+    var.enable_efs ? {
+      efs_client_policy = "arn:aws:iam::aws:policy/AmazonElasticFileSystemClientReadWriteAccess",
+    } : {}
+  )
+
+  node_group_block_device_mappings = {
+    xvda = {
+      device_name = "/dev/xvda"
+      ebs = {
+        delete_on_termination = true
+        volume_size           = var.node_group_disk_size
+        volume_type           = "gp3"
+      }
+    }
+  }
+
+  # Base configuration for GPU node groups
+  gpu_node_group_base = {
+    ami_type                     = "AL2023_x86_64_NVIDIA"
+    min_size                     = 0
+    max_size                     = 10
+    desired_size                 = 0
+    disk_size                    = var.node_group_disk_size
+    use_custom_launch_template   = false
+    iam_role_additional_policies = local.anyscale_iam
+  }
+
+  gpu_node_taints_base = [
+    {
+      key    = "nvidia.com/gpu",
+      value  = "present",
+      effect = "NO_SCHEDULE",
+    },
+    {
+      key    = "node.anyscale.com/accelerator-type",
+      value  = "GPU",
+      effect = "NO_SCHEDULE",
+    }
+  ]
+
+  gpu_node_taints_ondemand = concat(local.gpu_node_taints_base, [
+    {
+      key    = "node.anyscale.com/capacity-type",
+      value  = "ON_DEMAND",
+      effect = "NO_SCHEDULE",
+    }
+  ])
+
+  gpu_node_taints_spot = concat(local.gpu_node_taints_base, [
+    {
+      key    = "node.anyscale.com/capacity-type",
+      value  = "SPOT",
+      effect = "NO_SCHEDULE",
+    }
+  ])
+
+  # Create a map of GPU node groups based on gpu_instance_types
+  gpu_node_groups = {
+    for gpu_type in keys(var.gpu_instance_types) : gpu_type => {
+      ondemand = merge(
+        local.gpu_node_group_base,
+        {
+          instance_types = var.gpu_instance_types[gpu_type].instance_types
+          capacity_type  = "ON_DEMAND"
+          labels = {
+            "nvidia.com/gpu.product" = var.gpu_instance_types[gpu_type].product_name
+            "nvidia.com/gpu.count"   = "1"
+          }
+          taints = local.gpu_node_taints_ondemand
+        }
+      )
+      spot = merge(
+        local.gpu_node_group_base,
+        {
+          instance_types = var.gpu_instance_types[gpu_type].instance_types
+          capacity_type  = "SPOT"
+          labels = {
+            "nvidia.com/gpu.product" = var.gpu_instance_types[gpu_type].product_name
+            "nvidia.com/gpu.count"   = "1"
+          }
+          taints = local.gpu_node_taints_spot
+        }
+      )
+    }
+  }
+}
+
+#trivy:ignore:avd-aws-0038
+#trivy:ignore:avd-aws-0040
+#trivy:ignore:avd-aws-0041
+#trivy:ignore:avd-aws-0104
+module "eks" {
+  #checkov:skip=CKV_TF_1: Use the given version of the module
+  source  = "terraform-aws-modules/eks/aws"
+  version = "20.33.1"
+
+  # Cluster basic configuration
+  cluster_name    = var.eks_cluster_name
+  cluster_version = var.eks_cluster_version
+
+  cluster_addons = {
+    coredns                = {}
+    eks-pod-identity-agent = {}
+    kube-proxy             = {}
+  }
+
+  # API endpoint access configuration
+  cluster_endpoint_public_access = true
+
+  # The authentication mode for the cluster. Valid values are `CONFIG_MAP`, `API` or `API_AND_CONFIG_MAP`
+  authentication_mode = "API_AND_CONFIG_MAP"
+
+  # Optional: Adds the current caller identity as an administrator via cluster access entry
+  enable_cluster_creator_admin_permissions = true
+
+  vpc_id                   = module.anyscale_vpc.vpc_id
+  control_plane_subnet_ids = module.anyscale_vpc.public_subnet_ids
+  subnet_ids               = module.anyscale_vpc.private_subnet_ids
+
+  node_security_group_additional_rules = {
+    anyscale_ingress_nodes = {
+      description = "Node to node ingress - all traffic"
+      protocol    = "-1"
+      from_port   = 0
+      to_port     = 0
+      type        = "ingress"
+      self        = true
+    }
+    anyscale_egress_nodes = {
+      description = "Node to node egress - all traffic"
+      protocol    = "-1"
+      from_port   = 0
+      to_port     = 0
+      type        = "egress"
+      self        = true
+    }
+  }
+
+  #############################################################
+  # Managed Node Groups configuration example
+  #############################################################
+
+  eks_managed_node_groups = merge(
+    {
+      # This node group is for management components such as CoreDNS, Cluster Autoscaler, AWS-LB controller, ingress-nginx, Anyscale Operator, etc.
+      # Note that small instance types of Anyscale workloads can still be scheduled onto this node group.
+      default = {
+        ami_type       = "AL2023_x86_64_STANDARD"
+        instance_types = ["t3.medium"]
+
+        min_size     = 1
+        max_size     = 10
+        desired_size = 2
+
+        iam_role_additional_policies = merge(local.anyscale_iam, {
+          cluster_autoscaler_policy = aws_iam_policy.autoscaler_policy.arn
+          elb_policy                = aws_iam_policy.elb_policy.arn
+        })
+      }
+
+      ondemand_cpu = {
+        ami_type = "AL2023_x86_64_STANDARD"
+        instance_types = [
+          "m5.8xlarge",
+          "m5.4xlarge",
+        ]
+
+        capacity_type              = "ON_DEMAND"
+        min_size                   = 0
+        max_size                   = 10
+        desired_size               = 0
+        block_device_mappings      = local.node_group_block_device_mappings
+        use_custom_launch_template = true
+
+        taints = [
+          {
+            key    = "node.anyscale.com/capacity-type",
+            value  = "ON_DEMAND",
+            effect = "NO_SCHEDULE",
+          }
+        ]
+
+        iam_role_additional_policies = local.anyscale_iam
+      }
+
+      spot_cpu = {
+        ami_type = "AL2023_x86_64_STANDARD"
+        instance_types = [
+          "m5.8xlarge",
+          "m5.4xlarge",
+        ]
+
+        capacity_type              = "SPOT"
+        min_size                   = 0
+        max_size                   = 10
+        desired_size               = 0
+        block_device_mappings      = local.node_group_block_device_mappings
+        use_custom_launch_template = true
+
+        taints = [
+          {
+            key    = "node.anyscale.com/capacity-type",
+            value  = "SPOT",
+            effect = "NO_SCHEDULE",
+          }
+        ]
+
+        iam_role_additional_policies = local.anyscale_iam
+      }
+    },
+    # Merge in GPU node groups based on gpu_instance_types
+    {
+      for gpu_type in keys(var.gpu_instance_types) : "ondemand_gpu_${lower(gpu_type)}" => local.gpu_node_groups[gpu_type].ondemand
+    },
+    {
+      for gpu_type in keys(var.gpu_instance_types) : "spot_gpu_${lower(gpu_type)}" => local.gpu_node_groups[gpu_type].spot
+    }
+  )
+
+  tags = var.tags
+}
+
+#trivy:ignore:avd-aws-0057
+resource "aws_iam_policy" "autoscaler_policy" {
+  #checkov:skip=CKV_AWS_290: Ensure IAM policies does not allow write access without constraints
+  #checkov:skip=CKV_AWS_355: Ensure no IAM policies documents allow "*" as a statement's resource for restrictable actions
+  name        = "${var.eks_cluster_name}-autoscaler-policy"
+  description = "Policy that allows autoscaling and EC2 describe actions for EKS nodegroups."
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "autoscaling:DescribeAutoScalingGroups",
+          "autoscaling:DescribeAutoScalingInstances",
+          "autoscaling:DescribeLaunchConfigurations",
+          "autoscaling:DescribeScalingActivities",
+          "ec2:DescribeImages",
+          "ec2:DescribeInstanceTypes",
+          "ec2:DescribeLaunchTemplateVersions",
+          "ec2:GetInstanceTypesFromInstanceRequirements",
+          "eks:DescribeNodegroup"
+        ]
+        Resource = ["*"]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "autoscaling:SetDesiredCapacity",
+          "autoscaling:TerminateInstanceInAutoScalingGroup"
+        ]
+        Resource = ["*"]
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+# For AWS LBC:
+#   https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.11.0/docs/install/iam_policy.json
+#trivy:ignore:avd-aws-0057
+resource "aws_iam_policy" "elb_policy" {
+  #checkov:skip=CKV_AWS_290: Ensure IAM policies does not allow write access without constraints
+  #checkov:skip=CKV_AWS_355: Ensure no IAM policies documents allow "*" as a statement's resource for restrictable actions
+  name        = "${var.eks_cluster_name}-elb-policy"
+  description = "IAM policy for AWS Load Balancer Controller in Kubernetes"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["iam:CreateServiceLinkedRole"]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "iam:AWSServiceName" = "elasticloadbalancing.amazonaws.com"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:DescribeAccountAttributes",
+          "ec2:DescribeAddresses",
+          "ec2:DescribeAvailabilityZones",
+          "ec2:DescribeInternetGateways",
+          "ec2:DescribeVpcs",
+          "ec2:DescribeVpcPeeringConnections",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeInstances",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DescribeTags",
+          "ec2:GetCoipPoolUsage",
+          "ec2:DescribeCoipPools",
+          "ec2:GetSecurityGroupsForVpc",
+          "elasticloadbalancing:DescribeLoadBalancers",
+          "elasticloadbalancing:DescribeLoadBalancerAttributes",
+          "elasticloadbalancing:DescribeListeners",
+          "elasticloadbalancing:DescribeListenerCertificates",
+          "elasticloadbalancing:DescribeSSLPolicies",
+          "elasticloadbalancing:DescribeRules",
+          "elasticloadbalancing:DescribeTargetGroups",
+          "elasticloadbalancing:DescribeTargetGroupAttributes",
+          "elasticloadbalancing:DescribeTargetHealth",
+          "elasticloadbalancing:DescribeTags",
+          "elasticloadbalancing:DescribeTrustStores",
+          "elasticloadbalancing:DescribeListenerAttributes",
+          "elasticloadbalancing:DescribeCapacityReservation"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "cognito-idp:DescribeUserPoolClient",
+          "acm:ListCertificates",
+          "acm:DescribeCertificate",
+          "iam:ListServerCertificates",
+          "iam:GetServerCertificate",
+          "waf-regional:GetWebACL",
+          "waf-regional:GetWebACLForResource",
+          "waf-regional:AssociateWebACL",
+          "waf-regional:DisassociateWebACL",
+          "wafv2:GetWebACL",
+          "wafv2:GetWebACLForResource",
+          "wafv2:AssociateWebACL",
+          "wafv2:DisassociateWebACL",
+          "shield:GetSubscriptionState",
+          "shield:DescribeProtection",
+          "shield:CreateProtection",
+          "shield:DeleteProtection"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:AuthorizeSecurityGroupIngress",
+          "ec2:RevokeSecurityGroupIngress"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["ec2:CreateSecurityGroup"]
+        Resource = "*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["ec2:CreateTags"]
+        Resource = "arn:aws:ec2:*:*:security-group/*"
+        Condition = {
+          StringEquals = {
+            "ec2:CreateAction" = "CreateSecurityGroup"
+          }
+          Null = {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" = "false"
+          }
+        }
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["ec2:CreateTags", "ec2:DeleteTags"]
+        Resource = "arn:aws:ec2:*:*:security-group/*"
+        Condition = {
+          Null = {
+            "aws:RequestTag/elbv2.k8s.aws/cluster"  = "true"
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" = "false"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:AuthorizeSecurityGroupIngress",
+          "ec2:RevokeSecurityGroupIngress",
+          "ec2:DeleteSecurityGroup"
+        ]
+        Resource = "*"
+        Condition = {
+          Null = {
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" = "false"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:CreateLoadBalancer",
+          "elasticloadbalancing:CreateTargetGroup"
+        ]
+        Resource = "*"
+        Condition = {
+          Null = {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" = "false"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:CreateListener",
+          "elasticloadbalancing:DeleteListener",
+          "elasticloadbalancing:CreateRule",
+          "elasticloadbalancing:DeleteRule"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:AddTags",
+          "elasticloadbalancing:RemoveTags"
+        ]
+        Resource = [
+          "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+          "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+          "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+        ]
+        Condition = {
+          Null = {
+            "aws:RequestTag/elbv2.k8s.aws/cluster"  = "true"
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" = "false"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:AddTags",
+          "elasticloadbalancing:RemoveTags"
+        ]
+        Resource = [
+          "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
+          "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
+          "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+          "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:ModifyLoadBalancerAttributes",
+          "elasticloadbalancing:SetIpAddressType",
+          "elasticloadbalancing:SetSecurityGroups",
+          "elasticloadbalancing:SetSubnets",
+          "elasticloadbalancing:DeleteLoadBalancer",
+          "elasticloadbalancing:ModifyTargetGroup",
+          "elasticloadbalancing:ModifyTargetGroupAttributes",
+          "elasticloadbalancing:DeleteTargetGroup",
+          "elasticloadbalancing:ModifyListenerAttributes",
+          "elasticloadbalancing:ModifyCapacityReservation"
+        ]
+        Resource = "*"
+        Condition = {
+          Null = {
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" = "false"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = ["elasticloadbalancing:AddTags"]
+        Resource = [
+          "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+          "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+          "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+        ]
+        Condition = {
+          StringEquals = {
+            "elasticloadbalancing:CreateAction" = ["CreateTargetGroup", "CreateLoadBalancer"]
+          }
+          Null = {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" = "false"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:RegisterTargets",
+          "elasticloadbalancing:DeregisterTargets"
+        ]
+        Resource = "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+      }
+    ]
+  })
+
+  tags = var.tags
+}

--- a/examples/aws/eks-public-efa/gpu_instances.tfvars.example
+++ b/examples/aws/eks-public-efa/gpu_instances.tfvars.example
@@ -1,0 +1,31 @@
+# GPU Instance Types for EKS
+#
+# This file contains additional GPU instance configurations beyond the default (T4).
+# Use this file directly or copy and modify as needed:
+#
+#   terraform plan -var-file="gpu_instances.tfvars.example"
+#   terraform apply -var-file="gpu_instances.tfvars.example"
+
+# GPU types configuration - node groups will be created for each entry
+gpu_instance_types = {
+  "T4" = {
+    product_name   = "Tesla-T4"
+    instance_types = ["g4dn.xlarge", "g4dn.2xlarge", "g4dn.4xlarge"]
+  }
+  "T4-4x" = {
+    product_name   = "Tesla-T4"
+    instance_types = ["g4dn.12xlarge"]
+  }
+  "A10G" = {
+    product_name   = "NVIDIA-A10G"
+    instance_types = ["g5.4xlarge"]
+  }
+  "L4" = {
+    product_name   = "NVIDIA-L4"
+    instance_types = ["g6.2xlarge", "g6.4xlarge"]
+  }
+  "L4-4x" = {
+    product_name   = "NVIDIA-L4"
+    instance_types = ["g6.24xlarge"]
+  }
+}

--- a/examples/aws/eks-public-efa/main.tf
+++ b/examples/aws/eks-public-efa/main.tf
@@ -1,0 +1,106 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Example Anyscale K8s Resources - Public Networking
+#   This template creates EKS resources for Anyscale
+#   It creates:
+#     - VPC
+#     - EFS
+#     - S3 Bucket
+#     - IAM policies
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  public_subnets  = ["172.24.101.0/24", "172.24.102.0/24"]
+  private_subnets = ["172.24.20.0/24", "172.24.21.0/24"]
+}
+
+module "anyscale_vpc" {
+  #checkov:skip=CKV_TF_1: Example code should use the latest version of the module
+  #checkov:skip=CKV_TF_2: Example code should use the latest version of the module
+  source = "github.com/anyscale/terraform-aws-anyscale-cloudfoundation-modules//modules/aws-anyscale-vpc"
+
+  anyscale_vpc_name = "anyscale-${var.eks_cluster_name}"
+  cidr_block        = "172.24.0.0/16"
+
+  public_subnets  = local.public_subnets
+  private_subnets = local.private_subnets
+
+  public_subnet_tags = {
+    "kubernetes.io/role/elb" = "1"
+  }
+  private_subnet_tags = {
+    "kubernetes.io/role/internal-elb" = "1"
+  }
+}
+
+#trivy:ignore:avd-aws-0132
+module "anyscale_s3" {
+  #checkov:skip=CKV_TF_1: Example code should use the latest version of the module
+  #checkov:skip=CKV_TF_2: Example code should use the latest version of the module
+  source = "github.com/anyscale/terraform-aws-anyscale-cloudfoundation-modules//modules/aws-anyscale-s3"
+
+  module_enabled = true
+
+  anyscale_bucket_name = "${var.eks_cluster_name}-${var.aws_region}"
+
+  tags = var.tags
+}
+
+#trivy:ignore:avd-aws-0104
+resource "aws_security_group" "allow_all_vpc" {
+  #checkov:skip=CKV2_AWS_5: "Ensure that Security Groups are attached to another resource"
+  #checkov:skip=CKV_AWS_382: "Egress is allowed to the internet for the Anyscale Control Plane and other services."
+  name        = "allow-all-vpc"
+  description = "Allow all traffic within the VPC"
+  vpc_id      = module.anyscale_vpc.vpc_id
+
+  ingress {
+    description = "Allow all traffic from within the VPC"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = [module.anyscale_vpc.vpc_cidr_block]
+  }
+
+  egress {
+    description = "Allow all traffic to the internet"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = var.tags
+}
+
+module "anyscale_efs" {
+  #checkov:skip=CKV_TF_1: Example code should use the latest version of the module
+  #checkov:skip=CKV_TF_2: Example code should use the latest version of the module
+  source = "github.com/anyscale/terraform-aws-anyscale-cloudfoundation-modules//modules/aws-anyscale-efs"
+
+  module_enabled = var.enable_efs
+
+  anyscale_efs_name          = "anyscale-${var.eks_cluster_name}"
+  mount_targets_subnet_count = length(local.private_subnets)
+  mount_targets_subnets      = module.anyscale_vpc.private_subnet_ids
+
+  associated_security_group_ids = [aws_security_group.allow_all_vpc.id]
+
+  tags = var.tags
+}
+
+#trivy:ignore:avd-aws-0342
+module "anyscale_iam_roles" {
+  #checkov:skip=CKV_TF_1: Example code should use the latest version of the module
+  #checkov:skip=CKV_TF_2: Example code should use the latest version of the module
+  source = "github.com/anyscale/terraform-aws-anyscale-cloudfoundation-modules//modules/aws-anyscale-iam"
+
+  module_enabled = true
+
+  create_anyscale_access_role          = false
+  create_cluster_node_instance_profile = false
+
+  create_iam_s3_policy   = true
+  anyscale_s3_bucket_arn = module.anyscale_s3.s3_bucket_arn
+
+  tags = var.tags
+}

--- a/examples/aws/eks-public-efa/outputs.tf
+++ b/examples/aws/eks-public-efa/outputs.tf
@@ -1,0 +1,52 @@
+locals {
+  kubernetes_zones = join(",", module.anyscale_vpc.availability_zones)
+}
+
+data "aws_iam_role" "default_nodegroup" {
+  name = module.eks.eks_managed_node_groups["default"].iam_role_name
+}
+
+output "eks_cluster_name" {
+  description = "The name of the EKS cluster. This is used for Helm chart values."
+  value       = var.eks_cluster_name
+}
+
+output "aws_region" {
+  description = "The AWS region. This is used for Helm chart values."
+  value       = var.aws_region
+}
+
+locals {
+  registration_command_parts = compact([
+    "anyscale cloud register",
+    "--name <anyscale_cloud_name>",
+    "--region ${var.aws_region}",
+    "--provider aws",
+    "--compute-stack k8s",
+    "--kubernetes-zones ${local.kubernetes_zones}",
+    "--s3-bucket-id ${module.anyscale_s3.s3_bucket_id}",
+    var.enable_efs ? "--efs-id ${module.anyscale_efs.efs_id}" : null,
+    "--anyscale-operator-iam-identity ${data.aws_iam_role.default_nodegroup.arn}",
+  ])
+
+  helm_upgrade_command_parts = compact([
+    "helm upgrade anyscale-operator anyscale/anyscale-operator",
+    "--set-string global.cloudDeploymentId=<cloud-deployment-id>",
+    "--set-string global.cloudProvider=aws",
+    "--set-string global.aws.region=${var.aws_region}",
+    "--set-string workloads.serviceAccount.name=anyscale-operator",
+    "--namespace anyscale-operator",
+    "--create-namespace",
+    "-i"
+  ])
+}
+
+output "anyscale_registration_command" {
+  description = "The Anyscale registration command."
+  value       = join(" \\\n\t", local.registration_command_parts)
+}
+
+output "helm_upgrade_command" {
+  description = "The helm upgrade command."
+  value       = join(" \\\n\t", local.helm_upgrade_command_parts)
+}

--- a/examples/aws/eks-public-efa/sample-values_nginx.yaml
+++ b/examples/aws/eks-public-efa/sample-values_nginx.yaml
@@ -1,0 +1,13 @@
+controller:
+  service:
+    type: LoadBalancer
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+      service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+      service.beta.kubernetes.io/aws-load-balancer-type: nlb
+  allowSnippetAnnotations: true
+  config:
+    enable-underscores-in-headers: true
+    annotations-risk-level: "Critical"
+  autoscaling:
+    enabled: true

--- a/examples/aws/eks-public-efa/sample-values_nvdp.yaml
+++ b/examples/aws/eks-public-efa/sample-values_nvdp.yaml
@@ -1,0 +1,18 @@
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        # We allow a GPU deployment to be forced by setting the following label to "true"
+        - key: "nvidia.com/gpu.product"
+          operator: Exists
+tolerations:
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule
+  - key: node.anyscale.com/capacity-type
+    operator: Exists
+    effect: NoSchedule
+  - key: node.anyscale.com/accelerator-type
+    operator: Exists
+    effect: NoSchedule

--- a/examples/aws/eks-public-efa/variables.tf
+++ b/examples/aws/eks-public-efa/variables.tf
@@ -1,0 +1,139 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# ENVIRONMENT VARIABLES
+# Define these secrets as environment variables
+# ---------------------------------------------------------------------------------------------------------------------
+
+# AWS_ACCESS_KEY_ID
+# AWS_SECRET_ACCESS_KEY
+
+# ---------------------------------------------------------------------------------------------------------------------
+# REQUIRED VARIABLES
+# These variables must be set when using this module.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------------------------------------------------
+# OPTIONAL VARIABLES
+# These variables have defaults but must be included when using this module.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "aws_region" {
+  description = <<-EOT
+    (Optional) The AWS region in which all resources will be created.
+
+    ex:
+    ```
+    aws_region = "us-east-2"
+    ```
+  EOT
+  type        = string
+  default     = "us-east-2"
+}
+
+variable "tags" {
+  description = <<-EOT
+    (Optional) A map of tags to all resources that accept tags.
+
+    ex:
+    ```
+    tags = {
+      Environment = "dev"
+      Repo        = "terraform-kubernetes-anyscale-foundation-modules",
+    }
+    ```
+  EOT
+  type        = map(string)
+  default = {
+    Test        = "true"
+    Environment = "dev"
+    Repo        = "terraform-kubernetes-anyscale-foundation-modules",
+    Example     = "aws/eks-public-efa"
+  }
+}
+
+variable "eks_cluster_name" {
+  description = <<-EOT
+    (Optional) The name of the EKS cluster.
+
+    This will be used for naming resources created by this module including the EKS cluster and the S3 bucket.
+
+    ex:
+    ```
+    eks_cluster_name = "anyscale-eks-public-efa"
+    ```
+  EOT
+  type        = string
+  default     = "anyscale-eks-public-efa"
+}
+
+variable "eks_cluster_version" {
+  description = <<-EOT
+    (Optional) The Kubernetes version of the EKS cluster.
+
+    ex:
+    ```
+    eks_cluster_version = "1.32"
+    ```
+  EOT
+  type        = string
+  default     = "1.32"
+}
+
+variable "gpu_instance_types" {
+  description = <<-EOT
+    (Optional) GPU types configuration for the EKS cluster.
+    See gpu_instances.tfvars.example for additional GPU types.
+
+    ex:
+    ```
+    gpu_instance_types = {
+      "T4" = {
+        product_name   = "Tesla-T4"
+        instance_types = ["g4dn.xlarge", "g4dn.2xlarge", "g4dn.4xlarge"]
+      }
+      "A10G" = {
+        product_name   = "NVIDIA-A10G"
+        instance_types = ["g5.4xlarge"]
+      }
+    }
+    ```
+  EOT
+  type = map(object({
+    product_name   = string
+    instance_types = list(string)
+  }))
+  default = {
+    "T4" = {
+      product_name   = "Tesla-T4"
+      instance_types = ["g4dn.4xlarge"]
+    }
+  }
+}
+
+variable "node_group_disk_size" {
+  description = <<-EOT
+    (Optional) The disk size (GB) of the EKS nodes.
+    Possible values: [500, 1000]
+
+    ex:
+    ```
+    node_group_disk_size = 1000
+    ```
+  EOT
+  type        = number
+  default     = 500
+}
+
+variable "enable_efs" {
+  description = <<-EOT
+    (Optional) Enable the creation of an EFS instance.
+
+    This is optional for Anyscale deployments. EFS is used for shared storage between nodes.
+
+    ex:
+    ```
+    enable_efs = true
+    ```
+  EOT
+  type        = bool
+  default     = false
+}

--- a/examples/aws/eks-public-efa/variables_efa.tf
+++ b/examples/aws/eks-public-efa/variables_efa.tf
@@ -1,0 +1,28 @@
+variable "efa_capacity_reservation_id" {
+  description = "(Optional) Targeted EC2 Capacity Reservation ID for the p5.48xlarge EFA node group."
+  type        = string
+  default     = null
+}
+
+variable "efa_capacity_reservation_az_id" {
+  description = "(Optional) Availability Zone ID for the targeted EFA capacity reservation, for example use1-az3."
+  type        = string
+  default     = null
+}
+
+variable "efa_workload_name" {
+  description = "(Optional) Workload name used for the P5/H100 EFA node group name, labels, taints, and Cluster Autoscaler template tags."
+  type        = string
+  default     = "h100-efa"
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]*[a-z0-9]$", var.efa_workload_name))
+    error_message = "efa_workload_name must be lowercase DNS-style text: letters, numbers, hyphens, no leading/trailing hyphen."
+  }
+}
+
+variable "efa_private_subnet_cidr" {
+  description = "(Optional) CIDR block for the private EFA subnet created in the capacity reservation AZ."
+  type        = string
+  default     = "172.24.22.0/24"
+}

--- a/examples/aws/eks-public-efa/versions.tf
+++ b/examples/aws/eks-public-efa/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/modules/aws-efa-nodegroup/README.md
+++ b/modules/aws-efa-nodegroup/README.md
@@ -1,0 +1,202 @@
+# AWS EFA EKS Managed Node Group Module
+
+This module creates the AWS infrastructure required before Kubernetes can expose
+EFA devices to Pods running on `p5.48xlarge` H100 workers.
+
+It is intentionally scoped to the GPU worker node group. It expects an existing
+EKS cluster, VPC, subnet, and worker-node IAM role from an Anyscale/EKS
+foundation module.
+
+## What It Creates
+
+```text
+aws_placement_group strategy=cluster
+EFA security group with self-referencing all ingress/egress
+aws_launch_template with EFA-only network interfaces
+aws_eks_node_group pinned to one subnet/AZ
+```
+
+The default network interface layout is for `p5.48xlarge`:
+
+```text
+network card 0, device 0: interface  (primary ENA/IP)
+network card 0, device 1: efa-only   (RDMA)
+network cards 1-31, device 0: efa-only
+```
+
+That gives one IP-consuming ENA interface for Kubernetes/TCP bootstrap traffic
+and 32 EFA-only interfaces for RDMA payload traffic.
+
+The module intentionally defaults to `p5.48xlarge` and H100 node metadata. The
+caller still controls the workload identity through `workload_name`, which is
+used in generated resource names, Kubernetes labels, default taints, and
+Cluster Autoscaler node-template tags. Override `labels`, `taints`, or
+`enable_cluster_autoscaler_tags` when integrating with a different scheduler
+policy.
+
+## Example
+
+```hcl
+module "h100_efa_nodegroup" {
+  source = "./modules/aws-efa-nodegroup"
+
+  cluster_name  = "my-eks-cluster"
+  vpc_id        = "vpc-0123456789abcdef0"
+  subnet_id     = "subnet-0123456789abcdef0"
+  node_role_arn = "arn:aws:iam::123456789012:role/eks-node-role"
+
+  availability_zone = "us-west-2a"
+  workload_name     = "training"
+  desired_size      = 4
+  min_size          = 0
+  max_size          = 4
+
+  cluster_security_group_ids    = ["sg-eks-control-plane"]
+  additional_security_group_ids = ["sg-existing-anyscale-or-node-sg"]
+
+  tags = {
+    project = "h100-efa"
+  }
+}
+```
+
+For Capacity Blocks:
+
+```hcl
+capacity_type           = "CAPACITY_BLOCK"
+capacity_reservation_id = "cr-0123456789abcdef0"
+subnet_id               = "subnet-in-the-reservation-az"
+```
+
+## Follow-On Kubernetes Layer
+
+After this module is applied, install either the EFA device plugin or EFA DRA
+driver. With the device plugin path, a `p5.48xlarge` node should advertise:
+
+```text
+nvidia.com/gpu: 8
+vpc.amazonaws.com/efa: 32
+```
+
+Pods for this node group should request all node-local devices:
+
+```yaml
+resources:
+  limits:
+    nvidia.com/gpu: 8
+    vpc.amazonaws.com/efa: 32
+```
+
+## Validation
+
+Run in a Terraform-capable environment:
+
+```bash
+terraform fmt -recursive
+terraform init
+terraform validate
+terraform plan
+```
+
+After apply:
+
+```bash
+kubectl get nodes -l efa=true -o wide
+kubectl describe node <node-name> | egrep 'nvidia.com/gpu|vpc.amazonaws.com/efa'
+```
+
+Then run workload-image checks that exercise EFA device discovery, NCCL, and
+any collective communication libraries used by the workload.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0, < 7.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0, < 7.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_autoscaling_group_tag.efa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group_tag) | resource |
+| [aws_eks_node_group.efa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group) | resource |
+| [aws_launch_template.efa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
+| [aws_placement_group.efa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/placement_group) | resource |
+| [aws_security_group.efa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.cluster_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.efa_all_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.efa_self_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.efa_self_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_subnet.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | (Required) Name of the existing EKS cluster. | `string` | n/a | yes |
+| <a name="input_node_role_arn"></a> [node\_role\_arn](#input\_node\_role\_arn) | (Required) IAM role ARN for the EKS managed node group workers. | `string` | n/a | yes |
+| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | (Required) Single subnet ID for the EFA managed node group. Use a private subnet in one Availability Zone. | `string` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | (Required) VPC ID where the EKS worker nodes and EFA security group are created. | `string` | n/a | yes |
+| <a name="input_additional_security_group_ids"></a> [additional\_security\_group\_ids](#input\_additional\_security\_group\_ids) | (Optional) Additional security group IDs attached to every launch-template network interface, such as an existing Anyscale/EKS node security group. | `list(string)` | `[]` | no |
+| <a name="input_allow_all_egress"></a> [allow\_all\_egress](#input\_allow\_all\_egress) | (Optional) Whether to allow outbound IPv4 traffic from the EFA security group. | `bool` | `true` | no |
+| <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | (Optional) Custom AMI ID for the launch template. If set, provide bootstrap-compatible user data outside this module if needed. | `string` | `null` | no |
+| <a name="input_ami_type"></a> [ami\_type](#input\_ami\_type) | (Optional) EKS managed node group AMI type. Ignored when ami\_id is set in the launch template. | `string` | `"AL2023_x86_64_NVIDIA"` | no |
+| <a name="input_availability_zone"></a> [availability\_zone](#input\_availability\_zone) | (Optional) Expected Availability Zone for subnet\_id. When set, the module verifies the subnet is in this AZ. | `string` | `null` | no |
+| <a name="input_capacity_reservation_id"></a> [capacity\_reservation\_id](#input\_capacity\_reservation\_id) | (Optional) Targeted EC2 Capacity Reservation ID. Required when capacity\_type is CAPACITY\_BLOCK; also usable with ON\_DEMAND targeted reservations. | `string` | `null` | no |
+| <a name="input_capacity_type"></a> [capacity\_type](#input\_capacity\_type) | (Optional) EKS managed node group capacity type. | `string` | `"ON_DEMAND"` | no |
+| <a name="input_cluster_security_group_ids"></a> [cluster\_security\_group\_ids](#input\_cluster\_security\_group\_ids) | (Optional) EKS control-plane or cluster security group IDs allowed to initiate traffic to EFA nodes. | `list(string)` | `[]` | no |
+| <a name="input_create_efa_security_group"></a> [create\_efa\_security\_group](#input\_create\_efa\_security\_group) | (Optional) Whether to create the EFA security group. | `bool` | `true` | no |
+| <a name="input_desired_size"></a> [desired\_size](#input\_desired\_size) | (Optional) Desired number of EFA worker nodes. | `number` | `4` | no |
+| <a name="input_efa_interface_count"></a> [efa\_interface\_count](#input\_efa\_interface\_count) | (Optional) Number of EFA-only interfaces to generate when network\_interfaces is not supplied. p5.48xlarge supports 32. | `number` | `32` | no |
+| <a name="input_efa_security_group_id"></a> [efa\_security\_group\_id](#input\_efa\_security\_group\_id) | (Optional) Existing EFA security group ID to use when create\_efa\_security\_group is false. | `string` | `null` | no |
+| <a name="input_efa_security_group_name"></a> [efa\_security\_group\_name](#input\_efa\_security\_group\_name) | (Optional) Name for the EFA security group. | `string` | `null` | no |
+| <a name="input_efa_security_group_name_prefix"></a> [efa\_security\_group\_name\_prefix](#input\_efa\_security\_group\_name\_prefix) | (Optional) Name prefix for the EFA security group. | `string` | `null` | no |
+| <a name="input_enable_cluster_autoscaler_tags"></a> [enable\_cluster\_autoscaler\_tags](#input\_enable\_cluster\_autoscaler\_tags) | (Optional) Whether to add Cluster Autoscaler node-template tags for the P5/H100/EFA labels, taints, and resources. | `bool` | `true` | no |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | (Optional) EFA-capable GPU instance type for the node group. | `string` | `"p5.48xlarge"` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | (Optional) Additional or overriding Kubernetes labels for the managed node group. The module supplies P5/H100/EFA defaults. | `map(string)` | `{}` | no |
+| <a name="input_launch_template_name_prefix"></a> [launch\_template\_name\_prefix](#input\_launch\_template\_name\_prefix) | (Optional) Explicit launch template name prefix. | `string` | `null` | no |
+| <a name="input_max_size"></a> [max\_size](#input\_max\_size) | (Optional) Maximum number of EFA worker nodes. | `number` | `4` | no |
+| <a name="input_min_size"></a> [min\_size](#input\_min\_size) | (Optional) Minimum number of EFA worker nodes. | `number` | `0` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | (Optional) Prefix used for generated resource names. | `string` | `null` | no |
+| <a name="input_network_interfaces"></a> [network\_interfaces](#input\_network\_interfaces) | (Optional) Override launch-template network interface layout.<br/><br/>Leave null for the p5.48xlarge one-IP layout:<br/>card 0 device 0 interface, card 0 device 1 efa-only, cards 1..31 device 0 efa-only. | <pre>list(object({<br/>    network_card_index = number<br/>    device_index       = number<br/>    interface_type     = string<br/>  }))</pre> | `null` | no |
+| <a name="input_node_group_name"></a> [node\_group\_name](#input\_node\_group\_name) | (Optional) Explicit EKS managed node group name. | `string` | `null` | no |
+| <a name="input_placement_group_name"></a> [placement\_group\_name](#input\_placement\_group\_name) | (Optional) Explicit placement group name. Defaults to a name derived from name\_prefix. | `string` | `null` | no |
+| <a name="input_revoke_security_group_rules_on_delete"></a> [revoke\_security\_group\_rules\_on\_delete](#input\_revoke\_security\_group\_rules\_on\_delete) | (Optional) Whether Terraform revokes security group rules before deleting the EFA security group. | `bool` | `false` | no |
+| <a name="input_root_block_device_name"></a> [root\_block\_device\_name](#input\_root\_block\_device\_name) | (Optional) Root block device name for the EKS optimized AMI. | `string` | `"/dev/xvda"` | no |
+| <a name="input_root_volume_encrypted"></a> [root\_volume\_encrypted](#input\_root\_volume\_encrypted) | (Optional) Whether to encrypt the root EBS volume. | `bool` | `true` | no |
+| <a name="input_root_volume_size_gb"></a> [root\_volume\_size\_gb](#input\_root\_volume\_size\_gb) | (Optional) Root EBS volume size in GiB. | `number` | `300` | no |
+| <a name="input_root_volume_type"></a> [root\_volume\_type](#input\_root\_volume\_type) | (Optional) Root EBS volume type. | `string` | `"gp3"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) Tags applied to resources that support tags. | `map(string)` | `{}` | no |
+| <a name="input_taints"></a> [taints](#input\_taints) | (Optional) Kubernetes taints for the managed node group.<br/><br/>Effects must use AWS EKS API values: NO\_SCHEDULE, NO\_EXECUTE, or PREFER\_NO\_SCHEDULE. | <pre>list(object({<br/>    key    = string<br/>    value  = string<br/>    effect = string<br/>  }))</pre> | `null` | no |
+| <a name="input_update_max_unavailable"></a> [update\_max\_unavailable](#input\_update\_max\_unavailable) | (Optional) Maximum unavailable nodes during managed node group updates. | `number` | `1` | no |
+| <a name="input_workload_label_key"></a> [workload\_label\_key](#input\_workload\_label\_key) | (Optional) Kubernetes label and taint key used to isolate this P5/H100 EFA node group. | `string` | `"workload"` | no |
+| <a name="input_workload_name"></a> [workload\_name](#input\_workload\_name) | (Optional) Workload name used in default resource names, Kubernetes labels, taints, and Cluster Autoscaler template tags. | `string` | `"h100-efa"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_efa_security_group_id"></a> [efa\_security\_group\_id](#output\_efa\_security\_group\_id) | Security group ID used by EFA network interfaces. |
+| <a name="output_launch_template_default_version"></a> [launch\_template\_default\_version](#output\_launch\_template\_default\_version) | Default version of the EFA launch template. |
+| <a name="output_launch_template_id"></a> [launch\_template\_id](#output\_launch\_template\_id) | ID of the EFA launch template. |
+| <a name="output_launch_template_latest_version"></a> [launch\_template\_latest\_version](#output\_launch\_template\_latest\_version) | Latest version of the EFA launch template. |
+| <a name="output_network_interfaces"></a> [network\_interfaces](#output\_network\_interfaces) | Network interface layout rendered into the launch template. |
+| <a name="output_node_group_arn"></a> [node\_group\_arn](#output\_node\_group\_arn) | ARN of the EKS managed node group. |
+| <a name="output_node_group_name"></a> [node\_group\_name](#output\_node\_group\_name) | Name of the EKS managed node group. |
+| <a name="output_node_group_status"></a> [node\_group\_status](#output\_node\_group\_status) | Status of the EKS managed node group. |
+| <a name="output_placement_group_name"></a> [placement\_group\_name](#output\_placement\_group\_name) | Name of the cluster placement group. |
+| <a name="output_security_group_ids"></a> [security\_group\_ids](#output\_security\_group\_ids) | Full set of security group IDs attached to launch-template network interfaces. |
+| <a name="output_subnet_availability_zone"></a> [subnet\_availability\_zone](#output\_subnet\_availability\_zone) | Availability Zone of subnet\_id. |
+<!-- END_TF_DOCS -->

--- a/modules/aws-efa-nodegroup/examples/basic/main.tf
+++ b/modules/aws-efa-nodegroup/examples/basic/main.tf
@@ -1,0 +1,37 @@
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 7.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+module "h100_efa_nodegroup" {
+  source = "../.."
+
+  cluster_name  = var.cluster_name
+  vpc_id        = var.vpc_id
+  subnet_id     = var.subnet_id
+  node_role_arn = var.node_role_arn
+
+  availability_zone = var.availability_zone
+
+  desired_size = var.desired_size
+  min_size     = var.min_size
+  max_size     = var.max_size
+
+  cluster_security_group_ids    = var.cluster_security_group_ids
+  additional_security_group_ids = var.additional_security_group_ids
+
+  capacity_type           = var.capacity_type
+  capacity_reservation_id = var.capacity_reservation_id
+
+  tags = var.tags
+}

--- a/modules/aws-efa-nodegroup/examples/basic/outputs.tf
+++ b/modules/aws-efa-nodegroup/examples/basic/outputs.tf
@@ -1,0 +1,19 @@
+output "node_group_name" {
+  description = "EKS managed node group name."
+  value       = module.h100_efa_nodegroup.node_group_name
+}
+
+output "launch_template_id" {
+  description = "EFA launch template ID."
+  value       = module.h100_efa_nodegroup.launch_template_id
+}
+
+output "placement_group_name" {
+  description = "Cluster placement group name."
+  value       = module.h100_efa_nodegroup.placement_group_name
+}
+
+output "efa_security_group_id" {
+  description = "EFA security group ID."
+  value       = module.h100_efa_nodegroup.efa_security_group_id
+}

--- a/modules/aws-efa-nodegroup/examples/basic/variables.tf
+++ b/modules/aws-efa-nodegroup/examples/basic/variables.tf
@@ -1,0 +1,78 @@
+variable "region" {
+  description = "AWS region."
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "Existing EKS cluster name."
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID for the EFA node group."
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "Single private subnet ID in the target Availability Zone."
+  type        = string
+}
+
+variable "availability_zone" {
+  description = "Availability Zone expected for subnet_id."
+  type        = string
+  default     = null
+}
+
+variable "node_role_arn" {
+  description = "IAM role ARN for EKS worker nodes."
+  type        = string
+}
+
+variable "desired_size" {
+  description = "Desired node count."
+  type        = number
+  default     = 4
+}
+
+variable "min_size" {
+  description = "Minimum node count."
+  type        = number
+  default     = 0
+}
+
+variable "max_size" {
+  description = "Maximum node count."
+  type        = number
+  default     = 4
+}
+
+variable "cluster_security_group_ids" {
+  description = "EKS control-plane or cluster security group IDs allowed to reach EFA nodes."
+  type        = list(string)
+  default     = []
+}
+
+variable "additional_security_group_ids" {
+  description = "Additional security groups attached to launch-template network interfaces."
+  type        = list(string)
+  default     = []
+}
+
+variable "capacity_type" {
+  description = "EKS capacity type."
+  type        = string
+  default     = "ON_DEMAND"
+}
+
+variable "capacity_reservation_id" {
+  description = "Capacity Block reservation ID when capacity_type is CAPACITY_BLOCK."
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "Tags applied to resources."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/aws-efa-nodegroup/main.tf
+++ b/modules/aws-efa-nodegroup/main.tf
@@ -1,0 +1,365 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# AWS EKS EFA Managed Node Group
+#
+# This module creates the infrastructure layer required before Kubernetes can expose EFA devices to Pods:
+# a cluster placement group, an EFA-friendly security group, a launch template with EFA-only network interfaces,
+# and an EKS managed node group pinned to one subnet/AZ.
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_subnet" "selected" {
+  id = var.subnet_id
+}
+
+locals {
+  name_prefix = coalesce(var.name_prefix, "${var.cluster_name}-${var.workload_name}-")
+
+  module_tags = {
+    tf_sub_module = "aws-efa-nodegroup"
+  }
+
+  efa_security_group_id = var.create_efa_security_group ? aws_security_group.efa[0].id : var.efa_security_group_id
+
+  security_group_ids = distinct(compact(concat(
+    [local.efa_security_group_id],
+    var.additional_security_group_ids
+  )))
+
+  default_network_interfaces = concat(
+    [
+      {
+        network_card_index = 0
+        device_index       = 0
+        interface_type     = "interface"
+      }
+    ],
+    var.efa_interface_count > 0 ? [
+      {
+        network_card_index = 0
+        device_index       = 1
+        interface_type     = "efa-only"
+      }
+    ] : [],
+    [
+      for index in range(1, var.efa_interface_count) : {
+        network_card_index = index
+        device_index       = 0
+        interface_type     = "efa-only"
+      }
+    ]
+  )
+
+  network_interfaces = var.network_interfaces == null ? local.default_network_interfaces : var.network_interfaces
+
+  h100_node_labels = {
+    (var.workload_label_key)             = var.workload_name
+    "accelerator"                        = "h100"
+    "efa"                                = "true"
+    "nvidia.com/gpu.present"             = "true"
+    "nvidia.com/gpu.product"             = "NVIDIA-H100-80GB-HBM3"
+    "nvidia.com/gpu.count"               = "8"
+    "vpc.amazonaws.com/efa.present"      = "true"
+    "vpc.amazonaws.com/efa.count"        = tostring(var.efa_interface_count)
+    "node.anyscale.com/accelerator-type" = "GPU"
+    "node.anyscale.com/gpu-accelerator"  = "H100"
+    "node.anyscale.com/efa-enabled"      = "true"
+  }
+
+  node_labels = merge(local.h100_node_labels, var.labels)
+
+  default_taints = [
+    {
+      key    = "nvidia.com/gpu"
+      value  = "present"
+      effect = "NO_SCHEDULE"
+    },
+    {
+      key    = "node.anyscale.com/accelerator-type"
+      value  = "GPU"
+      effect = "NO_SCHEDULE"
+    },
+    {
+      key    = var.workload_label_key
+      value  = var.workload_name
+      effect = "NO_SCHEDULE"
+    },
+  ]
+
+  node_taints = var.taints == null ? local.default_taints : var.taints
+
+  cluster_autoscaler_taint_effects = {
+    NO_SCHEDULE        = "NoSchedule"
+    NO_EXECUTE         = "NoExecute"
+    PREFER_NO_SCHEDULE = "PreferNoSchedule"
+  }
+
+  capacity_block_enabled = var.capacity_type == "CAPACITY_BLOCK"
+
+  launch_template_name_prefix = coalesce(var.launch_template_name_prefix, "${local.name_prefix}lt-")
+  node_group_name             = coalesce(var.node_group_name, "${local.name_prefix}nodegroup")
+  placement_group_name        = coalesce(var.placement_group_name, "${local.name_prefix}pg")
+
+  cluster_autoscaler_tags = var.enable_cluster_autoscaler_tags ? merge(
+    {
+      "k8s.io/cluster-autoscaler/enabled"                                            = "true"
+      "k8s.io/cluster-autoscaler/${var.cluster_name}"                                = "owned"
+      "k8s.io/cluster-autoscaler/node-template/label/eks.amazonaws.com/capacityType" = var.capacity_type
+      "k8s.io/cluster-autoscaler/node-template/resources/cpu"                        = "192"
+      "k8s.io/cluster-autoscaler/node-template/resources/memory"                     = "1800Gi"
+      "k8s.io/cluster-autoscaler/node-template/resources/nvidia.com/gpu"             = "8"
+      "k8s.io/cluster-autoscaler/node-template/resources/vpc.amazonaws.com/efa"      = tostring(var.efa_interface_count)
+    },
+    {
+      for key, value in local.node_labels :
+      "k8s.io/cluster-autoscaler/node-template/label/${key}" => value
+    },
+    {
+      for taint in local.node_taints :
+      "k8s.io/cluster-autoscaler/node-template/taint/${taint.key}" => "${taint.value}:${local.cluster_autoscaler_taint_effects[taint.effect]}"
+    }
+  ) : {}
+
+  tags = merge(local.module_tags, local.cluster_autoscaler_tags, var.tags)
+}
+
+resource "aws_placement_group" "efa" {
+  name     = local.placement_group_name
+  strategy = "cluster"
+
+  tags = merge(
+    {
+      Name = local.placement_group_name
+    },
+    local.tags
+  )
+}
+
+resource "aws_security_group" "efa" {
+  count = var.create_efa_security_group ? 1 : 0
+
+  name        = var.efa_security_group_name
+  name_prefix = var.efa_security_group_name == null ? coalesce(var.efa_security_group_name_prefix, "${local.name_prefix}efa-sg-") : null
+  description = "Security group for EKS EFA worker nodes"
+  vpc_id      = var.vpc_id
+
+  revoke_rules_on_delete = var.revoke_security_group_rules_on_delete
+
+  tags = merge(
+    {
+      Name = coalesce(var.efa_security_group_name, "${local.name_prefix}efa-sg")
+    },
+    local.tags
+  )
+}
+
+resource "aws_security_group_rule" "efa_self_ingress" {
+  count = var.create_efa_security_group ? 1 : 0
+
+  security_group_id = aws_security_group.efa[0].id
+  type              = "ingress"
+  self              = true
+  description       = "Allow all node-to-node EFA traffic inside the EFA node group"
+  from_port         = -1
+  to_port           = -1
+  protocol          = "-1"
+}
+
+resource "aws_security_group_rule" "efa_self_egress" {
+  count = var.create_efa_security_group ? 1 : 0
+
+  security_group_id = aws_security_group.efa[0].id
+  type              = "egress"
+  self              = true
+  description       = "Allow all node-to-node EFA traffic inside the EFA node group"
+  from_port         = -1
+  to_port           = -1
+  protocol          = "-1"
+}
+
+resource "aws_security_group_rule" "efa_all_egress" {
+  count = var.create_efa_security_group && var.allow_all_egress ? 1 : 0
+
+  security_group_id = aws_security_group.efa[0].id
+  type              = "egress"
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "Allow outbound control-plane, registry, and package traffic"
+  from_port         = -1
+  to_port           = -1
+  protocol          = "-1"
+}
+
+resource "aws_security_group_rule" "cluster_ingress" {
+  for_each = var.create_efa_security_group ? {
+    for index, security_group_id in var.cluster_security_group_ids : index => security_group_id
+  } : {}
+
+  security_group_id        = aws_security_group.efa[0].id
+  type                     = "ingress"
+  source_security_group_id = each.value
+  description              = "Allow EKS control-plane security group traffic to EFA nodes"
+  from_port                = -1
+  to_port                  = -1
+  protocol                 = "-1"
+}
+
+resource "aws_launch_template" "efa" {
+  name_prefix   = local.launch_template_name_prefix
+  instance_type = var.instance_type
+  image_id      = var.ami_id
+
+  update_default_version = true
+
+  dynamic "instance_market_options" {
+    for_each = local.capacity_block_enabled ? [1] : []
+
+    content {
+      market_type = "capacity-block"
+    }
+  }
+
+  dynamic "capacity_reservation_specification" {
+    for_each = var.capacity_reservation_id != null ? [1] : []
+
+    content {
+      capacity_reservation_target {
+        capacity_reservation_id = var.capacity_reservation_id
+      }
+    }
+  }
+
+  placement {
+    group_name = aws_placement_group.efa.name
+  }
+
+  block_device_mappings {
+    device_name = var.root_block_device_name
+
+    ebs {
+      delete_on_termination = true
+      encrypted             = var.root_volume_encrypted
+      volume_size           = var.root_volume_size_gb
+      volume_type           = var.root_volume_type
+    }
+  }
+
+  dynamic "network_interfaces" {
+    for_each = local.network_interfaces
+
+    content {
+      associate_public_ip_address = false
+      delete_on_termination       = true
+      device_index                = network_interfaces.value.device_index
+      interface_type              = network_interfaces.value.interface_type
+      network_card_index          = network_interfaces.value.network_card_index
+      security_groups             = local.security_group_ids
+    }
+  }
+
+  tag_specifications {
+    resource_type = "instance"
+
+    tags = merge(
+      {
+        Name = local.node_group_name
+      },
+      local.tags
+    )
+  }
+
+  tag_specifications {
+    resource_type = "volume"
+
+    tags = merge(
+      {
+        Name = local.node_group_name
+      },
+      local.tags
+    )
+  }
+
+  tag_specifications {
+    resource_type = "network-interface"
+
+    tags = merge(
+      {
+        Name = local.node_group_name
+      },
+      local.tags
+    )
+  }
+
+  tags = local.tags
+
+  lifecycle {
+    precondition {
+      condition     = var.create_efa_security_group || var.efa_security_group_id != null
+      error_message = "efa_security_group_id is required when create_efa_security_group is false."
+    }
+
+    precondition {
+      condition     = !local.capacity_block_enabled || var.capacity_reservation_id != null
+      error_message = "capacity_reservation_id is required when capacity_type is CAPACITY_BLOCK."
+    }
+  }
+}
+
+resource "aws_eks_node_group" "efa" {
+  cluster_name    = var.cluster_name
+  node_group_name = local.node_group_name
+  node_role_arn   = var.node_role_arn
+  subnet_ids      = [var.subnet_id]
+
+  ami_type      = var.ami_id == null ? var.ami_type : null
+  capacity_type = var.capacity_type
+  labels        = local.node_labels
+
+  launch_template {
+    id      = aws_launch_template.efa.id
+    version = aws_launch_template.efa.default_version
+  }
+
+  scaling_config {
+    desired_size = var.desired_size
+    max_size     = var.max_size
+    min_size     = var.min_size
+  }
+
+  update_config {
+    max_unavailable = var.update_max_unavailable
+  }
+
+  dynamic "taint" {
+    for_each = local.node_taints
+
+    content {
+      key    = taint.value.key
+      value  = taint.value.value
+      effect = taint.value.effect
+    }
+  }
+
+  tags = local.tags
+
+  lifecycle {
+    precondition {
+      condition     = var.availability_zone == null || data.aws_subnet.selected.availability_zone == var.availability_zone
+      error_message = "subnet_id must be in availability_zone when availability_zone is set."
+    }
+
+    precondition {
+      condition     = var.min_size <= var.desired_size && var.desired_size <= var.max_size
+      error_message = "desired_size must be between min_size and max_size."
+    }
+  }
+}
+
+resource "aws_autoscaling_group_tag" "efa" {
+  for_each = local.tags
+
+  autoscaling_group_name = aws_eks_node_group.efa.resources[0].autoscaling_groups[0].name
+
+  tag {
+    key                 = each.key
+    value               = each.value
+    propagate_at_launch = true
+  }
+}

--- a/modules/aws-efa-nodegroup/outputs.tf
+++ b/modules/aws-efa-nodegroup/outputs.tf
@@ -1,0 +1,54 @@
+output "node_group_arn" {
+  description = "ARN of the EKS managed node group."
+  value       = aws_eks_node_group.efa.arn
+}
+
+output "node_group_name" {
+  description = "Name of the EKS managed node group."
+  value       = aws_eks_node_group.efa.node_group_name
+}
+
+output "node_group_status" {
+  description = "Status of the EKS managed node group."
+  value       = aws_eks_node_group.efa.status
+}
+
+output "launch_template_id" {
+  description = "ID of the EFA launch template."
+  value       = aws_launch_template.efa.id
+}
+
+output "launch_template_latest_version" {
+  description = "Latest version of the EFA launch template."
+  value       = aws_launch_template.efa.latest_version
+}
+
+output "launch_template_default_version" {
+  description = "Default version of the EFA launch template."
+  value       = aws_launch_template.efa.default_version
+}
+
+output "placement_group_name" {
+  description = "Name of the cluster placement group."
+  value       = aws_placement_group.efa.name
+}
+
+output "efa_security_group_id" {
+  description = "Security group ID used by EFA network interfaces."
+  value       = local.efa_security_group_id
+}
+
+output "security_group_ids" {
+  description = "Full set of security group IDs attached to launch-template network interfaces."
+  value       = local.security_group_ids
+}
+
+output "subnet_availability_zone" {
+  description = "Availability Zone of subnet_id."
+  value       = data.aws_subnet.selected.availability_zone
+}
+
+output "network_interfaces" {
+  description = "Network interface layout rendered into the launch template."
+  value       = local.network_interfaces
+}

--- a/modules/aws-efa-nodegroup/variables.tf
+++ b/modules/aws-efa-nodegroup/variables.tf
@@ -1,0 +1,275 @@
+# ------------------------------------------------------------------------------
+# REQUIRED PARAMETERS
+# ------------------------------------------------------------------------------
+
+variable "cluster_name" {
+  description = "(Required) Name of the existing EKS cluster."
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "(Required) VPC ID where the EKS worker nodes and EFA security group are created."
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "(Required) Single subnet ID for the EFA managed node group. Use a private subnet in one Availability Zone."
+  type        = string
+}
+
+variable "node_role_arn" {
+  description = "(Required) IAM role ARN for the EKS managed node group workers."
+  type        = string
+}
+
+# ------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+# ------------------------------------------------------------------------------
+
+variable "name_prefix" {
+  description = "(Optional) Prefix used for generated resource names."
+  type        = string
+  default     = null
+}
+
+variable "workload_name" {
+  description = "(Optional) Workload name used in default resource names, Kubernetes labels, taints, and Cluster Autoscaler template tags."
+  type        = string
+  default     = "h100-efa"
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]*[a-z0-9]$", var.workload_name))
+    error_message = "workload_name must be lowercase DNS-style text: letters, numbers, hyphens, no leading/trailing hyphen."
+  }
+}
+
+variable "workload_label_key" {
+  description = "(Optional) Kubernetes label and taint key used to isolate this P5/H100 EFA node group."
+  type        = string
+  default     = "workload"
+}
+
+variable "tags" {
+  description = "(Optional) Tags applied to resources that support tags."
+  type        = map(string)
+  default     = {}
+}
+
+variable "availability_zone" {
+  description = "(Optional) Expected Availability Zone for subnet_id. When set, the module verifies the subnet is in this AZ."
+  type        = string
+  default     = null
+}
+
+variable "instance_type" {
+  description = "(Optional) EFA-capable GPU instance type for the node group."
+  type        = string
+  default     = "p5.48xlarge"
+}
+
+variable "desired_size" {
+  description = "(Optional) Desired number of EFA worker nodes."
+  type        = number
+  default     = 4
+}
+
+variable "min_size" {
+  description = "(Optional) Minimum number of EFA worker nodes."
+  type        = number
+  default     = 0
+}
+
+variable "max_size" {
+  description = "(Optional) Maximum number of EFA worker nodes."
+  type        = number
+  default     = 4
+}
+
+variable "ami_type" {
+  description = "(Optional) EKS managed node group AMI type. Ignored when ami_id is set in the launch template."
+  type        = string
+  default     = "AL2023_x86_64_NVIDIA"
+}
+
+variable "ami_id" {
+  description = "(Optional) Custom AMI ID for the launch template. If set, provide bootstrap-compatible user data outside this module if needed."
+  type        = string
+  default     = null
+}
+
+variable "capacity_type" {
+  description = "(Optional) EKS managed node group capacity type."
+  type        = string
+  default     = "ON_DEMAND"
+
+  validation {
+    condition     = contains(["ON_DEMAND", "SPOT", "CAPACITY_BLOCK"], var.capacity_type)
+    error_message = "capacity_type must be one of ON_DEMAND, SPOT, or CAPACITY_BLOCK."
+  }
+}
+
+variable "capacity_reservation_id" {
+  description = "(Optional) Targeted EC2 Capacity Reservation ID. Required when capacity_type is CAPACITY_BLOCK; also usable with ON_DEMAND targeted reservations."
+  type        = string
+  default     = null
+}
+
+variable "root_volume_size_gb" {
+  description = "(Optional) Root EBS volume size in GiB."
+  type        = number
+  default     = 300
+}
+
+variable "root_volume_type" {
+  description = "(Optional) Root EBS volume type."
+  type        = string
+  default     = "gp3"
+}
+
+variable "root_volume_encrypted" {
+  description = "(Optional) Whether to encrypt the root EBS volume."
+  type        = bool
+  default     = true
+}
+
+variable "root_block_device_name" {
+  description = "(Optional) Root block device name for the EKS optimized AMI."
+  type        = string
+  default     = "/dev/xvda"
+}
+
+variable "labels" {
+  description = "(Optional) Additional or overriding Kubernetes labels for the managed node group. The module supplies P5/H100/EFA defaults."
+  type        = map(string)
+  default     = {}
+}
+
+variable "taints" {
+  description = <<-EOT
+    (Optional) Kubernetes taints for the managed node group.
+
+    Effects must use AWS EKS API values: NO_SCHEDULE, NO_EXECUTE, or PREFER_NO_SCHEDULE.
+  EOT
+  type = list(object({
+    key    = string
+    value  = string
+    effect = string
+  }))
+  default  = null
+  nullable = true
+
+  validation {
+    condition = (
+      var.taints == null ||
+      alltrue([
+        for taint in var.taints :
+        contains(["NO_SCHEDULE", "NO_EXECUTE", "PREFER_NO_SCHEDULE"], taint.effect)
+      ])
+    )
+    error_message = "taints effects must be one of NO_SCHEDULE, NO_EXECUTE, or PREFER_NO_SCHEDULE."
+  }
+}
+
+variable "enable_cluster_autoscaler_tags" {
+  description = "(Optional) Whether to add Cluster Autoscaler node-template tags for the P5/H100/EFA labels, taints, and resources."
+  type        = bool
+  default     = true
+}
+
+variable "update_max_unavailable" {
+  description = "(Optional) Maximum unavailable nodes during managed node group updates."
+  type        = number
+  default     = 1
+}
+
+variable "placement_group_name" {
+  description = "(Optional) Explicit placement group name. Defaults to a name derived from name_prefix."
+  type        = string
+  default     = null
+}
+
+variable "launch_template_name_prefix" {
+  description = "(Optional) Explicit launch template name prefix."
+  type        = string
+  default     = null
+}
+
+variable "node_group_name" {
+  description = "(Optional) Explicit EKS managed node group name."
+  type        = string
+  default     = null
+}
+
+variable "create_efa_security_group" {
+  description = "(Optional) Whether to create the EFA security group."
+  type        = bool
+  default     = true
+}
+
+variable "efa_security_group_id" {
+  description = "(Optional) Existing EFA security group ID to use when create_efa_security_group is false."
+  type        = string
+  default     = null
+}
+
+variable "efa_security_group_name" {
+  description = "(Optional) Name for the EFA security group."
+  type        = string
+  default     = null
+}
+
+variable "efa_security_group_name_prefix" {
+  description = "(Optional) Name prefix for the EFA security group."
+  type        = string
+  default     = null
+}
+
+variable "revoke_security_group_rules_on_delete" {
+  description = "(Optional) Whether Terraform revokes security group rules before deleting the EFA security group."
+  type        = bool
+  default     = false
+}
+
+variable "allow_all_egress" {
+  description = "(Optional) Whether to allow outbound IPv4 traffic from the EFA security group."
+  type        = bool
+  default     = true
+}
+
+variable "cluster_security_group_ids" {
+  description = "(Optional) EKS control-plane or cluster security group IDs allowed to initiate traffic to EFA nodes."
+  type        = list(string)
+  default     = []
+}
+
+variable "additional_security_group_ids" {
+  description = "(Optional) Additional security group IDs attached to every launch-template network interface, such as an existing Anyscale/EKS node security group."
+  type        = list(string)
+  default     = []
+}
+
+variable "efa_interface_count" {
+  description = "(Optional) Number of EFA-only interfaces to generate when network_interfaces is not supplied. p5.48xlarge supports 32."
+  type        = number
+  default     = 32
+
+  validation {
+    condition     = var.efa_interface_count >= 1
+    error_message = "efa_interface_count must be at least 1."
+  }
+}
+
+variable "network_interfaces" {
+  description = <<-EOT
+    (Optional) Override launch-template network interface layout.
+
+    Leave null for the p5.48xlarge one-IP layout:
+    card 0 device 0 interface, card 0 device 1 efa-only, cards 1..31 device 0 efa-only.
+  EOT
+  type = list(object({
+    network_card_index = number
+    device_index       = number
+    interface_type     = string
+  }))
+  default = null
+}

--- a/modules/aws-efa-nodegroup/versions.tf
+++ b/modules/aws-efa-nodegroup/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 7.0"
+    }
+  }
+}


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] pre-commit has been run
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All tests passing
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull Request Type

- [ ] Bugfix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [x] Documentation change
- [ ] Other (please describe):

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

## Summary

This PR adds a reusable AWS EFA EKS managed node group module for P5/H100 workers, plus a public AWS EKS example that wires the module into an Anyscale Kubernetes foundation deployment.

The new `modules/aws-efa-nodegroup` module creates:
- a cluster placement group
- an EFA security group with self-referencing EFA traffic rules
- an EKS launch template with the `p5.48xlarge` EFA network interface layout
- an EKS managed node group scoped to a single subnet/AZ
- optional targeted Capacity Reservation support
- labels, taints, and Cluster Autoscaler node-template tags for GPU/EFA scheduling

The new `examples/aws/eks-public-efa` example extends the existing public EKS path with:
- an EFA private subnet in the requested AZ/AZ ID
- capacity reservation inputs for P5 workers
- the H100/EFA managed node group
- sample Helm values for NVIDIA and EFA device plugin scheduling
- README guidance for Terraform apply, device plugin setup, Anyscale cloud registration, and runtime validation

## Validation

Performed:
- end-to-end development validation created fresh AWS/EKS/Anyscale clouds with the EFA node group, installed the required Kubernetes add-ons/operator, launched a P5 validation workspace, and completed the runtime checks: `quick`, `nccl`, `uccl-ll`, and `uccl-ht`

## Privacy / Public Release Check

The branch was checked for private/local values before push. No real local paths, personal workspace paths, AWS account IDs, Anyscale cloud IDs, capacity reservation IDs, security group IDs, run directories, tfstate files, logs, keys, or secret values are included.

The remaining ID-like values are generic documentation placeholders such as `123456789012`, `cr-0123456789abcdef0`, and `sg-existing-*`.
