### PR TITLE
Add AWS EFA node group module

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The examples folder has a couple common use cases that have been tested. These i
   * [aks-new](https://github.com/anyscale/terraform-kubernetes-anyscale-foundation-modules/tree/main/examples/azure/aks-new_cluster) - Build everything - create a new AKS cluster and connect it to Anyscale
 * Anyscale - AWS & EKS
   * [eks-public](https://github.com/anyscale/terraform-kubernetes-anyscale-foundation-modules/tree/main/examples/aws/eks-public) - Build everything - use a common name for all resources, public networking
+  * [eks-public-efa](https://github.com/anyscale/terraform-kubernetes-anyscale-foundation-modules/tree/main/examples/aws/eks-public-efa) - Build everything - public networking with an additional P5/H100 EFA node group
   * [eks-private](https://github.com/anyscale/terraform-kubernetes-anyscale-foundation-modules/tree/main/examples/aws/eks-private) - Build everything - use a common name for all resources, private networking
 * Anyscale - GCP & GKE
   * [gke-existing_cluster](https://github.com/anyscale/terraform-kubernetes-anyscale-foundation-modules/tree/main/examples/gcp/gke-existing_cluster) - Use an existing GKE cluster, build additional resources such as object storage, service accounts, filestore.

--- a/examples/aws/eks-public-efa/README.md
+++ b/examples/aws/eks-public-efa/README.md
@@ -1,0 +1,257 @@
+[![Terraform Version][badge-terraform]](https://github.com/hashicorp/terraform/releases)
+[![AWS Provider Version][badge-tf-aws]](https://github.com/terraform-providers/terraform-provider-aws/releases)
+
+# Anyscale AWS EKS Example - Public Networking With P5/H100 EFA
+This example creates the resources to run Anyscale on AWS EKS with public networking and an additional `p5.48xlarge` H100 EFA node group.
+
+The content of this module should be used as a starting point and modified to your own security and infrastructure
+requirements.
+
+## Getting Started
+
+### Claude Code Guided Deployment
+
+If you have [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed, you can use the built-in skill to get interactive, step-by-step deployment guidance:
+
+```shell
+claude
+# Then type: /deploy-aws-eks
+```
+
+This will walk you through the full deployment process, check your prerequisites, and help you configure variables. You can also jump to a specific step (e.g., `/deploy-aws-eks nginx` or `/deploy-aws-eks register`).
+
+### Prerequisites
+
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+* [AWS Credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)
+* [kubectl CLI](https://kubernetes.io/docs/tasks/tools/)
+* [helm CLI](https://helm.sh/docs/intro/install/)
+* [Anyscale CLI](https://docs.anyscale.com/reference/quickstart-cli/)
+
+### Creating Anyscale Resources
+
+Steps for deploying Anyscale resources via Terraform:
+
+* Review variables.tf and (optionally) create a `terraform.tfvars` file to override any of the defaults.
+* Review `variables_efa.tf` if you plan to use the P5/H100 EFA node group. For targeted EC2 Capacity Reservations, set both of the following values:
+
+```hcl
+efa_capacity_reservation_id    = "cr-xxxxxxxxxxxxxxxxx"
+efa_capacity_reservation_az_id = "use1-az3"
+```
+
+The AZ ID must match the reservation. AZ names can differ between AWS accounts, while AZ IDs are stable.
+* Apply the terraform
+
+```shell
+terraform init
+terraform plan
+terraform apply
+```
+
+If you are using a `tfvars` file, you will need to update the above commands accordingly.
+Note the output from Terraform which includes an example cloud registration command you will use below.
+
+### Install the Kubernetes Requirements
+
+The Anyscale Operator requires the following components:
+* [Cluster autoscaler](https://github.com/kubernetes/autoscaler/tree/master/charts/cluster-autoscaler)
+* [AWS LBC (Load Balancer controller)](https://github.com/kubernetes-sigs/aws-load-balancer-controller/tree/main/helm/aws-load-balancer-controller)
+* [Nginx Ingress Controller](https://kubernetes.github.io/ingress-nginx/deploy/) (other ingress controllers may be possible but are untested)
+* (Optional) [Nvidia device plugin](https://github.com/NVIDIA/k8s-device-plugin/tree/main?tab=readme-ov-file#deployment-via-helm) (required if utilizing GPU nodes)
+* (Optional) [AWS EFA Kubernetes device plugin](https://github.com/aws/eks-charts/tree/master/stable/aws-efa-k8s-device-plugin) or EFA DRA driver (required if Pods request EFA devices)
+
+**Note:** Ensure that you are [authenticated to the EKS cluster](https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html) for the remaining steps.
+
+#### Install the Cluster autoscaler
+
+1. Run the following to install the Kubernetes Autoscaler helm chart:
+
+```shell
+helm repo add autoscaler https://kubernetes.github.io/autoscaler
+helm upgrade cluster-autoscaler autoscaler/cluster-autoscaler \
+  --version 9.46.0 \
+  --namespace kube-system \
+  --set awsRegion=<aws_region> \
+  --set 'autoDiscovery.clusterName'=<eks_cluster_name> \
+  --install
+```
+
+#### Install the AWS LBC (load balancer controller)
+1. Run the following to install the AWS Load Balancer Controller helm chart:
+
+```shell
+helm repo add eks https://aws.github.io/eks-charts
+helm upgrade aws-load-balancer-controller eks/aws-load-balancer-controller \
+  --version 1.13.2 \
+  --namespace kube-system \
+  --set clusterName=<eks_cluster_name> \
+  --install
+```
+
+#### Install the Nginx ingress controller
+
+A sample file, `sample-values_nginx.yaml` has been provided in this repo. Please review for your requirements before using.
+
+Run:
+
+```shell
+helm repo add nginx https://kubernetes.github.io/ingress-nginx
+helm upgrade ingress-nginx nginx/ingress-nginx \
+  --version 4.12.1 \
+  --namespace ingress-nginx \
+  --values sample-values_nginx.yaml \
+  --create-namespace \
+  --install
+```
+
+#### (Optional) Install the Nvidia device plugin
+
+A sample file, `sample-values_nvdp.yaml` has been provided in this repo. Please review for your requirements before using.
+
+1. Create a YAML values file named: `values_nvdp.yaml`
+2. Update the content with the following:
+
+```yaml
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        # We allow a GPU deployment to be forced by setting the following label to "true"
+        - key: "nvidia.com/gpu.product"
+          operator: Exists
+tolerations:
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule
+  - key: node.anyscale.com/capacity-type
+    operator: Exists
+    effect: NoSchedule
+  - key: node.anyscale.com/accelerator-type
+    operator: Exists
+    effect: NoSchedule
+```
+
+3. Run:
+
+```shell
+helm repo add nvdp https://nvidia.github.io/k8s-device-plugin
+helm upgrade nvdp nvdp/nvidia-device-plugin \
+  --namespace nvidia-device-plugin \
+  --version 0.17.1 \
+  --values values_nvdp.yaml \
+  --create-namespace \
+  --install
+```
+
+### Register the Anyscale Cloud
+
+Ensure that you are logged into Anyscale with valid CLI credentials. (`anyscale login`)
+
+1. Using the output from the Terraform modules, register the Anyscale Cloud. It should look sonething like:
+
+```shell
+anyscale cloud register --provider aws \
+  --name my_kubernetes_cloud \
+  --compute-stack k8s \
+  --region us-east-2 \
+  --s3-bucket-id anyscale_example_bucket \
+  --efs-id fs-abcdefgh01234567 \
+  --kubernetes-zones us-east-2a,us-east-2b,us-east-2c \
+  --anyscale-operator-iam-identity arn:aws:iam::123456789012:role/my-kubernetes-cloud-node-group-role
+```
+**Please note:** You must change the cloud name to a name that you choose. You will not be able to register a cloud with a name of `<CUSTOMER_DEFINED_NAME>`.
+
+2. Note the Cloud Deployment ID which will be used in the next step. The Anyscale CLI will return it as one of the outputs. Example:
+```shell
+Output
+(anyscale +22.5s) For registering this cloud's Kubernetes Manager, use cloud deployment ID '<cloud-deployment-id>'.
+```
+
+### Install the Anyscale Operator
+
+1. Using the below example, replace `<aws_region>` with the AWS region where EKS is running, and replace `<cloud-deployment-id>` with the appropriate value from the `anyscale cloud register` output. Please note that you can also change the namespace to one that you wish to associate with Anyscale pods.
+2. Using your updated helm upgrade command, install the Anyscale Operator.
+
+```shell
+helm repo add anyscale https://anyscale.github.io/helm-charts
+helm upgrade anyscale-operator anyscale/anyscale-operator \
+  --set-string global.cloudDeploymentId=<cloud-deployment-id> \
+  --set-string global.cloudProvider=aws \
+  --set-string global.aws.region=<aws_region> \
+  --set-string workloads.serviceAccount.name=anyscale-operator \
+  --namespace anyscale-operator \
+  --create-namespace \
+  --install
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_anyscale_efs"></a> [anyscale\_efs](#module\_anyscale\_efs) | github.com/anyscale/terraform-aws-anyscale-cloudfoundation-modules//modules/aws-anyscale-efs | n/a |
+| <a name="module_anyscale_iam_roles"></a> [anyscale\_iam\_roles](#module\_anyscale\_iam\_roles) | github.com/anyscale/terraform-aws-anyscale-cloudfoundation-modules//modules/aws-anyscale-iam | n/a |
+| <a name="module_anyscale_s3"></a> [anyscale\_s3](#module\_anyscale\_s3) | github.com/anyscale/terraform-aws-anyscale-cloudfoundation-modules//modules/aws-anyscale-s3 | n/a |
+| <a name="module_anyscale_vpc"></a> [anyscale\_vpc](#module\_anyscale\_vpc) | github.com/anyscale/terraform-aws-anyscale-cloudfoundation-modules//modules/aws-anyscale-vpc | n/a |
+| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 20.33.1 |
+| <a name="module_h100_efa_nodegroup"></a> [h100\_efa\_nodegroup](#module\_h100\_efa\_nodegroup) | ../../../modules/aws-efa-nodegroup | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_policy.autoscaler_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.elb_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_route_table_association.efa_private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
+| [aws_security_group.allow_all_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_subnet.efa_private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_iam_role.default_nodegroup](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | (Optional) The AWS region in which all resources will be created.<br/><br/>ex:<pre>aws_region = "us-east-2"</pre> | `string` | `"us-east-2"` | no |
+| <a name="input_efa_capacity_reservation_az_id"></a> [efa\_capacity\_reservation\_az\_id](#input\_efa\_capacity\_reservation\_az\_id) | (Optional) Availability Zone ID for the targeted EFA capacity reservation, for example use1-az3. | `string` | `null` | no |
+| <a name="input_efa_capacity_reservation_id"></a> [efa\_capacity\_reservation\_id](#input\_efa\_capacity\_reservation\_id) | (Optional) Targeted EC2 Capacity Reservation ID for the p5.48xlarge EFA node group. | `string` | `null` | no |
+| <a name="input_efa_private_subnet_cidr"></a> [efa\_private\_subnet\_cidr](#input\_efa\_private\_subnet\_cidr) | (Optional) CIDR block for the private EFA subnet created in the capacity reservation AZ. | `string` | `"172.24.22.0/24"` | no |
+| <a name="input_efa_workload_name"></a> [efa\_workload\_name](#input\_efa\_workload\_name) | (Optional) Workload name used for the P5/H100 EFA node group name, labels, taints, and Cluster Autoscaler template tags. | `string` | `"h100-efa"` | no |
+| <a name="input_eks_cluster_name"></a> [eks\_cluster\_name](#input\_eks\_cluster\_name) | (Optional) The name of the EKS cluster.<br/><br/>This will be used for naming resources created by this module including the EKS cluster and the S3 bucket.<br/><br/>ex:<pre>eks_cluster_name = "anyscale-eks-public-efa"</pre> | `string` | `"anyscale-eks-public-efa"` | no |
+| <a name="input_eks_cluster_version"></a> [eks\_cluster\_version](#input\_eks\_cluster\_version) | (Optional) The Kubernetes version of the EKS cluster.<br/><br/>ex:<pre>eks_cluster_version = "1.32"</pre> | `string` | `"1.32"` | no |
+| <a name="input_enable_efs"></a> [enable\_efs](#input\_enable\_efs) | (Optional) Enable the creation of an EFS instance.<br/><br/>This is optional for Anyscale deployments. EFS is used for shared storage between nodes.<br/><br/>ex:<pre>enable_efs = true</pre> | `bool` | `false` | no |
+| <a name="input_gpu_instance_types"></a> [gpu\_instance\_types](#input\_gpu\_instance\_types) | (Optional) GPU types configuration for the EKS cluster.<br/>See gpu\_instances.tfvars.example for additional GPU types.<br/><br/>ex:<pre>gpu_instance_types = {<br/>  "T4" = {<br/>    product_name   = "Tesla-T4"<br/>    instance_types = ["g4dn.xlarge", "g4dn.2xlarge", "g4dn.4xlarge"]<br/>  }<br/>  "A10G" = {<br/>    product_name   = "NVIDIA-A10G"<br/>    instance_types = ["g5.4xlarge"]<br/>  }<br/>}</pre> | <pre>map(object({<br/>    product_name   = string<br/>    instance_types = list(string)<br/>  }))</pre> | <pre>{<br/>  "T4": {<br/>    "instance_types": [<br/>      "g4dn.4xlarge"<br/>    ],<br/>    "product_name": "Tesla-T4"<br/>  }<br/>}</pre> | no |
+| <a name="input_node_group_disk_size"></a> [node\_group\_disk\_size](#input\_node\_group\_disk\_size) | (Optional) The disk size (GB) of the EKS nodes.<br/>Possible values: [500, 1000]<br/><br/>ex:<pre>node_group_disk_size = 1000</pre> | `number` | `500` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to all resources that accept tags.<br/><br/>ex:<pre>tags = {<br/>  Environment = "dev"<br/>  Repo        = "terraform-kubernetes-anyscale-foundation-modules",<br/>}</pre> | `map(string)` | <pre>{<br/>  "Environment": "dev",<br/>  "Example": "aws/eks-public-efa",<br/>  "Repo": "terraform-kubernetes-anyscale-foundation-modules",<br/>  "Test": "true"<br/>}</pre> | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_anyscale_registration_command"></a> [anyscale\_registration\_command](#output\_anyscale\_registration\_command) | The Anyscale registration command. |
+| <a name="output_aws_region"></a> [aws\_region](#output\_aws\_region) | The AWS region. This is used for Helm chart values. |
+| <a name="output_eks_cluster_name"></a> [eks\_cluster\_name](#output\_eks\_cluster\_name) | The name of the EKS cluster. This is used for Helm chart values. |
+| <a name="output_helm_upgrade_command"></a> [helm\_upgrade\_command](#output\_helm\_upgrade\_command) | The helm upgrade command. |
+<!-- END_TF_DOCS -->
+
+<!-- References -->
+[Terraform]: https://www.terraform.io
+[Issues]: https://github.com/anyscale/terraform-kubernetes-anyscale-foundation-modules/issues
+<!-- [badge-build]: https://github.com/anyscale/terraform-kubernetes-anyscale-foundation-modules/workflows/CI/CD%20Pipeline/badge.svg -->
+[badge-terraform]: https://img.shields.io/badge/terraform-1.x%20-623CE4.svg?logo=terraform
+[badge-tf-aws]: https://img.shields.io/badge/AWS-5.+-F8991D.svg?logo=terraform
+[build-status]: https://github.com/anyscale/terraform-kubernetes-anyscale-foundation-modules/actions

--- a/examples/aws/eks-public-efa/README.md
+++ b/examples/aws/eks-public-efa/README.md
@@ -186,6 +186,63 @@ helm upgrade anyscale-operator anyscale/anyscale-operator \
   --install
 ```
 
+### Create an EFA Runtime Workspace
+
+The sample Anyscale resource files in this example use the following EFA/UCCL
+runtime image:
+
+```text
+anyscale/image/anyscale-ray-2.55.1-cu128-torch2.8-efa-uccl:1
+```
+
+If the image is not already registered in your Anyscale organization, register
+the external image first:
+
+```shell
+anyscale image register \
+  --name anyscale-ray-2.55.1-cu128-torch2.8-efa-uccl \
+  --image-uri <external_registry_image_uri> \
+  --ray-version 2.55.1
+```
+
+You can confirm the registered image before launching a workload:
+
+```shell
+anyscale image get \
+  --name anyscale-ray-2.55.1-cu128-torch2.8-efa-uccl:1
+```
+
+Create a compute config from `sample-compute-config_efa.yaml` after replacing
+`<anyscale_cloud_name>`, `<efa_node_availability_zone>`, `<min_p5_workers>`,
+and `<max_p5_workers>`:
+
+```shell
+anyscale compute-config create \
+  --name <compute_config_name> \
+  --config-file sample-compute-config_efa.yaml
+```
+
+Then create a workspace from `sample-workspace_efa.yaml` after replacing
+`<workspace_name>`, `<anyscale_cloud_name>`, and `<compute_config_name>`:
+
+```shell
+anyscale workspace_v2 create \
+  --config-file sample-workspace_efa.yaml
+```
+
+The compute config requests one `p5.48xlarge` worker shape with 8 H100 GPUs and
+32 EFA devices per worker pod. The workspace pins the EFA/UCCL runtime image so
+that users can validate NCCL, UCCL, or Wide-EP workloads on the EFA node group
+created by this example.
+
+Set the worker count placeholders for the workload you plan to run. For a
+fixed-size two-node validation, set both `min_nodes` and `max_nodes` to `2`.
+For an eight-node workload, set both to `8`. For autoscaling, set `min_nodes`
+to the warm baseline and `max_nodes` to the largest allowed scale-out. The
+Terraform EFA node group limit, `efa_node_group_max_size`, must be at least as
+large as the compute config `max_nodes`, and the selected capacity reservation
+or AZ must have enough `p5.48xlarge` capacity.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -229,6 +286,9 @@ helm upgrade anyscale-operator anyscale/anyscale-operator \
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | (Optional) The AWS region in which all resources will be created.<br/><br/>ex:<pre>aws_region = "us-east-2"</pre> | `string` | `"us-east-2"` | no |
 | <a name="input_efa_capacity_reservation_az_id"></a> [efa\_capacity\_reservation\_az\_id](#input\_efa\_capacity\_reservation\_az\_id) | (Optional) Availability Zone ID for the targeted EFA capacity reservation, for example use1-az3. | `string` | `null` | no |
 | <a name="input_efa_capacity_reservation_id"></a> [efa\_capacity\_reservation\_id](#input\_efa\_capacity\_reservation\_id) | (Optional) Targeted EC2 Capacity Reservation ID for the p5.48xlarge EFA node group. | `string` | `null` | no |
+| <a name="input_efa_node_group_desired_size"></a> [efa\_node\_group\_desired\_size](#input\_efa\_node\_group\_desired\_size) | (Optional) Desired number of P5/H100 EFA worker nodes in the EKS managed node group. | `number` | `0` | no |
+| <a name="input_efa_node_group_max_size"></a> [efa\_node\_group\_max\_size](#input\_efa\_node\_group\_max\_size) | (Optional) Maximum number of P5/H100 EFA worker nodes in the EKS managed node group. Set this at least as high as the largest Anyscale compute config max_nodes value you plan to run. | `number` | `4` | no |
+| <a name="input_efa_node_group_min_size"></a> [efa\_node\_group\_min\_size](#input\_efa\_node\_group\_min\_size) | (Optional) Minimum number of P5/H100 EFA worker nodes in the EKS managed node group. | `number` | `0` | no |
 | <a name="input_efa_private_subnet_cidr"></a> [efa\_private\_subnet\_cidr](#input\_efa\_private\_subnet\_cidr) | (Optional) CIDR block for the private EFA subnet created in the capacity reservation AZ. | `string` | `"172.24.22.0/24"` | no |
 | <a name="input_efa_workload_name"></a> [efa\_workload\_name](#input\_efa\_workload\_name) | (Optional) Workload name used for the P5/H100 EFA node group name, labels, taints, and Cluster Autoscaler template tags. | `string` | `"h100-efa"` | no |
 | <a name="input_eks_cluster_name"></a> [eks\_cluster\_name](#input\_eks\_cluster\_name) | (Optional) The name of the EKS cluster.<br/><br/>This will be used for naming resources created by this module including the EKS cluster and the S3 bucket.<br/><br/>ex:<pre>eks_cluster_name = "anyscale-eks-public-efa"</pre> | `string` | `"anyscale-eks-public-efa"` | no |

--- a/examples/aws/eks-public-efa/README.md
+++ b/examples/aws/eks-public-efa/README.md
@@ -230,10 +230,10 @@ anyscale workspace_v2 create \
   --config-file sample-workspace_efa.yaml
 ```
 
-The compute config requests one `p5.48xlarge` worker shape with 8 H100 GPUs and
-32 EFA devices per worker pod. The workspace pins the EFA/UCCL runtime image so
-that users can validate NCCL, UCCL, or Wide-EP workloads on the EFA node group
-created by this example.
+The compute config uses a `16CPU-64GB` CPU head node and requests one
+`p5.48xlarge` worker shape with 8 H100 GPUs and 32 EFA devices per worker pod.
+The workspace pins the EFA/UCCL runtime image so that users can validate NCCL,
+UCCL, or Wide-EP workloads on the EFA node group created by this example.
 
 Set the worker count placeholders for the workload you plan to run. For a
 fixed-size two-node validation, set both `min_nodes` and `max_nodes` to `2`.

--- a/examples/aws/eks-public-efa/README.md
+++ b/examples/aws/eks-public-efa/README.md
@@ -188,29 +188,34 @@ helm upgrade anyscale-operator anyscale/anyscale-operator \
 
 ### Create an EFA Runtime Workspace
 
-The sample Anyscale resource files in this example use the following EFA/UCCL
-runtime image:
+The `docker/` directory is a self-contained EFA/UCCL image build context. It
+installs the EFA userspace stack, the AWS OFI NCCL plugin, UCCL/UCCL-EP, and
+post-start validation tools. Build and push it to a registry that the EKS
+nodes can pull from:
 
-```text
-anyscale/image/anyscale-ray-2.55.1-cu128-torch2.8-efa-uccl:1
+```shell
+cd docker
+
+export IMAGE_URI=<registry>/anyscale-ray-2.55.1-cu128-torch2.8-efa-uccl:1
+docker build \
+  -f Dockerfile.anyscale-ray-2.55.1-cu128-efa-uccl \
+  -t "$IMAGE_URI" \
+  .
+docker push "$IMAGE_URI"
 ```
 
-If the image is not already registered in your Anyscale organization, register
-the external image first:
+Register the pushed image with Anyscale before creating the workspace:
 
 ```shell
 anyscale image register \
   --name anyscale-ray-2.55.1-cu128-torch2.8-efa-uccl \
-  --image-uri <external_registry_image_uri> \
+  --image-uri "$IMAGE_URI" \
   --ray-version 2.55.1
 ```
 
-You can confirm the registered image before launching a workload:
-
-```shell
-anyscale image get \
-  --name anyscale-ray-2.55.1-cu128-torch2.8-efa-uccl:1
-```
+See [`docker/README.md`](docker/README.md) for build arguments, local smoke
+checks, and the multi-node EFA/NCCL/UCCL validation entrypoints baked into the
+image.
 
 Create a compute config from `sample-compute-config_efa.yaml` after replacing
 `<anyscale_cloud_name>`, `<efa_node_availability_zone>`, `<min_p5_workers>`,

--- a/examples/aws/eks-public-efa/docker/.dockerignore
+++ b/examples/aws/eks-public-efa/docker/.dockerignore
@@ -1,0 +1,5 @@
+.DS_Store
+.git
+.gitignore
+README.md
+examples/

--- a/examples/aws/eks-public-efa/docker/Dockerfile.anyscale-ray-2.55.1-cu128-efa-uccl
+++ b/examples/aws/eks-public-efa/docker/Dockerfile.anyscale-ray-2.55.1-cu128-efa-uccl
@@ -1,0 +1,182 @@
+FROM anyscale/ray:2.55.1-slim-py312-cu128
+
+USER root
+
+ARG EFA_INSTALLER_VERSION=1.43.2
+ARG AWS_OFI_NCCL_VERSION=1.19.2
+ARG AWS_OFI_NCCL_SHA512=ec578da632166fd7f885dbc8cfa3f07be19a056276a2bd82a6868fe78160f2df07338068ef1bf5367fd3e81d9b06016fc546e3ea673566ed787e3be49438bf80
+ARG UCCL_URL=https://github.com/uccl-project/uccl.git
+ARG UCCL_REF=v0.1.1
+ARG RAY_ALL_REDUCE_BENCH_URL=https://gist.githubusercontent.com/SumanthRH/d92ca3f690ece64d407423073a169fdf/raw/3b062b14ba597730855c0f14a306001cb2ed7a0e/all_reduce_bench.py
+ARG TORCH_VERSION=2.8.0
+ARG TORCH_INDEX_URL=https://download.pytorch.org/whl/cu128
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV EFA_HOME=/opt/amazon/efa
+ENV OFI_NCCL_HOME=/opt/amazon/ofi-nccl
+ENV CUDA_HOME=/usr/local/cuda
+ENV TORCH_CUDA_ARCH_LIST=9.0
+ENV PER_EXPERT_BATCHING=1
+ENV USE_DMABUF=1
+ENV MAX_JOBS=16
+ENV CPATH=/opt/amazon/efa/include:${CPATH}
+ENV LIBRARY_PATH=/opt/amazon/efa/lib:${LIBRARY_PATH}
+ENV PKG_CONFIG_PATH=/opt/amazon/efa/lib/pkgconfig:${PKG_CONFIG_PATH}
+
+RUN /bin/bash -lc "set -euo pipefail; \
+  apt-get update; \
+  apt-get install -y --no-install-recommends \
+    autoconf \
+    automake \
+    bash \
+    build-essential \
+    ca-certificates \
+    cuda-nvcc-12-8 \
+    cmake \
+    curl \
+    git \
+    ibverbs-utils \
+    iproute2 \
+    kmod \
+    libc6-dev \
+    libhwloc-dev \
+    libibverbs-dev \
+    libtool \
+    libnl-3-dev \
+    libnl-route-3-dev \
+    libnuma-dev \
+    librdmacm-dev \
+    net-tools \
+    ninja-build \
+    numactl \
+    openssh-client \
+    pciutils \
+    pkg-config \
+    rdma-core \
+    wget; \
+  if [ -x /usr/local/cuda-12.8/bin/nvcc ] && [ ! -x /usr/local/cuda/bin/nvcc ]; then \
+    ln -sfn /usr/local/cuda-12.8 /usr/local/cuda; \
+  fi; \
+  /usr/local/cuda/bin/nvcc --version; \
+  rm -rf /var/lib/apt/lists/*"
+
+# Install AWS EFA userspace only. Kernel modules and /dev/infiniband come from
+# the host/EKS node, so --skip-kmod is intentional for a container image.
+RUN /bin/bash -lc "set -euo pipefail; \
+  apt-get update; \
+  cd /tmp; \
+  curl -fsSLO https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz; \
+  tar -xf aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz; \
+  cd aws-efa-installer; \
+  ./efa_installer.sh -y --skip-kmod -g --no-verify; \
+  rm -rf /tmp/aws-efa-installer /tmp/aws-efa-installer-*.tar.gz /var/lib/apt/lists/*"
+
+# Install the AWS OFI NCCL network plugin. Without this libnccl-net.so, NCCL
+# falls back to sockets and EFA all-reduce bandwidth is extremely low.
+RUN /bin/bash -lc "set -euo pipefail; \
+  cd /tmp; \
+  curl -fsSLO https://github.com/aws/aws-ofi-nccl/releases/download/v${AWS_OFI_NCCL_VERSION}/aws-ofi-nccl-${AWS_OFI_NCCL_VERSION}.tar.gz; \
+  echo \"${AWS_OFI_NCCL_SHA512}  aws-ofi-nccl-${AWS_OFI_NCCL_VERSION}.tar.gz\" | sha512sum -c -; \
+  tar -xf aws-ofi-nccl-${AWS_OFI_NCCL_VERSION}.tar.gz; \
+  cd aws-ofi-nccl-${AWS_OFI_NCCL_VERSION}; \
+  ./configure \
+    --prefix=${OFI_NCCL_HOME} \
+    --libdir=${OFI_NCCL_HOME}/lib \
+    --with-libfabric=${EFA_HOME} \
+    --with-cuda=${CUDA_HOME} \
+    --enable-platform-aws \
+    --disable-tests; \
+  make -j\"$(nproc)\"; \
+  make install; \
+  test -f ${OFI_NCCL_HOME}/lib/libnccl-net.so; \
+  rm -rf /tmp/aws-ofi-nccl-${AWS_OFI_NCCL_VERSION} /tmp/aws-ofi-nccl-${AWS_OFI_NCCL_VERSION}.tar.gz"
+
+RUN /bin/bash -lc "set -euo pipefail; \
+  python -m pip install --no-cache-dir --upgrade pip setuptools wheel; \
+  python -m pip install --no-cache-dir \
+    intervaltree \
+    nanobind \
+    packaging \
+    sortedcontainers; \
+  if python -c 'import torch, sys; sys.exit(0 if torch.version.cuda else 1)' >/dev/null 2>&1; then \
+    python -c 'import torch; print(\"Using existing CUDA torch\", torch.__version__, torch.version.cuda)'; \
+  else \
+    python -m pip install --no-cache-dir --force-reinstall --index-url ${TORCH_INDEX_URL} torch==${TORCH_VERSION}; \
+  fi; \
+  python -c 'import torch; print(\"torch\", torch.__version__, \"cuda\", torch.version.cuda)'; \
+  chmod a+rx /home/ray/anaconda3/bin/pip /home/ray/anaconda3/bin/pip3 || true"
+
+# Build/install UCCL and UCCL-EP with EFA + DMA-BUF support.
+RUN /bin/bash -lc "set -euo pipefail; \
+  git clone ${UCCL_URL} /opt/uccl; \
+  cd /opt/uccl; \
+  git checkout ${UCCL_REF}; \
+  TORCH_LIB=/home/ray/anaconda3/lib/python3.12/site-packages/torch/lib; \
+  export LD_LIBRARY_PATH=${EFA_HOME}/lib:${OFI_NCCL_HOME}/lib:\${TORCH_LIB}:${CUDA_HOME}/lib64:\${LD_LIBRARY_PATH:-}; \
+  python -c 'import torch; print(\"Building UCCL-EP with torch\", torch.__version__, \"cuda\", torch.version.cuda)'; \
+  python -m pip install --no-cache-dir /opt/uccl; \
+  rm -rf /tmp/uccl_ep_build; \
+  cp -a /opt/uccl /tmp/uccl_ep_build; \
+  cd /tmp/uccl_ep_build/ep; \
+  python setup.py install; \
+  python -c 'import uccl.ep; print(\"uccl.ep import ok\", uccl.ep)'; \
+  cd /tmp/uccl_ep_build/ep/deep_ep_wrapper; \
+  for name in buffer.py test_internode.py utils.py; do \
+    rm -f deep_ep/\${name}; \
+    cp ../bench/\${name} deep_ep/\${name}; \
+  done; \
+  python -m pip install --no-cache-dir --no-build-isolation .; \
+  rm -rf /tmp/uccl_ep_build"
+
+COPY env/ /opt/efa-middle/env/
+COPY scripts/ /opt/efa-middle/scripts/
+COPY detect_compute_nodes.py /opt/efa-middle/scripts/detect_compute_nodes.py
+
+RUN /bin/bash -lc "set -euo pipefail; \
+  mkdir -p /opt/efa-middle/bench; \
+  curl -fsSL \"${RAY_ALL_REDUCE_BENCH_URL}\" -o /opt/efa-middle/bench/all_reduce_bench.py"
+
+RUN /bin/bash -lc 'set -euo pipefail; \
+  chmod +x /opt/efa-middle/env/aws_efa_uccl_env.sh; \
+  chmod +x /opt/efa-middle/scripts/*.sh /opt/efa-middle/scripts/*.py; \
+  chmod a+r /opt/efa-middle/bench/all_reduce_bench.py; \
+  ln -sf /opt/efa-middle/scripts/detect_compute_nodes.py /opt/efa-middle/scripts/detect_compute_nodes; \
+  ln -sf /opt/efa-middle/scripts/validate_compute_nodes.sh /opt/efa-middle/scripts/validate_compute_nodes'
+
+ENV PATH=/opt/efa-middle/scripts:/usr/local/cuda/bin:/opt/amazon/efa/bin:${PATH}
+ENV LD_LIBRARY_PATH=/opt/amazon/efa/lib:/opt/amazon/ofi-nccl/lib:/home/ray/anaconda3/lib/python3.12/site-packages/torch/lib:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}
+ENV FI_PROVIDER=efa
+ENV FI_EFA_USE_DEVICE_RDMA=1
+ENV NCCL_NET_PLUGIN=libnccl-net.so
+ENV NCCL_SOCKET_IFNAME=eth0
+ENV GLOO_SOCKET_IFNAME=eth0
+ENV UCCL_SOCKET_IFNAME=eth0
+ENV CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+ENV OMP_NUM_THREADS=8
+ENV PYTHONUNBUFFERED=1
+ENV NCCL_DEBUG=WARN
+ENV NCCL_DEBUG_SUBSYS=INIT,NET
+
+WORKDIR /workspace
+
+RUN /bin/bash -lc 'set -euo pipefail; \
+  ray_group="$(id -gn ray 2>/dev/null || echo ray)"; \
+  chown -Rh ray:"${ray_group}" /home/ray/anaconda3/bin; \
+  chmod u+rwx,go+rx /home /home/ray /home/ray/anaconda3 /home/ray/anaconda3/bin; \
+  find /home/ray/anaconda3/bin -maxdepth 1 \( -name "pip*" -o -name "python*" \) -exec chmod u+rwx,go+rx {} +; \
+  for exe in /home/ray/anaconda3/bin/pip /home/ray/anaconda3/bin/pip3 /home/ray/anaconda3/bin/pip3.12 /home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/python3 /home/ray/anaconda3/bin/python3.12; do \
+    if [ -e "$exe" ] || [ -L "$exe" ]; then \
+      chown -h ray:"${ray_group}" "$exe" || true; \
+      chmod u+rwx,go+rx "$exe" || true; \
+      target="$(readlink -f "$exe" 2>/dev/null || true)"; \
+      if [ -n "$target" ] && [ -e "$target" ]; then \
+        chown ray:"${ray_group}" "$target" || true; \
+        chmod u+rwx,go+rx "$target" || true; \
+      fi; \
+    fi; \
+  done; \
+  su -s /bin/bash ray -c "/home/ray/anaconda3/bin/python -m pip --version"; \
+  su -s /bin/bash ray -c "/home/ray/anaconda3/bin/pip --version"; \
+  su -s /bin/bash ray -c "/home/ray/anaconda3/bin/pip3 --version"'
+
+USER ray

--- a/examples/aws/eks-public-efa/docker/Dockerfile.aws-efa-uccl.fragment
+++ b/examples/aws/eks-public-efa/docker/Dockerfile.aws-efa-uccl.fragment
@@ -1,0 +1,116 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+SHELL ["/bin/bash", "-lc"]
+
+ARG EFA_INSTALLER_VERSION=1.43.2
+ARG AWS_OFI_NCCL_VERSION=1.19.2
+ARG AWS_OFI_NCCL_SHA512=ec578da632166fd7f885dbc8cfa3f07be19a056276a2bd82a6868fe78160f2df07338068ef1bf5367fd3e81d9b06016fc546e3ea673566ed787e3be49438bf80
+ARG UCCL_URL=https://github.com/uccl-project/uccl.git
+ARG UCCL_REF=v0.1.1
+ARG RAY_ALL_REDUCE_BENCH_URL=https://gist.githubusercontent.com/SumanthRH/d92ca3f690ece64d407423073a169fdf/raw/3b062b14ba597730855c0f14a306001cb2ed7a0e/all_reduce_bench.py
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV EFA_HOME=/opt/amazon/efa
+ENV OFI_NCCL_HOME=/opt/amazon/ofi-nccl
+ENV CUDA_HOME=/usr/local/cuda
+ENV TORCH_CUDA_ARCH_LIST=9.0
+ENV PER_EXPERT_BATCHING=1
+ENV USE_DMABUF=1
+ENV MAX_JOBS=16
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    autoconf \
+    automake \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    libc6-dev \
+    libhwloc-dev \
+    libnuma-dev \
+    libnl-3-dev \
+    libnl-route-3-dev \
+    librdmacm-dev \
+    libibverbs-dev \
+    libtool \
+    pciutils \
+    pkg-config \
+    rdma-core \
+    wget \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install EFA userspace in the image. Kernel modules still come from the host.
+# The --skip-kmod flag is intentional for containers.
+RUN cd /tmp \
+  && curl -fsSLO "https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz" \
+  && tar -xf "aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz" \
+  && cd aws-efa-installer \
+  && ./efa_installer.sh -y --skip-kmod -g --no-verify \
+  && rm -rf /tmp/aws-efa-installer /tmp/aws-efa-installer-*.tar.gz
+
+# Install the AWS OFI NCCL network plugin. Without this libnccl-net.so, NCCL
+# falls back to sockets and EFA all-reduce bandwidth is extremely low.
+RUN cd /tmp \
+  && curl -fsSLO "https://github.com/aws/aws-ofi-nccl/releases/download/v${AWS_OFI_NCCL_VERSION}/aws-ofi-nccl-${AWS_OFI_NCCL_VERSION}.tar.gz" \
+  && echo "${AWS_OFI_NCCL_SHA512}  aws-ofi-nccl-${AWS_OFI_NCCL_VERSION}.tar.gz" | sha512sum -c - \
+  && tar -xf "aws-ofi-nccl-${AWS_OFI_NCCL_VERSION}.tar.gz" \
+  && cd "aws-ofi-nccl-${AWS_OFI_NCCL_VERSION}" \
+  && ./configure \
+       --prefix="${OFI_NCCL_HOME}" \
+       --libdir="${OFI_NCCL_HOME}/lib" \
+       --with-libfabric="${EFA_HOME}" \
+       --with-cuda="${CUDA_HOME}" \
+       --enable-platform-aws \
+       --disable-tests \
+  && make -j"$(nproc)" \
+  && make install \
+  && test -f "${OFI_NCCL_HOME}/lib/libnccl-net.so" \
+  && rm -rf "/tmp/aws-ofi-nccl-${AWS_OFI_NCCL_VERSION}" "/tmp/aws-ofi-nccl-${AWS_OFI_NCCL_VERSION}.tar.gz"
+
+RUN python -m pip install --no-cache-dir --upgrade pip setuptools wheel \
+  && python -m pip install --no-cache-dir nanobind intervaltree sortedcontainers
+
+RUN git clone "${UCCL_URL}" /opt/uccl \
+  && cd /opt/uccl \
+  && git checkout "${UCCL_REF}"
+
+RUN export LD_LIBRARY_PATH="${EFA_HOME}/lib:${OFI_NCCL_HOME}/lib:${LD_LIBRARY_PATH:-}" \
+  && python -m pip install --no-cache-dir /opt/uccl \
+  && rm -rf /tmp/uccl_ep_build \
+  && cp -a /opt/uccl /tmp/uccl_ep_build \
+  && cd /tmp/uccl_ep_build/ep \
+  && python -m pip install --no-cache-dir . \
+  && cd /tmp/uccl_ep_build/ep/deep_ep_wrapper \
+  && for name in buffer.py test_internode.py utils.py; do \
+       rm -f "deep_ep/${name}"; \
+       cp "../bench/${name}" "deep_ep/${name}"; \
+     done \
+  && python -m pip install --no-cache-dir . \
+  && rm -rf /tmp/uccl_ep_build
+
+COPY env/ /opt/efa-middle/env/
+COPY scripts/ /opt/efa-middle/scripts/
+COPY detect_compute_nodes.py /opt/efa-middle/scripts/detect_compute_nodes.py
+
+RUN mkdir -p /opt/efa-middle/bench \
+  && curl -fsSL "${RAY_ALL_REDUCE_BENCH_URL}" -o /opt/efa-middle/bench/all_reduce_bench.py \
+  && chmod +x /opt/efa-middle/env/aws_efa_uccl_env.sh \
+  && chmod +x /opt/efa-middle/scripts/*.sh /opt/efa-middle/scripts/*.py \
+  && chmod a+r /opt/efa-middle/bench/all_reduce_bench.py \
+  && ln -sf /opt/efa-middle/scripts/detect_compute_nodes.py /opt/efa-middle/scripts/detect_compute_nodes \
+  && ln -sf /opt/efa-middle/scripts/validate_compute_nodes.sh /opt/efa-middle/scripts/validate_compute_nodes
+
+ENV PATH=/opt/efa-middle/scripts:/usr/local/cuda/bin:/opt/amazon/efa/bin:${PATH}
+ENV LD_LIBRARY_PATH=/opt/amazon/efa/lib:/opt/amazon/ofi-nccl/lib:${LD_LIBRARY_PATH}
+ENV FI_PROVIDER=efa
+ENV FI_EFA_USE_DEVICE_RDMA=1
+ENV NCCL_NET_PLUGIN=libnccl-net.so
+ENV NCCL_SOCKET_IFNAME=eth0
+ENV GLOO_SOCKET_IFNAME=eth0
+ENV UCCL_SOCKET_IFNAME=eth0
+ENV CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+ENV OMP_NUM_THREADS=8
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /workspace

--- a/examples/aws/eks-public-efa/docker/README.md
+++ b/examples/aws/eks-public-efa/docker/README.md
@@ -1,0 +1,217 @@
+# AWS EFA UCCL-EP Docker Middle Layer
+
+This directory builds a CUDA container layer for AWS EFA workloads that need
+NCCL, UCCL, UCCL-EP, and basic runtime validation tools.
+
+It is a self-contained Docker build context shipped with the
+`examples/aws/eks-public-efa` Terraform example. From the repository root,
+change into this directory before running the build commands below:
+
+```bash
+cd examples/aws/eks-public-efa/docker
+```
+
+The image installs:
+
+```text
+AWS EFA userspace and libfabric EFA provider
+aws-ofi-nccl for NCCL over EFA
+UCCL and UCCL-EP
+DeepEP compatibility wrapper backed by UCCL-EP
+Runtime environment setup
+EFA, NCCL, and UCCL validation scripts
+```
+
+Validation scripts and benchmark assets are baked into `/opt/efa-middle`, but
+they are not run during image build or container startup.
+
+## Requirements
+
+The host or Kubernetes pod must provide the hardware and kernel-side devices:
+
+```text
+EFA-capable GPU instance, such as p5.48xlarge
+NVIDIA GPUs exposed to the container
+/dev/infiniband mounted into the container
+EFA/RDMA devices exposed by the AWS EFA Kubernetes device plugin or host runtime
+Network placement compatible with EFA, such as a single AZ and placement group
+```
+
+The container provides userspace libraries and validation entrypoints only. It
+does not create EFA devices or load host kernel modules.
+
+## Build
+
+Build with a configurable base image:
+
+```bash
+BASE_IMAGE=anyscale/ray:2.55.1-slim-py312-cu128 \
+IMAGE=aws-efa-uccl-middle:dev \
+DOCKER=docker \
+bash scripts/build_image.sh
+```
+
+Or build the concrete Anyscale Ray image directly:
+
+```bash
+docker build \
+  -f Dockerfile.anyscale-ray-2.55.1-cu128-efa-uccl \
+  -t anyscale-ray-2.55.1-cu128-torch2.8-efa-uccl:dev \
+  .
+```
+
+The build context must be this directory because the Dockerfiles copy `env/`,
+`scripts/`, and `detect_compute_nodes.py` into the image. The Ray all-reduce
+benchmark is downloaded from a pinned gist URL during the image build.
+
+Default build arguments:
+
+```text
+EFA_INSTALLER_VERSION=1.43.2
+AWS_OFI_NCCL_VERSION=1.19.2
+UCCL_REF=v0.1.1
+TORCH_VERSION=2.8.0
+TORCH_INDEX_URL=https://download.pytorch.org/whl/cu128
+```
+
+## Runtime Environment
+
+The main environment file is:
+
+```bash
+source /opt/efa-middle/env/aws_efa_uccl_env.sh
+```
+
+It sets the EFA/libfabric, NCCL, CUDA, and bootstrap-interface defaults used by
+the validation scripts:
+
+```text
+FI_PROVIDER=efa
+FI_EFA_USE_DEVICE_RDMA=1
+NCCL_NET_PLUGIN=libnccl-net.so
+NCCL_SOCKET_IFNAME=eth0
+GLOO_SOCKET_IFNAME=eth0
+UCCL_SOCKET_IFNAME=eth0
+```
+
+`eth0` is used for TCP bootstrap and metadata traffic. EFA payload transport is
+selected separately through libfabric and the NCCL OFI plugin.
+
+## Local Container Smoke Test
+
+For a manually started container, mount GPUs and EFA devices:
+
+```bash
+docker run --rm -it \
+  --gpus all \
+  --network host \
+  --ipc host \
+  --ulimit memlock=-1:-1 \
+  --device /dev/infiniband \
+  aws-efa-uccl-middle:dev \
+  bash
+```
+
+Inside the container:
+
+```bash
+/opt/efa-middle/scripts/validate_middle_layer_local.sh
+```
+
+This checks local GPU visibility, EFA/RDMA devices, libfabric EFA provider
+availability, and Python imports. It does not run multi-node collectives.
+
+## Workspace Validation
+
+After a Ray workspace or cluster starts, run validation from the Ray head:
+
+```bash
+/opt/efa-middle/scripts/validate_compute_nodes.py all \
+  --nnodes 2 \
+  --nproc-per-node 8
+```
+
+The `all` action runs:
+
+```text
+EFA/GPU device detection on each compute node
+Ray-based NCCL all-reduce across the requested compute nodes
+UCCL-EP low-latency benchmark across the requested compute nodes
+UCCL-EP high-throughput benchmark across the requested compute nodes
+```
+
+The script discovers Ray compute nodes and then uses SSH for per-node checks.
+Defaults are `SSH_TARGET=ip` and `SSH_PORT=2222`; override with environment
+variables or command flags when needed.
+
+Useful examples:
+
+```bash
+# Device detection only
+/opt/efa-middle/scripts/validate_compute_nodes.py devices
+
+# Ray NCCL all-reduce only
+/opt/efa-middle/scripts/validate_compute_nodes.py all-reduce --nnodes 2
+
+# UCCL-EP modes only
+/opt/efa-middle/scripts/validate_compute_nodes.py uccl-ll --nnodes 2
+/opt/efa-middle/scripts/validate_compute_nodes.py uccl-ht --nnodes 2
+```
+
+`EXPECTED_EFA_DEVICES` is intentionally not baked into the image. Set it only
+when you want to enforce a specific instance shape:
+
+```bash
+EXPECTED_EFA_DEVICES=32 \
+/opt/efa-middle/scripts/validate_compute_nodes.py devices
+```
+
+## Kubernetes Example
+
+`examples/k8s-efa-uccl-validation-job.yaml` contains a minimal EKS validation
+job shape. Replace `REPLACE_WITH_AWS_EFA_UCCL_IMAGE` with the image you built.
+
+The example requests one full `p5.48xlarge` worker pod:
+
+```yaml
+resources:
+  limits:
+    nvidia.com/gpu: "8"
+    vpc.amazonaws.com/efa: "32"
+```
+
+Adjust those resource limits for other EFA-capable instance types.
+
+## Files
+
+```text
+Dockerfile.aws-efa-uccl.fragment
+  Generic Dockerfile fragment that accepts BASE_IMAGE.
+
+Dockerfile.anyscale-ray-2.55.1-cu128-efa-uccl
+  Concrete image recipe based on anyscale/ray:2.55.1-slim-py312-cu128.
+
+env/aws_efa_uccl_env.sh
+  Runtime environment defaults for EFA, NCCL, UCCL, and Ray validation.
+
+detect_compute_nodes.py
+  Helper for discovering Ray compute nodes.
+
+scripts/build_image.sh
+  Build helper for the generic Dockerfile fragment.
+
+scripts/validate_compute_nodes.py
+  Main post-start validation entrypoint for Ray workspaces.
+
+scripts/validate_efa_devices.sh
+  Local GPU, EFA/RDMA, libfabric, and topology checks.
+
+scripts/validate_nccl_all_reduce.sh
+  Ray-based NCCL all-reduce validation.
+
+scripts/validate_uccl_ep.sh
+  UCCL-EP low-latency and high-throughput validation.
+
+scripts/validate_uccl_imports.sh
+  Python import check for torch, uccl.ep, and deep_ep.
+```

--- a/examples/aws/eks-public-efa/docker/detect_compute_nodes.py
+++ b/examples/aws/eks-public-efa/docker/detect_compute_nodes.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Print IP addresses and hostnames for Ray compute nodes.
+
+By default this excludes the Ray head node and reports only worker/compute
+nodes. Use --include-head if you also want the head node in the output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import socket
+import sys
+from typing import Any
+
+
+# Some workspace environments install a runtime-env hook that packages workspace
+# files for Ray jobs. This probe does not need those files, and disabling the
+# hook avoids large uploads from large workspaces.
+os.environ.pop("RAY_RUNTIME_ENV_HOOK", None)
+os.environ.setdefault("RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO", "0")
+
+import ray  # noqa: E402
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy  # noqa: E402
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Detect IP addresses and hostnames for Ray compute nodes."
+    )
+    parser.add_argument(
+        "--address",
+        default="auto",
+        help="Ray cluster address. Defaults to auto.",
+    )
+    parser.add_argument(
+        "--include-head",
+        action="store_true",
+        help="Include the Ray head node in the output.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON instead of a table.",
+    )
+    parser.add_argument(
+        "--details",
+        action="store_true",
+        help="Include node group, instance type, and availability zone in table output.",
+    )
+    return parser.parse_args()
+
+
+@ray.remote(num_cpus=0)
+def probe_hostname() -> dict[str, Any]:
+    hostname = socket.gethostname()
+    env_keys = (
+        "ANYSCALE_INSTANCE_ID",
+        "ANYSCALE_NODE_IP",
+        "ANYSCALE_NODE_GROUP_ID",
+        "ANYSCALE_NODE_AZ",
+        "RAY_CLOUD_INSTANCE_ID",
+        "RAY_CLOUD_INSTANCE_TYPE_NAME",
+        "RAY_NODE_TYPE_NAME",
+    )
+
+    host_ips: list[str] = []
+    try:
+        host_ips = socket.gethostbyname_ex(hostname)[2]
+    except socket.gaierror:
+        pass
+
+    return {
+        "hostname": hostname,
+        "fqdn": socket.getfqdn(),
+        "host_ips": host_ips,
+        "env": {key: os.environ.get(key) for key in env_keys if os.environ.get(key)},
+    }
+
+
+def is_head_node(node: dict[str, Any]) -> bool:
+    resources = node.get("Resources", {})
+    labels = node.get("Labels", {})
+    return bool(
+        resources.get("node:__internal_head__")
+        or labels.get("ray.io/node-group") == "head"
+        or labels.get("ray.io/node-type") == "head"
+    )
+
+
+def node_ip(node: dict[str, Any]) -> str:
+    return (
+        node.get("NodeManagerAddress")
+        or node.get("node_ip")
+        or node.get("NodeManagerHostname")
+        or ""
+    )
+
+
+def collect_nodes(include_head: bool) -> list[dict[str, Any]]:
+    records = []
+    for node in ray.nodes():
+        if not node.get("Alive"):
+            continue
+        if not include_head and is_head_node(node):
+            continue
+
+        node_id = node["NodeID"]
+        ray_ip = node_ip(node)
+        labels = node.get("Labels", {})
+
+        ref = probe_hostname.options(
+            scheduling_strategy=NodeAffinitySchedulingStrategy(
+                node_id=node_id,
+                soft=False,
+            )
+        ).remote()
+        probe = ray.get(ref)
+        env = probe.get("env", {})
+
+        records.append(
+            {
+                "hostname": probe.get("hostname") or env.get("ANYSCALE_INSTANCE_ID") or "",
+                "ip": env.get("ANYSCALE_NODE_IP") or ray_ip,
+                "ray_node_id": node_id,
+                "node_group": labels.get("ray.io/node-group")
+                or env.get("ANYSCALE_NODE_GROUP_ID")
+                or "",
+                "instance_type": labels.get("anyscale.com/instance-type")
+                or env.get("RAY_CLOUD_INSTANCE_TYPE_NAME")
+                or "",
+                "availability_zone": labels.get("ray.io/availability-zone")
+                or env.get("ANYSCALE_NODE_AZ")
+                or "",
+                "is_head": is_head_node(node),
+            }
+        )
+
+    return sorted(records, key=lambda item: (item["is_head"], item["ip"], item["hostname"]))
+
+
+def print_table(records: list[dict[str, Any]], details: bool) -> None:
+    columns = [
+        ("HOSTNAME", "hostname"),
+        ("IP", "ip"),
+    ]
+    if details:
+        columns.extend(
+            [
+                ("NODE_GROUP", "node_group"),
+                ("INSTANCE_TYPE", "instance_type"),
+                ("AZ", "availability_zone"),
+            ]
+        )
+    widths = {
+        header: max(len(header), *(len(str(record[key])) for record in records))
+        for header, key in columns
+    }
+
+    print("  ".join(header.ljust(widths[header]) for header, _ in columns))
+    for record in records:
+        print(
+            "  ".join(
+                str(record[key]).ljust(widths[header]) for header, key in columns
+            )
+        )
+
+
+def main() -> int:
+    args = parse_args()
+
+    ray.init(
+        address=args.address,
+        namespace="detect-compute-nodes",
+        runtime_env={},
+        logging_level=logging.ERROR,
+        log_to_driver=False,
+    )
+    records = collect_nodes(include_head=args.include_head)
+
+    if args.json:
+        print(json.dumps(records, indent=2, sort_keys=True))
+    elif records:
+        print_table(records, details=args.details)
+    else:
+        print("No alive compute nodes found.", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/aws/eks-public-efa/docker/env/aws_efa_uccl_env.sh
+++ b/examples/aws/eks-public-efa/docker/env/aws_efa_uccl_env.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+if [ -z "${BASH_VERSION:-}" ]; then
+  exec bash "$0" "$@"
+fi
+
+# Source this file inside the container before NCCL/UCCL/vLLM validation.
+
+export EFA_HOME="${EFA_HOME:-/opt/amazon/efa}"
+export OFI_NCCL_HOME="${OFI_NCCL_HOME:-/opt/amazon/ofi-nccl}"
+export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
+
+if ! command -v python >/dev/null 2>&1 && [ -x /home/ray/anaconda3/bin/python ]; then
+  export PATH="/home/ray/anaconda3/bin:${PATH}"
+fi
+
+export PATH="${CUDA_HOME}/bin:${EFA_HOME}/bin:${PATH}"
+
+_torch_lib=""
+if command -v python >/dev/null 2>&1; then
+  _torch_lib="$(python - <<'PY' 2>/dev/null || true
+import pathlib
+import torch
+print(pathlib.Path(torch.__file__).resolve().parent / "lib")
+PY
+)"
+fi
+
+if [ -n "$_torch_lib" ]; then
+  export LD_LIBRARY_PATH="${EFA_HOME}/lib:${OFI_NCCL_HOME}/lib:${_torch_lib}:${LD_LIBRARY_PATH:-}"
+else
+  export LD_LIBRARY_PATH="${EFA_HOME}/lib:${OFI_NCCL_HOME}/lib:${LD_LIBRARY_PATH:-}"
+fi
+
+export FI_PROVIDER="${FI_PROVIDER:-efa}"
+export FI_EFA_USE_DEVICE_RDMA="${FI_EFA_USE_DEVICE_RDMA:-1}"
+export NCCL_NET_PLUGIN="${NCCL_NET_PLUGIN:-libnccl-net.so}"
+
+# These pick the TCP/IP interface for rendezvous, bootstrap, and metadata.
+# They do not force payload traffic through eth0 when EFA/OFI is selected.
+export NCCL_SOCKET_IFNAME="${NCCL_SOCKET_IFNAME:-eth0}"
+export GLOO_SOCKET_IFNAME="${GLOO_SOCKET_IFNAME:-eth0}"
+export UCCL_SOCKET_IFNAME="${UCCL_SOCKET_IFNAME:-eth0}"
+
+export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0,1,2,3,4,5,6,7}"
+export OMP_NUM_THREADS="${OMP_NUM_THREADS:-8}"
+export PYTHONUNBUFFERED="${PYTHONUNBUFFERED:-1}"
+
+export NCCL_DEBUG="${NCCL_DEBUG:-WARN}"
+export NCCL_DEBUG_SUBSYS="${NCCL_DEBUG_SUBSYS:-INIT,NET}"

--- a/examples/aws/eks-public-efa/docker/examples/k8s-efa-uccl-validation-job.yaml
+++ b/examples/aws/eks-public-efa/docker/examples/k8s-efa-uccl-validation-job.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: efa-uccl-middle-layer-validation
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: validation
+          image: REPLACE_WITH_AWS_EFA_UCCL_IMAGE
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -lc
+            - |
+              source /opt/efa-middle/env/aws_efa_uccl_env.sh
+              /opt/efa-middle/scripts/validate_efa_devices.sh
+              /opt/efa-middle/scripts/validate_uccl_imports.sh
+          env:
+            - name: EXPECTED_GPUS
+              value: "8"
+            - name: FI_PROVIDER
+              value: efa
+            - name: FI_EFA_USE_DEVICE_RDMA
+              value: "1"
+            - name: NCCL_SOCKET_IFNAME
+              value: eth0
+            - name: GLOO_SOCKET_IFNAME
+              value: eth0
+            - name: UCCL_SOCKET_IFNAME
+              value: eth0
+          resources:
+            limits:
+              nvidia.com/gpu: "8"
+              vpc.amazonaws.com/efa: "32"
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK

--- a/examples/aws/eks-public-efa/docker/scripts/build_image.sh
+++ b/examples/aws/eks-public-efa/docker/scripts/build_image.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+if [ -z "${BASH_VERSION:-}" ]; then
+  exec bash "$0" "$@"
+fi
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+ROOT_DIR=$(cd -- "${SCRIPT_DIR}/.." && pwd)
+
+DOCKER=${DOCKER:-docker}
+BASE_IMAGE=${BASE_IMAGE:-}
+IMAGE=${IMAGE:-aws-efa-uccl-middle:dev}
+DOCKERFILE=${DOCKERFILE:-Dockerfile.aws-efa-uccl.fragment}
+EFA_INSTALLER_VERSION=${EFA_INSTALLER_VERSION:-1.43.2}
+AWS_OFI_NCCL_VERSION=${AWS_OFI_NCCL_VERSION:-1.19.2}
+AWS_OFI_NCCL_SHA512=${AWS_OFI_NCCL_SHA512:-ec578da632166fd7f885dbc8cfa3f07be19a056276a2bd82a6868fe78160f2df07338068ef1bf5367fd3e81d9b06016fc546e3ea673566ed787e3be49438bf80}
+UCCL_URL=${UCCL_URL:-https://github.com/uccl-project/uccl.git}
+UCCL_REF=${UCCL_REF:-v0.1.1}
+RAY_ALL_REDUCE_BENCH_URL=${RAY_ALL_REDUCE_BENCH_URL:-https://gist.githubusercontent.com/SumanthRH/d92ca3f690ece64d407423073a169fdf/raw/3b062b14ba597730855c0f14a306001cb2ed7a0e/all_reduce_bench.py}
+
+if [ -z "$BASE_IMAGE" ]; then
+  cat >&2 <<EOF
+Set BASE_IMAGE before building.
+
+Example:
+  BASE_IMAGE=<anyscale-or-vllm-cuda-image> \\
+  IMAGE=${IMAGE} \\
+  DOCKER="sudo docker" \\
+  $0
+EOF
+  exit 2
+fi
+
+cd "$ROOT_DIR"
+echo "Building ${IMAGE}"
+echo "BASE_IMAGE=${BASE_IMAGE}"
+echo "AWS_OFI_NCCL_VERSION=${AWS_OFI_NCCL_VERSION}"
+echo "UCCL_REF=${UCCL_REF}"
+
+$DOCKER build \
+  -f "$DOCKERFILE" \
+  --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
+  --build-arg "EFA_INSTALLER_VERSION=${EFA_INSTALLER_VERSION}" \
+  --build-arg "AWS_OFI_NCCL_VERSION=${AWS_OFI_NCCL_VERSION}" \
+  --build-arg "AWS_OFI_NCCL_SHA512=${AWS_OFI_NCCL_SHA512}" \
+  --build-arg "UCCL_URL=${UCCL_URL}" \
+  --build-arg "UCCL_REF=${UCCL_REF}" \
+  --build-arg "RAY_ALL_REDUCE_BENCH_URL=${RAY_ALL_REDUCE_BENCH_URL}" \
+  -t "$IMAGE" \
+  .

--- a/examples/aws/eks-public-efa/docker/scripts/exec_started_container_validation.sh
+++ b/examples/aws/eks-public-efa/docker/scripts/exec_started_container_validation.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+if [ -z "${BASH_VERSION:-}" ]; then
+  exec bash "$0" "$@"
+fi
+set -euo pipefail
+
+CONTAINER=${CONTAINER:-${1:-}}
+DOCKER=${DOCKER:-docker}
+
+if [ -z "$CONTAINER" ]; then
+  cat >&2 <<EOF
+Usage:
+  CONTAINER=<container-name-or-id> $0
+  $0 <container-name-or-id>
+
+Optional:
+  DOCKER="sudo docker"
+EOF
+  exit 2
+fi
+
+$DOCKER exec \
+  "$CONTAINER" \
+  bash /opt/efa-middle/scripts/validate_middle_layer_local.sh

--- a/examples/aws/eks-public-efa/docker/scripts/run_local_container_smoke.sh
+++ b/examples/aws/eks-public-efa/docker/scripts/run_local_container_smoke.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+if [ -z "${BASH_VERSION:-}" ]; then
+  exec bash "$0" "$@"
+fi
+set -euo pipefail
+
+IMAGE=${IMAGE:-}
+DOCKER=${DOCKER:-docker}
+HOST_EFA_DIR=${HOST_EFA_DIR:-/path/to/efa}
+CONTAINER_EFA_DIR=${CONTAINER_EFA_DIR:-/workspace/efa}
+MOUNT_HOST_EFA_STACK=${MOUNT_HOST_EFA_STACK:-1}
+EXTRA_DOCKER_ARGS=${EXTRA_DOCKER_ARGS:-}
+
+if [ -z "$IMAGE" ]; then
+  echo "Set IMAGE=<container-image> before running this script" >&2
+  exit 2
+fi
+
+efa_mounts=()
+if [ "$MOUNT_HOST_EFA_STACK" = "1" ]; then
+  efa_mounts+=(-v /opt/amazon/efa:/opt/amazon/efa:ro)
+  efa_mounts+=(-v /opt/amazon/ofi-nccl:/opt/amazon/ofi-nccl:ro)
+fi
+
+# EXTRA_DOCKER_ARGS is intentionally split by the shell for operator-provided
+# flags such as: EXTRA_DOCKER_ARGS="--privileged --name efa-smoke"
+# shellcheck disable=SC2206
+extra_args=($EXTRA_DOCKER_ARGS)
+
+$DOCKER run --rm \
+  --gpus all \
+  --network host \
+  --ipc host \
+  --ulimit memlock=-1:-1 \
+  --device /dev/infiniband \
+  "${efa_mounts[@]}" \
+  -v "${HOST_EFA_DIR}:${CONTAINER_EFA_DIR}:ro" \
+  "${extra_args[@]}" \
+  -e NCCL_SOCKET_IFNAME="${NCCL_SOCKET_IFNAME:-eth0}" \
+  -e GLOO_SOCKET_IFNAME="${GLOO_SOCKET_IFNAME:-eth0}" \
+  -e UCCL_SOCKET_IFNAME="${UCCL_SOCKET_IFNAME:-eth0}" \
+  -e FI_PROVIDER="${FI_PROVIDER:-efa}" \
+  -e FI_EFA_USE_DEVICE_RDMA="${FI_EFA_USE_DEVICE_RDMA:-1}" \
+  "$IMAGE" \
+  bash /opt/efa-middle/scripts/validate_middle_layer_local.sh

--- a/examples/aws/eks-public-efa/docker/scripts/run_two_node_container_validation.sh
+++ b/examples/aws/eks-public-efa/docker/scripts/run_two_node_container_validation.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+if [ -z "${BASH_VERSION:-}" ]; then
+  exec bash "$0" "$@"
+fi
+set -euo pipefail
+
+ACTION=${1:-all}
+
+NODE0=${NODE0:-}
+NODE1=${NODE1:-}
+SSH_PORT=${SSH_PORT:-2222}
+IMAGE=${IMAGE:-}
+DOCKER=${DOCKER:-docker}
+LOG_DIR=${LOG_DIR:-/tmp/efa-middle-layer-validation}
+HOST_EFA_DIR=${HOST_EFA_DIR:-/path/to/efa}
+CONTAINER_EFA_DIR=${CONTAINER_EFA_DIR:-/workspace/efa}
+EXTRA_DOCKER_ARGS=${EXTRA_DOCKER_ARGS:-}
+MOUNT_HOST_EFA_STACK=${MOUNT_HOST_EFA_STACK:-1}
+
+if [ -z "$IMAGE" ]; then
+  echo "Set IMAGE=<container-image> before running this script" >&2
+  exit 2
+fi
+if [ -z "$NODE0" ] || [ -z "$NODE1" ]; then
+  echo "Set NODE0=<host-or-ip> and NODE1=<host-or-ip> before running this script" >&2
+  exit 2
+fi
+
+mkdir -p "$LOG_DIR"
+
+wait_for_pair() {
+  local pid0=$1
+  local pid1=$2
+  local status=0
+  wait "$pid0" || status=$?
+  wait "$pid1" || status=$?
+  return "$status"
+}
+
+container_prefix() {
+  local node_rank=$1
+  local efa_mounts=""
+  if [ "$MOUNT_HOST_EFA_STACK" = "1" ]; then
+    efa_mounts="\
+  -v /opt/amazon/efa:/opt/amazon/efa:ro \
+  -v /opt/amazon/ofi-nccl:/opt/amazon/ofi-nccl:ro"
+  fi
+  cat <<EOF
+$DOCKER run --rm \
+  --gpus all \
+  --network host \
+  --ipc host \
+  --ulimit memlock=-1:-1 \
+  --device /dev/infiniband \
+  ${efa_mounts} \
+  -v ${HOST_EFA_DIR}:${CONTAINER_EFA_DIR}:ro \
+  ${EXTRA_DOCKER_ARGS} \
+  -e NNODES=2 \
+  -e NODE_RANK=${node_rank} \
+  -e MASTER_ADDR=${NODE0} \
+  -e NPROC_PER_NODE=8 \
+  -e NCCL_SOCKET_IFNAME=eth0 \
+  -e GLOO_SOCKET_IFNAME=eth0 \
+  -e UCCL_SOCKET_IFNAME=eth0 \
+  -e FI_PROVIDER=efa \
+  -e FI_EFA_USE_DEVICE_RDMA=1 \
+  "$IMAGE"
+EOF
+}
+
+remote_cmd() {
+  local node_rank=$1
+  local action=$2
+  local prefix
+  prefix=$(container_prefix "$node_rank")
+
+  case "$action" in
+    devices)
+      echo "$prefix bash /opt/efa-middle/scripts/validate_efa_devices.sh"
+      ;;
+    imports)
+      echo "$prefix bash /opt/efa-middle/scripts/validate_uccl_imports.sh"
+      ;;
+    nccl)
+      echo "Ray all-reduce must be run from the Ray head with validate_compute_nodes.py all-reduce" >&2
+      exit 2
+      ;;
+    ll)
+      echo "$prefix bash /opt/efa-middle/scripts/validate_uccl_ep.sh ll"
+      ;;
+    ht)
+      echo "$prefix bash /opt/efa-middle/scripts/validate_uccl_ep.sh ht"
+      ;;
+    local)
+      echo "$prefix bash /opt/efa-middle/scripts/validate_middle_layer_local.sh"
+      ;;
+    *)
+      echo "unknown action $action" >&2
+      exit 2
+      ;;
+  esac
+}
+
+run_pair() {
+  local action=$1
+  echo "Running container validation action=$action image=$IMAGE"
+  ssh -p "$SSH_PORT" "$NODE0" "$(remote_cmd 0 "$action")" >"$LOG_DIR/${action}_node0.log" 2>&1 &
+  local pid0=$!
+  ssh -p "$SSH_PORT" "$NODE1" "$(remote_cmd 1 "$action")" >"$LOG_DIR/${action}_node1.log" 2>&1 &
+  local pid1=$!
+  wait_for_pair "$pid0" "$pid1"
+  echo "Logs:"
+  echo "  $LOG_DIR/${action}_node0.log"
+  echo "  $LOG_DIR/${action}_node1.log"
+}
+
+case "$ACTION" in
+  devices|imports|ll|ht|local)
+    run_pair "$ACTION"
+    ;;
+  nccl)
+    echo "Ray all-reduce must be run from the Ray head with validate_compute_nodes.py all-reduce" >&2
+    exit 2
+    ;;
+  all)
+    run_pair devices
+    run_pair imports
+    run_pair ll
+    run_pair ht
+    ;;
+  *)
+    echo "Usage: IMAGE=<image> NODE0=<host> NODE1=<host> $0 all|local|devices|imports|ll|ht" >&2
+    exit 2
+    ;;
+esac

--- a/examples/aws/eks-public-efa/docker/scripts/validate_compute_nodes.py
+++ b/examples/aws/eks-public-efa/docker/scripts/validate_compute_nodes.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""Run EFA/UCCL validation on Ray compute nodes through SSH."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import os
+import selectors
+import shlex
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DETECT_SCRIPT = SCRIPT_DIR / "detect_compute_nodes.py"
+if not DETECT_SCRIPT.exists():
+    DETECT_SCRIPT = SCRIPT_DIR.parent / "detect_compute_nodes.py"
+DEFAULT_LOG_ROOT = Path("/home/ray/default/efa_validation_logs")
+DEFAULT_ACTION_TIMEOUTS = {
+    "devices": 180,
+    "imports": 180,
+    "local": 300,
+    "all-reduce": 600,
+    "nccl": 600,
+    "uccl-ll": 900,
+    "uccl-ht": 900,
+}
+LOCAL_ACTIONS = {"all-reduce", "nccl"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="SSH to Ray compute nodes and run EFA/UCCL validation."
+    )
+    parser.add_argument(
+        "action",
+        nargs="?",
+        default="all",
+        choices=(
+            "all",
+            "quick",
+            "local",
+            "devices",
+            "imports",
+            "all-reduce",
+            "nccl",
+            "uccl-ll",
+            "uccl-ht",
+        ),
+        help=(
+            "Validation to run. all runs EFA device detection, Ray all-reduce, "
+            "and UCCL-EP LL/HT. quick runs only EFA device detection."
+        ),
+    )
+    parser.add_argument(
+        "--address",
+        default="auto",
+        help="Ray cluster address passed to detect_compute_nodes.py.",
+    )
+    parser.add_argument(
+        "--include-head",
+        action="store_true",
+        help="Include the Ray head node. Usually leave this off.",
+    )
+    parser.add_argument(
+        "--target",
+        choices=("hostname", "ip"),
+        default=os.environ.get("SSH_TARGET", "ip"),
+        help="Use hostnames or IPs as SSH targets. Defaults to SSH_TARGET or ip.",
+    )
+    parser.add_argument(
+        "--ssh-port",
+        default=os.environ.get("SSH_PORT", "2222"),
+        help="Optional SSH port. Defaults to SSH_PORT or 2222.",
+    )
+    parser.add_argument(
+        "--connect-timeout",
+        default=os.environ.get("SSH_CONNECT_TIMEOUT", "15"),
+        help="SSH connection timeout in seconds.",
+    )
+    parser.add_argument(
+        "--log-dir",
+        default=os.environ.get("EFA_VALIDATION_LOG_DIR", ""),
+        help="Directory on the head node for per-node logs.",
+    )
+    parser.add_argument(
+        "--nnodes",
+        type=int,
+        default=int(os.environ.get("NNODES", "0")),
+        help="Number of nodes for distributed checks. Defaults to all compute nodes.",
+    )
+    parser.add_argument(
+        "--nproc-per-node",
+        type=int,
+        default=int(os.environ.get("NPROC_PER_NODE", "8")),
+        help="Processes per node for distributed checks.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print planned SSH commands without running them.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=int(os.environ.get("EFA_VALIDATION_TIMEOUT", "-1")),
+        help=(
+            "Per-step timeout in seconds. Defaults are action-specific. "
+            "Use 0 to disable timeouts."
+        ),
+    )
+    return parser.parse_args()
+
+
+def run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **kwargs)
+
+
+def detect_nodes(address: str, include_head: bool) -> list[dict[str, Any]]:
+    cmd = [sys.executable, str(DETECT_SCRIPT), "--address", address, "--json"]
+    if include_head:
+        cmd.append("--include-head")
+    result = run(cmd)
+    if result.returncode != 0:
+        sys.stderr.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        raise SystemExit(result.returncode)
+    return json.loads(result.stdout)
+
+
+def ssh_base_args(args: argparse.Namespace) -> list[str]:
+    ssh_args = [
+        "ssh",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "StrictHostKeyChecking=accept-new",
+        "-o",
+        f"ConnectTimeout={args.connect_timeout}",
+    ]
+    if args.ssh_port:
+        ssh_args.extend(["-p", str(args.ssh_port)])
+    if os.environ.get("SSH_OPTS"):
+        ssh_args.extend(shlex.split(os.environ["SSH_OPTS"]))
+    return ssh_args
+
+
+def target_for(node: dict[str, Any], mode: str) -> str:
+    value = node.get(mode) or node.get("hostname") or node.get("ip")
+    if not value:
+        raise ValueError(f"Node has no usable SSH target: {node}")
+    return str(value)
+
+
+def remote_env(extra: dict[str, str] | None = None) -> str:
+    values: dict[str, str] = {}
+    for key in ("EXPECTED_GPUS", "EXPECTED_EFA_DEVICES"):
+        if key in os.environ:
+            values[key] = os.environ[key]
+    if extra:
+        values.update(extra)
+    passthrough = (
+        "ALL_REDUCE_WARMUPS",
+        "ALL_REDUCE_TRIALS",
+        "ALL_REDUCE_LOWER_POWER",
+        "ALL_REDUCE_UPPER_POWER",
+        "ALL_REDUCE_PAYLOAD_SIZE_GIB",
+        "ALL_REDUCE_PROFILE_STABILITY",
+        "EFA_MIDDLE_PRELOAD_NCCL",
+        "NCCL_DEBUG",
+        "NCCL_DEBUG_SUBSYS",
+        "NCCL_NET_PLUGIN",
+        "NCCL_SOCKET_IFNAME",
+        "NCCL_VALIDATION_DEBUG",
+        "NCCL_VALIDATION_DEBUG_SUBSYS",
+        "REQUIRE_NCCL_OFI",
+        "RAY_ADDRESS",
+        "WORLD_SIZE",
+    )
+    for key in passthrough:
+        if key in os.environ:
+            values[key] = os.environ[key]
+    return " ".join(f"{key}={shlex.quote(value)}" for key, value in values.items())
+
+
+def action_timeout(args: argparse.Namespace, action: str) -> int:
+    if args.timeout >= 0:
+        return args.timeout
+    env_key = f"EFA_VALIDATION_{action.upper().replace('-', '_')}_TIMEOUT"
+    if env_key in os.environ:
+        return int(os.environ[env_key])
+    return DEFAULT_ACTION_TIMEOUTS.get(action, 300)
+
+
+def remote_command(action: str, extra_env: dict[str, str] | None = None) -> str:
+    script_map = {
+        "devices": "/opt/efa-middle/scripts/validate_efa_devices.sh",
+        "imports": "/opt/efa-middle/scripts/validate_uccl_imports.sh",
+        "local": "/opt/efa-middle/scripts/validate_middle_layer_local.sh",
+        "all-reduce": "/opt/efa-middle/scripts/validate_nccl_all_reduce.sh",
+        "nccl": "/opt/efa-middle/scripts/validate_nccl_all_reduce.sh",
+        "uccl-ll": "/opt/efa-middle/scripts/validate_uccl_ep.sh ll",
+        "uccl-ht": "/opt/efa-middle/scripts/validate_uccl_ep.sh ht",
+    }
+    script = script_map[action]
+    check_path = script.split()[0]
+    return (
+        "set -euo pipefail; "
+        "export PATH=/home/ray/anaconda3/bin:/opt/efa-middle/scripts:/opt/amazon/efa/bin:/usr/local/cuda/bin:$PATH; "
+        f"if [ ! -x {shlex.quote(check_path)} ]; then "
+        f"echo \"Missing {check_path}. Did this worker use the EFA/UCCL image?\" >&2; "
+        "exit 127; "
+        "fi; "
+        f"{remote_env(extra_env)} {script}"
+    )
+
+
+def run_streaming(cmd: list[str], log_path: Path, timeout_seconds: int) -> int:
+    deadline = time.monotonic() + timeout_seconds if timeout_seconds > 0 else None
+    with log_path.open("w", buffering=1) as log:
+        log.write("$ " + " ".join(shlex.quote(part) for part in cmd) + "\n\n")
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        if process.stdout is None:
+            return process.wait()
+
+        selector = selectors.DefaultSelector()
+        selector.register(process.stdout, selectors.EVENT_READ)
+        timed_out = False
+
+        while True:
+            if deadline is not None and time.monotonic() >= deadline:
+                timed_out = True
+                log.write(f"\nTimed out after {timeout_seconds}s. Terminating SSH command.\n")
+                process.terminate()
+                break
+
+            wait_for = 1.0
+            if deadline is not None:
+                wait_for = max(0.0, min(wait_for, deadline - time.monotonic()))
+
+            for key, _ in selector.select(wait_for):
+                line = key.fileobj.readline()
+                if line:
+                    log.write(line)
+
+            if process.poll() is not None:
+                break
+
+        for line in process.stdout:
+            log.write(line)
+
+        if timed_out:
+            try:
+                process.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                log.write("SSH command did not exit after SIGTERM; killing it.\n")
+                process.kill()
+                process.wait()
+            return 124
+
+        return process.wait()
+
+
+def run_ssh_action(
+    args: argparse.Namespace,
+    node: dict[str, Any],
+    action: str,
+    log_dir: Path,
+    rank: int | None = None,
+    nnodes: int | None = None,
+    master_addr: str | None = None,
+) -> dict[str, Any]:
+    target = target_for(node, args.target)
+    extra_env: dict[str, str] = {}
+    if rank is not None and nnodes is not None and master_addr is not None:
+        extra_env.update(
+            {
+                "NNODES": str(nnodes),
+                "NODE_RANK": str(rank),
+                "MASTER_ADDR": master_addr,
+                "NPROC_PER_NODE": str(args.nproc_per_node),
+            }
+        )
+
+    remote = remote_command(action, extra_env)
+    timeout_seconds = action_timeout(args, action)
+    remote_shell = f"bash -lc {shlex.quote(remote)}"
+    if timeout_seconds > 0:
+        remote_shell = f"timeout -s INT -k 30 {timeout_seconds}s {remote_shell}"
+    cmd = ssh_base_args(args) + [target, remote_shell]
+    safe_name = node.get("hostname") or node.get("ip") or target
+    rank_label = rank if rank is not None else "node"
+    log_path = log_dir / f"{action}_{rank_label}_{safe_name}.log"
+
+    if args.dry_run:
+        return {
+            "node": node,
+            "action": action,
+            "target": target,
+            "returncode": 0,
+            "log_path": str(log_path),
+            "dry_run": " ".join(shlex.quote(part) for part in cmd),
+        }
+
+    started = time.time()
+    local_timeout = timeout_seconds + 60 if timeout_seconds > 0 else 0
+    returncode = run_streaming(cmd, log_path, local_timeout)
+    elapsed = time.time() - started
+    return {
+        "node": node,
+        "action": action,
+        "target": target,
+        "returncode": returncode,
+        "log_path": str(log_path),
+        "elapsed": elapsed,
+    }
+
+
+def run_local_action(
+    args: argparse.Namespace,
+    nodes: list[dict[str, Any]],
+    action: str,
+    log_dir: Path,
+) -> dict[str, Any]:
+    nnodes = args.nnodes or len(nodes)
+    if nnodes < 1:
+        raise SystemExit("Ray all-reduce validation requires at least one node.")
+    if nnodes > len(nodes):
+        raise SystemExit(
+            f"Requested {nnodes} nodes but only detected {len(nodes)}."
+        )
+
+    extra_env = {
+        "NNODES": str(nnodes),
+        "NPROC_PER_NODE": str(args.nproc_per_node),
+        "WORLD_SIZE": str(nnodes * args.nproc_per_node),
+    }
+    remote = remote_command(action, extra_env)
+    timeout_seconds = action_timeout(args, action)
+    cmd = ["bash", "-lc", remote]
+    if timeout_seconds > 0:
+        cmd = ["timeout", "-s", "INT", "-k", "30", f"{timeout_seconds}s"] + cmd
+
+    log_path = log_dir / f"{action}_ray_head.log"
+    if args.dry_run:
+        return {
+            "node": {"hostname": "ray-head"},
+            "action": action,
+            "target": "ray-head",
+            "returncode": 0,
+            "log_path": str(log_path),
+            "dry_run": " ".join(shlex.quote(part) for part in cmd),
+        }
+
+    started = time.time()
+    local_timeout = timeout_seconds + 60 if timeout_seconds > 0 else 0
+    returncode = run_streaming(cmd, log_path, local_timeout)
+    elapsed = time.time() - started
+    return {
+        "node": {"hostname": "ray-head"},
+        "action": action,
+        "target": "ray-head",
+        "returncode": returncode,
+        "log_path": str(log_path),
+        "elapsed": elapsed,
+    }
+
+
+def run_parallel(
+    args: argparse.Namespace,
+    nodes: list[dict[str, Any]],
+    action: str,
+    log_dir: Path,
+    distributed: bool = False,
+) -> list[dict[str, Any]]:
+    if distributed:
+        nnodes = args.nnodes or len(nodes)
+        if nnodes < 1:
+            raise SystemExit("Distributed validation requires at least one node.")
+        if nnodes > len(nodes):
+            raise SystemExit(
+                f"Requested {nnodes} distributed nodes but only detected {len(nodes)}."
+            )
+        selected = nodes[:nnodes]
+        master_addr = str(selected[0].get("ip") or selected[0].get("hostname"))
+        jobs = [
+            (node, rank, nnodes, master_addr)
+            for rank, node in enumerate(selected)
+        ]
+    else:
+        jobs = [(node, None, None, None) for node in nodes]
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, len(jobs))) as pool:
+        futures = [
+            pool.submit(run_ssh_action, args, node, action, log_dir, rank, nnodes, master_addr)
+            for node, rank, nnodes, master_addr in jobs
+        ]
+        return [future.result() for future in concurrent.futures.as_completed(futures)]
+
+
+def print_nodes(nodes: list[dict[str, Any]]) -> None:
+    print("Compute nodes:")
+    print("HOSTNAME                         IP              INSTANCE_TYPE              AZ")
+    for node in nodes:
+        hostname = str(node.get("hostname", ""))
+        ip = str(node.get("ip", ""))
+        instance_type = str(node.get("instance_type", ""))
+        availability_zone = str(node.get("availability_zone", ""))
+        print(
+            f"{hostname[:32].ljust(32)} "
+            f"{ip.ljust(15)} "
+            f"{instance_type.ljust(26)} "
+            f"{availability_zone}"
+        )
+    print()
+
+
+def print_summary(results: list[dict[str, Any]]) -> int:
+    print("Validation summary:")
+    print("ACTION    STATUS  TARGET                          LOG")
+    failures = 0
+    for item in sorted(results, key=lambda value: (value["action"], value["target"])):
+        action = item["action"]
+        target = item["target"]
+        log_path = item["log_path"]
+        dry_run = item.get("dry_run")
+        returncode = item["returncode"]
+        status = "PASS" if returncode == 0 else f"FAIL({returncode})"
+        if returncode != 0:
+            failures += 1
+        print(
+            f"{action.ljust(9)} {status.ljust(7)} "
+            f"{target[:31].ljust(31)} {log_path}"
+        )
+        if dry_run:
+            print(f"  {dry_run}")
+    print()
+    if failures:
+        print(f"{failures} validation step(s) failed.")
+    else:
+        print("All requested validation steps passed.")
+    return 1 if failures else 0
+
+
+def main() -> int:
+    args = parse_args()
+    nodes = detect_nodes(args.address, args.include_head)
+    if not nodes:
+        print("No alive compute nodes found.", file=sys.stderr)
+        return 1
+
+    log_dir = Path(args.log_dir) if args.log_dir else DEFAULT_LOG_ROOT / time.strftime("%Y%m%d-%H%M%S")
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    print_nodes(nodes)
+    print(f"Writing per-node logs to: {log_dir}")
+    print()
+
+    if args.action == "all":
+        actions = ["devices", "all-reduce", "uccl-ll", "uccl-ht"]
+    elif args.action == "quick":
+        actions = ["devices"]
+    else:
+        actions = [args.action]
+
+    results: list[dict[str, Any]] = []
+    for action in actions:
+        if action in LOCAL_ACTIONS:
+            print(f"Running {action} from the Ray head...")
+            print(f"  Live logs: tail -f {log_dir}/{action}_ray_head.log", flush=True)
+            results.append(run_local_action(args, nodes, action, log_dir))
+            continue
+
+        distributed = action in {"uccl-ll", "uccl-ht"}
+        print(f"Running {action}...")
+        print(f"  Live logs: tail -f {log_dir}/{action}_*.log", flush=True)
+        results.extend(run_parallel(args, nodes, action, log_dir, distributed=distributed))
+
+    return print_summary(results)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/aws/eks-public-efa/docker/scripts/validate_compute_nodes.sh
+++ b/examples/aws/eks-public-efa/docker/scripts/validate_compute_nodes.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+if [ -z "${BASH_VERSION:-}" ]; then
+  exec bash "$0" "$@"
+fi
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python "${SCRIPT_DIR}/validate_compute_nodes.py" "$@"

--- a/examples/aws/eks-public-efa/docker/scripts/validate_efa_devices.sh
+++ b/examples/aws/eks-public-efa/docker/scripts/validate_efa_devices.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+if [ -z "${BASH_VERSION:-}" ]; then
+  exec bash "$0" "$@"
+fi
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+source "${SCRIPT_DIR}/../env/aws_efa_uccl_env.sh"
+
+EXPECTED_GPUS=${EXPECTED_GPUS:-8}
+EXPECTED_EFA_DEVICES=${EXPECTED_EFA_DEVICES:-}
+
+section() {
+  printf '\n== %s ==\n' "$1"
+}
+
+section "Host"
+hostname
+
+section "GPU Devices"
+if ! command -v nvidia-smi >/dev/null 2>&1; then
+  echo "nvidia-smi not found. If this is the CPU head node, run validate_compute_nodes.sh from the head to validate all compute nodes." >&2
+  exit 127
+fi
+nvidia-smi --query-gpu=index,name,pci.bus_id --format=csv,noheader |
+  awk -F', *' '{printf "GPU%-2s  %-24s  pci=%s\n", $1, $2, tolower($3)}'
+gpu_count=$(nvidia-smi --query-gpu=index --format=csv,noheader | wc -l | tr -d ' ')
+echo "GPU count: ${gpu_count}"
+if [ "$gpu_count" -lt "$EXPECTED_GPUS" ]; then
+  echo "Expected at least ${EXPECTED_GPUS} GPUs, found ${gpu_count}" >&2
+  exit 1
+fi
+
+section "GPU Topology"
+nvidia-smi topo -m | sed -r 's/\x1B\[[0-9;]*[[:alpha:]]//g' | sed -n '1,14p'
+
+section "EFA / RDMA Devices"
+if [ ! -d /sys/class/infiniband ]; then
+  echo "/sys/class/infiniband not found" >&2
+  exit 1
+fi
+
+tmp_nics=$(mktemp)
+trap 'rm -f "$tmp_nics" /tmp/fi_info_efa.out' EXIT
+printf '%-14s %-14s %-6s %s\n' "rdma_dev" "pci" "numa" "netdev"
+for d in /sys/class/infiniband/*; do
+  [ -e "$d" ] || continue
+  dev=$(basename "$d")
+  pci=$(basename "$(readlink -f "$d/device")")
+  numa=$(cat "$d/device/numa_node" 2>/dev/null || echo NA)
+  netdevs="none"
+  if [ -d "$d/device/net" ]; then
+    netdevs=$(ls "$d/device/net" 2>/dev/null | paste -sd, -)
+    [ -n "$netdevs" ] || netdevs="none"
+  fi
+  printf '%-14s %-14s %-6s %s\n' "$dev" "$pci" "$numa" "$netdevs" >>"$tmp_nics"
+done
+sort -k2,2 "$tmp_nics"
+
+efa_count=$(awk '$1 ~ /^(rdmap|efa)/ {count++} END {print count+0}' "$tmp_nics")
+echo "EFA-like RDMA device count: ${efa_count}"
+if [ "$efa_count" -lt 1 ]; then
+  echo "Expected at least one EFA-like RDMA device, found ${efa_count}" >&2
+  exit 1
+fi
+if [ -n "$EXPECTED_EFA_DEVICES" ] && [ "$efa_count" -lt "$EXPECTED_EFA_DEVICES" ]; then
+  echo "Expected at least ${EXPECTED_EFA_DEVICES} EFA-like RDMA devices, found ${efa_count}" >&2
+  exit 1
+fi
+if [ -z "$EXPECTED_EFA_DEVICES" ]; then
+  echo "EXPECTED_EFA_DEVICES is not set; skipping minimum EFA count check."
+fi
+
+section "libfabric EFA Provider"
+if command -v fi_info >/dev/null 2>&1; then
+  fi_info -p efa >/tmp/fi_info_efa.out
+  sed -n '1,40p' /tmp/fi_info_efa.out
+else
+  echo "fi_info not found" >&2
+  exit 1
+fi
+
+section "ibv_devices"
+if command -v ibv_devices >/dev/null 2>&1; then
+  ibv_devices | sed -n '1,80p'
+else
+  echo "ibv_devices not found" >&2
+  exit 1
+fi
+
+section "Environment"
+env | grep -E '^(LD_LIBRARY_PATH|FI_|NCCL_|GLOO_SOCKET_IFNAME|UCCL_SOCKET_IFNAME|CUDA_VISIBLE_DEVICES|OMP_NUM_THREADS)=' | sort
+
+echo
+echo "EFA device validation passed"

--- a/examples/aws/eks-public-efa/docker/scripts/validate_middle_layer_local.sh
+++ b/examples/aws/eks-public-efa/docker/scripts/validate_middle_layer_local.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+if [ -z "${BASH_VERSION:-}" ]; then
+  exec bash "$0" "$@"
+fi
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+source "${SCRIPT_DIR}/../env/aws_efa_uccl_env.sh"
+
+echo "Running local middle-layer smoke checks"
+
+"${SCRIPT_DIR}/validate_efa_devices.sh"
+"${SCRIPT_DIR}/validate_uccl_imports.sh"
+
+echo
+echo "Local middle-layer smoke checks passed"

--- a/examples/aws/eks-public-efa/docker/scripts/validate_nccl_all_reduce.sh
+++ b/examples/aws/eks-public-efa/docker/scripts/validate_nccl_all_reduce.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+if [ -z "${BASH_VERSION:-}" ]; then
+  exec bash "$0" "$@"
+fi
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+source "${SCRIPT_DIR}/../env/aws_efa_uccl_env.sh"
+
+PYTHON=${PYTHON:-python}
+BENCH_SCRIPT=${BENCH_SCRIPT:-/opt/efa-middle/bench/all_reduce_bench.py}
+NNODES=${NNODES:-1}
+NPROC_PER_NODE=${NPROC_PER_NODE:-8}
+WORLD_SIZE=${WORLD_SIZE:-$((NNODES * NPROC_PER_NODE))}
+ALL_REDUCE_WARMUPS=${ALL_REDUCE_WARMUPS:-1}
+ALL_REDUCE_TRIALS=${ALL_REDUCE_TRIALS:-3}
+ALL_REDUCE_PAYLOAD_SIZE_GIB=${ALL_REDUCE_PAYLOAD_SIZE_GIB:-1}
+ALL_REDUCE_PROFILE_STABILITY=${ALL_REDUCE_PROFILE_STABILITY:-0}
+REQUIRE_NCCL_OFI=${REQUIRE_NCCL_OFI:-1}
+
+export NCCL_NET_PLUGIN=${NCCL_NET_PLUGIN:-libnccl-net.so}
+export NCCL_DEBUG=${NCCL_VALIDATION_DEBUG:-INFO}
+export NCCL_DEBUG_SUBSYS=${NCCL_VALIDATION_DEBUG_SUBSYS:-INIT,NET,ENV}
+
+if [ ! -f "$BENCH_SCRIPT" ]; then
+  echo "Cannot find Ray all-reduce benchmark at ${BENCH_SCRIPT}." >&2
+  echo "The image should bake it into /opt/efa-middle/bench/all_reduce_bench.py." >&2
+  exit 1
+fi
+
+if [ "$WORLD_SIZE" -lt 1 ]; then
+  echo "WORLD_SIZE must be at least 1; got ${WORLD_SIZE}." >&2
+  exit 2
+fi
+
+echo "Running Ray NCCL all-reduce validation"
+echo "WORLD_SIZE=${WORLD_SIZE} NNODES=${NNODES} NPROC_PER_NODE=${NPROC_PER_NODE}"
+echo "BENCH_SCRIPT=${BENCH_SCRIPT}"
+echo "ALL_REDUCE_WARMUPS=${ALL_REDUCE_WARMUPS} ALL_REDUCE_TRIALS=${ALL_REDUCE_TRIALS} PAYLOAD=${ALL_REDUCE_PAYLOAD_SIZE_GIB}GiB"
+echo "NCCL_NET_PLUGIN=${NCCL_NET_PLUGIN}"
+echo "NCCL_DEBUG=${NCCL_DEBUG} NCCL_DEBUG_SUBSYS=${NCCL_DEBUG_SUBSYS}"
+echo "FI_PROVIDER=${FI_PROVIDER} FI_EFA_USE_DEVICE_RDMA=${FI_EFA_USE_DEVICE_RDMA}"
+echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
+echo "aws-ofi-nccl plugin candidates:"
+find "${OFI_NCCL_HOME}/lib" -maxdepth 1 -name "libnccl-net.so*" -print -exec ls -l {} \; 2>/dev/null || true
+if [ "$REQUIRE_NCCL_OFI" = "1" ] && ! find "${OFI_NCCL_HOME}/lib" -maxdepth 1 -name "libnccl-net.so*" -print -quit 2>/dev/null | grep -q .; then
+  echo "Missing aws-ofi-nccl libnccl-net.so under ${OFI_NCCL_HOME}/lib" >&2
+  exit 1
+fi
+
+args=(
+  "$BENCH_SCRIPT"
+  --world_size "$WORLD_SIZE"
+  --num_iterations "$ALL_REDUCE_TRIALS"
+  --num_warmup_iterations "$ALL_REDUCE_WARMUPS"
+  --payload_size_in_gib "$ALL_REDUCE_PAYLOAD_SIZE_GIB"
+)
+if [ "$ALL_REDUCE_PROFILE_STABILITY" = "1" ]; then
+  args+=(--profile_stability)
+fi
+
+run_log=$(mktemp -t ray-nccl-allreduce.XXXXXX.log)
+set +e
+"$PYTHON" -u "${args[@]}" 2>&1 | tee "$run_log"
+status=${PIPESTATUS[0]}
+set -e
+
+if [ "$status" -ne 0 ]; then
+  exit "$status"
+fi
+
+if [ "$REQUIRE_NCCL_OFI" = "1" ] && ! grep -E "Loaded net plugin AWS Libfabric|NET/OFI Initializing aws-ofi-nccl|Using network AWS Libfabric" "$run_log" >/dev/null; then
+  echo "Ray all-reduce completed, but the log did not show aws-ofi-nccl/AWS Libfabric." >&2
+  echo "If Ray worker logs are not forwarded to the driver, verify the worker logs manually or set REQUIRE_NCCL_OFI=0." >&2
+  exit 2
+fi
+
+echo "Ray NCCL aws-ofi-nccl validation passed"

--- a/examples/aws/eks-public-efa/docker/scripts/validate_uccl_ep.sh
+++ b/examples/aws/eks-public-efa/docker/scripts/validate_uccl_ep.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+if [ -z "${BASH_VERSION:-}" ]; then
+  exec bash "$0" "$@"
+fi
+set -euo pipefail
+
+MODE=${1:-}
+if [ "$MODE" != "ll" ] && [ "$MODE" != "ht" ]; then
+  echo "Usage: $0 ll|ht" >&2
+  exit 2
+fi
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+source "${SCRIPT_DIR}/../env/aws_efa_uccl_env.sh"
+
+PYTHON=${PYTHON:-python}
+NNODES=${NNODES:-1}
+NPROC_PER_NODE=${NPROC_PER_NODE:-8}
+NODE_RANK=${NODE_RANK:-0}
+MASTER_ADDR=${MASTER_ADDR:-127.0.0.1}
+
+LL_PORT=${LL_PORT:-6123}
+HT_PORT=${HT_PORT:-6124}
+LL_TOKENS=${LL_TOKENS:-128}
+HT_TOKENS=${HT_TOKENS:-4096}
+HIDDEN=${HIDDEN:-7168}
+TOPK=${TOPK:-8}
+EXPERTS=${EXPERTS:-288}
+
+UCCL_BENCH_DIR=${UCCL_BENCH_DIR:-/opt/uccl/ep/bench}
+if [ ! -d "$UCCL_BENCH_DIR" ] && [ -d /workspace/efa/uccl/ep/bench ]; then
+  UCCL_BENCH_DIR=/workspace/efa/uccl/ep/bench
+fi
+
+if [ ! -d "$UCCL_BENCH_DIR" ]; then
+  echo "Cannot find UCCL bench dir. Set UCCL_BENCH_DIR=/path/to/uccl/ep/bench" >&2
+  exit 1
+fi
+
+if [ "$MODE" = "ll" ]; then
+  MASTER_PORT=${MASTER_PORT:-$LL_PORT}
+  BENCH_SCRIPT=test_low_latency.py
+  BENCH_ARGS=(--num-tokens="$LL_TOKENS" --hidden="$HIDDEN" --num-topk="$TOPK" --num-experts="$EXPERTS")
+else
+  MASTER_PORT=${MASTER_PORT:-$HT_PORT}
+  BENCH_SCRIPT=test_internode.py
+  BENCH_ARGS=(--num-tokens="$HT_TOKENS" --hidden="$HIDDEN" --num-topk="$TOPK" --num-experts="$EXPERTS" --test-ll-compatibility)
+fi
+
+echo "Running UCCL-EP ${MODE} validation"
+echo "NNODES=$NNODES NPROC_PER_NODE=$NPROC_PER_NODE NODE_RANK=$NODE_RANK MASTER=$MASTER_ADDR:$MASTER_PORT"
+echo "UCCL_BENCH_DIR=$UCCL_BENCH_DIR"
+echo "BENCH_SCRIPT=$BENCH_SCRIPT ${BENCH_ARGS[*]}"
+
+cd "$UCCL_BENCH_DIR"
+"$PYTHON" -u -m torch.distributed.run \
+  --nnodes="$NNODES" \
+  --nproc_per_node="$NPROC_PER_NODE" \
+  --node_rank="$NODE_RANK" \
+  --master_addr="$MASTER_ADDR" \
+  --master_port="$MASTER_PORT" \
+  "$BENCH_SCRIPT" \
+  "${BENCH_ARGS[@]}"

--- a/examples/aws/eks-public-efa/docker/scripts/validate_uccl_imports.sh
+++ b/examples/aws/eks-public-efa/docker/scripts/validate_uccl_imports.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+if [ -z "${BASH_VERSION:-}" ]; then
+  exec bash "$0" "$@"
+fi
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+source "${SCRIPT_DIR}/../env/aws_efa_uccl_env.sh"
+
+python - <<'PY'
+import pathlib
+import torch
+import uccl
+import uccl.ep
+from uccl.ep import Config
+from deep_ep import Buffer
+
+print("torch", torch.__version__)
+print("torch_cuda", torch.version.cuda)
+print("cuda_available", torch.cuda.is_available())
+print("cuda_device_count", torch.cuda.device_count())
+if torch.cuda.is_available():
+    print("gpu0", torch.cuda.get_device_name(0))
+    print("gpu0_capability", torch.cuda.get_device_capability(0))
+print("uccl", getattr(uccl, "__version__", "unknown"))
+print("uccl_path", pathlib.Path(uccl.__file__).resolve())
+print("uccl_ep", uccl.ep)
+print("Config", Config)
+print("Buffer", Buffer)
+print("import_check ok")
+PY

--- a/examples/aws/eks-public-efa/efa_capacity.tf
+++ b/examples/aws/eks-public-efa/efa_capacity.tf
@@ -1,0 +1,32 @@
+locals {
+  efa_capacity_reservation_enabled = var.efa_capacity_reservation_id != null && var.efa_capacity_reservation_id != ""
+  efa_node_subnet_id               = local.efa_capacity_reservation_enabled ? aws_subnet.efa_private[0].id : module.anyscale_vpc.private_subnet_ids[0]
+  efa_node_availability_zone       = local.efa_capacity_reservation_enabled ? aws_subnet.efa_private[0].availability_zone : module.anyscale_vpc.availability_zones[0]
+}
+
+resource "aws_subnet" "efa_private" {
+  count = local.efa_capacity_reservation_enabled ? 1 : 0
+
+  vpc_id               = module.anyscale_vpc.vpc_id
+  cidr_block           = var.efa_private_subnet_cidr
+  availability_zone_id = var.efa_capacity_reservation_az_id
+
+  tags = merge(var.tags, {
+    "Name"                            = "anyscale-${var.eks_cluster_name}-private-efa"
+    "kubernetes.io/role/internal-elb" = "1"
+  })
+
+  lifecycle {
+    precondition {
+      condition     = var.efa_capacity_reservation_az_id != null && var.efa_capacity_reservation_az_id != ""
+      error_message = "efa_capacity_reservation_az_id is required when efa_capacity_reservation_id is set."
+    }
+  }
+}
+
+resource "aws_route_table_association" "efa_private" {
+  count = local.efa_capacity_reservation_enabled ? 1 : 0
+
+  subnet_id      = aws_subnet.efa_private[0].id
+  route_table_id = module.anyscale_vpc.private_route_table_ids[0]
+}

--- a/examples/aws/eks-public-efa/efa_nodegroup.tf
+++ b/examples/aws/eks-public-efa/efa_nodegroup.tf
@@ -25,9 +25,9 @@ module "h100_efa_nodegroup" {
   capacity_type           = "ON_DEMAND"
   capacity_reservation_id = var.efa_capacity_reservation_id
 
-  min_size     = 0
-  desired_size = 0
-  max_size     = 4
+  min_size     = var.efa_node_group_min_size
+  desired_size = var.efa_node_group_desired_size
+  max_size     = var.efa_node_group_max_size
 
   root_volume_size_gb = var.node_group_disk_size
 

--- a/examples/aws/eks-public-efa/efa_nodegroup.tf
+++ b/examples/aws/eks-public-efa/efa_nodegroup.tf
@@ -1,0 +1,39 @@
+# This EFA worker pool extends the standard Anyscale EKS public example with a
+# p5.48xlarge H100 node group.
+module "h100_efa_nodegroup" {
+  source = "../../../modules/aws-efa-nodegroup"
+
+  cluster_name  = var.eks_cluster_name
+  vpc_id        = module.anyscale_vpc.vpc_id
+  subnet_id     = local.efa_node_subnet_id
+  node_role_arn = data.aws_iam_role.default_nodegroup.arn
+
+  availability_zone = local.efa_node_availability_zone
+  workload_name     = var.efa_workload_name
+
+  cluster_security_group_ids = [
+    module.eks.cluster_security_group_id,
+  ]
+
+  additional_security_group_ids = [
+    module.eks.node_security_group_id,
+  ]
+
+  instance_type = "p5.48xlarge"
+  ami_type      = "AL2023_x86_64_NVIDIA"
+
+  capacity_type           = "ON_DEMAND"
+  capacity_reservation_id = var.efa_capacity_reservation_id
+
+  min_size     = 0
+  desired_size = 0
+  max_size     = 4
+
+  root_volume_size_gb = var.node_group_disk_size
+
+  tags = var.tags
+
+  depends_on = [
+    module.eks,
+  ]
+}

--- a/examples/aws/eks-public-efa/eks.tf
+++ b/examples/aws/eks-public-efa/eks.tf
@@ -1,0 +1,516 @@
+#################################################################
+# Terraform configuration to create a new Amazon EKS cluster
+#
+# This example uses the official EKS module:
+# https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest
+#
+# It demonstrated creation of different kinds of managed node groups:
+# - on-demand CPU
+# - on-demand GPU
+# - spot CPU
+# - spot GPU
+# - custom AMI with launch template
+#
+# For capacity reservations, refer to:
+# https://aws-ia.github.io/terraform-aws-eks-blueprints/patterns/machine-learning/targeted-odcr/
+#
+#################################################################
+
+locals {
+  anyscale_iam = merge(
+    {
+      anyscale_s3_policy = module.anyscale_iam_roles.anyscale_iam_s3_policy_arn,
+    },
+    var.enable_efs ? {
+      efs_client_policy = "arn:aws:iam::aws:policy/AmazonElasticFileSystemClientReadWriteAccess",
+    } : {}
+  )
+
+  node_group_block_device_mappings = {
+    xvda = {
+      device_name = "/dev/xvda"
+      ebs = {
+        delete_on_termination = true
+        volume_size           = var.node_group_disk_size
+        volume_type           = "gp3"
+      }
+    }
+  }
+
+  # Base configuration for GPU node groups
+  gpu_node_group_base = {
+    ami_type                     = "AL2023_x86_64_NVIDIA"
+    min_size                     = 0
+    max_size                     = 10
+    desired_size                 = 0
+    disk_size                    = var.node_group_disk_size
+    use_custom_launch_template   = false
+    iam_role_additional_policies = local.anyscale_iam
+  }
+
+  gpu_node_taints_base = [
+    {
+      key    = "nvidia.com/gpu",
+      value  = "present",
+      effect = "NO_SCHEDULE",
+    },
+    {
+      key    = "node.anyscale.com/accelerator-type",
+      value  = "GPU",
+      effect = "NO_SCHEDULE",
+    }
+  ]
+
+  gpu_node_taints_ondemand = concat(local.gpu_node_taints_base, [
+    {
+      key    = "node.anyscale.com/capacity-type",
+      value  = "ON_DEMAND",
+      effect = "NO_SCHEDULE",
+    }
+  ])
+
+  gpu_node_taints_spot = concat(local.gpu_node_taints_base, [
+    {
+      key    = "node.anyscale.com/capacity-type",
+      value  = "SPOT",
+      effect = "NO_SCHEDULE",
+    }
+  ])
+
+  # Create a map of GPU node groups based on gpu_instance_types
+  gpu_node_groups = {
+    for gpu_type in keys(var.gpu_instance_types) : gpu_type => {
+      ondemand = merge(
+        local.gpu_node_group_base,
+        {
+          instance_types = var.gpu_instance_types[gpu_type].instance_types
+          capacity_type  = "ON_DEMAND"
+          labels = {
+            "nvidia.com/gpu.product" = var.gpu_instance_types[gpu_type].product_name
+            "nvidia.com/gpu.count"   = "1"
+          }
+          taints = local.gpu_node_taints_ondemand
+        }
+      )
+      spot = merge(
+        local.gpu_node_group_base,
+        {
+          instance_types = var.gpu_instance_types[gpu_type].instance_types
+          capacity_type  = "SPOT"
+          labels = {
+            "nvidia.com/gpu.product" = var.gpu_instance_types[gpu_type].product_name
+            "nvidia.com/gpu.count"   = "1"
+          }
+          taints = local.gpu_node_taints_spot
+        }
+      )
+    }
+  }
+}
+
+#trivy:ignore:avd-aws-0038
+#trivy:ignore:avd-aws-0040
+#trivy:ignore:avd-aws-0041
+#trivy:ignore:avd-aws-0104
+module "eks" {
+  #checkov:skip=CKV_TF_1: Use the given version of the module
+  source  = "terraform-aws-modules/eks/aws"
+  version = "20.33.1"
+
+  # Cluster basic configuration
+  cluster_name    = var.eks_cluster_name
+  cluster_version = var.eks_cluster_version
+
+  cluster_addons = {
+    coredns                = {}
+    eks-pod-identity-agent = {}
+    kube-proxy             = {}
+  }
+
+  # API endpoint access configuration
+  cluster_endpoint_public_access = true
+
+  # The authentication mode for the cluster. Valid values are `CONFIG_MAP`, `API` or `API_AND_CONFIG_MAP`
+  authentication_mode = "API_AND_CONFIG_MAP"
+
+  # Optional: Adds the current caller identity as an administrator via cluster access entry
+  enable_cluster_creator_admin_permissions = true
+
+  vpc_id                   = module.anyscale_vpc.vpc_id
+  control_plane_subnet_ids = module.anyscale_vpc.public_subnet_ids
+  subnet_ids               = module.anyscale_vpc.private_subnet_ids
+
+  node_security_group_additional_rules = {
+    anyscale_ingress_nodes = {
+      description = "Node to node ingress - all traffic"
+      protocol    = "-1"
+      from_port   = 0
+      to_port     = 0
+      type        = "ingress"
+      self        = true
+    }
+    anyscale_egress_nodes = {
+      description = "Node to node egress - all traffic"
+      protocol    = "-1"
+      from_port   = 0
+      to_port     = 0
+      type        = "egress"
+      self        = true
+    }
+  }
+
+  #############################################################
+  # Managed Node Groups configuration example
+  #############################################################
+
+  eks_managed_node_groups = merge(
+    {
+      # This node group is for management components such as CoreDNS, Cluster Autoscaler, AWS-LB controller, ingress-nginx, Anyscale Operator, etc.
+      # Note that small instance types of Anyscale workloads can still be scheduled onto this node group.
+      default = {
+        ami_type       = "AL2023_x86_64_STANDARD"
+        instance_types = ["t3.medium"]
+
+        min_size     = 1
+        max_size     = 10
+        desired_size = 2
+
+        iam_role_additional_policies = merge(local.anyscale_iam, {
+          cluster_autoscaler_policy = aws_iam_policy.autoscaler_policy.arn
+          elb_policy                = aws_iam_policy.elb_policy.arn
+        })
+      }
+
+      ondemand_cpu = {
+        ami_type = "AL2023_x86_64_STANDARD"
+        instance_types = [
+          "m5.8xlarge",
+          "m5.4xlarge",
+        ]
+
+        capacity_type              = "ON_DEMAND"
+        min_size                   = 0
+        max_size                   = 10
+        desired_size               = 0
+        block_device_mappings      = local.node_group_block_device_mappings
+        use_custom_launch_template = true
+
+        taints = [
+          {
+            key    = "node.anyscale.com/capacity-type",
+            value  = "ON_DEMAND",
+            effect = "NO_SCHEDULE",
+          }
+        ]
+
+        iam_role_additional_policies = local.anyscale_iam
+      }
+
+      spot_cpu = {
+        ami_type = "AL2023_x86_64_STANDARD"
+        instance_types = [
+          "m5.8xlarge",
+          "m5.4xlarge",
+        ]
+
+        capacity_type              = "SPOT"
+        min_size                   = 0
+        max_size                   = 10
+        desired_size               = 0
+        block_device_mappings      = local.node_group_block_device_mappings
+        use_custom_launch_template = true
+
+        taints = [
+          {
+            key    = "node.anyscale.com/capacity-type",
+            value  = "SPOT",
+            effect = "NO_SCHEDULE",
+          }
+        ]
+
+        iam_role_additional_policies = local.anyscale_iam
+      }
+    },
+    # Merge in GPU node groups based on gpu_instance_types
+    {
+      for gpu_type in keys(var.gpu_instance_types) : "ondemand_gpu_${lower(gpu_type)}" => local.gpu_node_groups[gpu_type].ondemand
+    },
+    {
+      for gpu_type in keys(var.gpu_instance_types) : "spot_gpu_${lower(gpu_type)}" => local.gpu_node_groups[gpu_type].spot
+    }
+  )
+
+  tags = var.tags
+}
+
+#trivy:ignore:avd-aws-0057
+resource "aws_iam_policy" "autoscaler_policy" {
+  #checkov:skip=CKV_AWS_290: Ensure IAM policies does not allow write access without constraints
+  #checkov:skip=CKV_AWS_355: Ensure no IAM policies documents allow "*" as a statement's resource for restrictable actions
+  name        = "${var.eks_cluster_name}-autoscaler-policy"
+  description = "Policy that allows autoscaling and EC2 describe actions for EKS nodegroups."
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "autoscaling:DescribeAutoScalingGroups",
+          "autoscaling:DescribeAutoScalingInstances",
+          "autoscaling:DescribeLaunchConfigurations",
+          "autoscaling:DescribeScalingActivities",
+          "ec2:DescribeImages",
+          "ec2:DescribeInstanceTypes",
+          "ec2:DescribeLaunchTemplateVersions",
+          "ec2:GetInstanceTypesFromInstanceRequirements",
+          "eks:DescribeNodegroup"
+        ]
+        Resource = ["*"]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "autoscaling:SetDesiredCapacity",
+          "autoscaling:TerminateInstanceInAutoScalingGroup"
+        ]
+        Resource = ["*"]
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+# For AWS LBC:
+#   https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.11.0/docs/install/iam_policy.json
+#trivy:ignore:avd-aws-0057
+resource "aws_iam_policy" "elb_policy" {
+  #checkov:skip=CKV_AWS_290: Ensure IAM policies does not allow write access without constraints
+  #checkov:skip=CKV_AWS_355: Ensure no IAM policies documents allow "*" as a statement's resource for restrictable actions
+  name        = "${var.eks_cluster_name}-elb-policy"
+  description = "IAM policy for AWS Load Balancer Controller in Kubernetes"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["iam:CreateServiceLinkedRole"]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "iam:AWSServiceName" = "elasticloadbalancing.amazonaws.com"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:DescribeAccountAttributes",
+          "ec2:DescribeAddresses",
+          "ec2:DescribeAvailabilityZones",
+          "ec2:DescribeInternetGateways",
+          "ec2:DescribeVpcs",
+          "ec2:DescribeVpcPeeringConnections",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeInstances",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DescribeTags",
+          "ec2:GetCoipPoolUsage",
+          "ec2:DescribeCoipPools",
+          "ec2:GetSecurityGroupsForVpc",
+          "elasticloadbalancing:DescribeLoadBalancers",
+          "elasticloadbalancing:DescribeLoadBalancerAttributes",
+          "elasticloadbalancing:DescribeListeners",
+          "elasticloadbalancing:DescribeListenerCertificates",
+          "elasticloadbalancing:DescribeSSLPolicies",
+          "elasticloadbalancing:DescribeRules",
+          "elasticloadbalancing:DescribeTargetGroups",
+          "elasticloadbalancing:DescribeTargetGroupAttributes",
+          "elasticloadbalancing:DescribeTargetHealth",
+          "elasticloadbalancing:DescribeTags",
+          "elasticloadbalancing:DescribeTrustStores",
+          "elasticloadbalancing:DescribeListenerAttributes",
+          "elasticloadbalancing:DescribeCapacityReservation"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "cognito-idp:DescribeUserPoolClient",
+          "acm:ListCertificates",
+          "acm:DescribeCertificate",
+          "iam:ListServerCertificates",
+          "iam:GetServerCertificate",
+          "waf-regional:GetWebACL",
+          "waf-regional:GetWebACLForResource",
+          "waf-regional:AssociateWebACL",
+          "waf-regional:DisassociateWebACL",
+          "wafv2:GetWebACL",
+          "wafv2:GetWebACLForResource",
+          "wafv2:AssociateWebACL",
+          "wafv2:DisassociateWebACL",
+          "shield:GetSubscriptionState",
+          "shield:DescribeProtection",
+          "shield:CreateProtection",
+          "shield:DeleteProtection"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:AuthorizeSecurityGroupIngress",
+          "ec2:RevokeSecurityGroupIngress"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["ec2:CreateSecurityGroup"]
+        Resource = "*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["ec2:CreateTags"]
+        Resource = "arn:aws:ec2:*:*:security-group/*"
+        Condition = {
+          StringEquals = {
+            "ec2:CreateAction" = "CreateSecurityGroup"
+          }
+          Null = {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" = "false"
+          }
+        }
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["ec2:CreateTags", "ec2:DeleteTags"]
+        Resource = "arn:aws:ec2:*:*:security-group/*"
+        Condition = {
+          Null = {
+            "aws:RequestTag/elbv2.k8s.aws/cluster"  = "true"
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" = "false"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:AuthorizeSecurityGroupIngress",
+          "ec2:RevokeSecurityGroupIngress",
+          "ec2:DeleteSecurityGroup"
+        ]
+        Resource = "*"
+        Condition = {
+          Null = {
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" = "false"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:CreateLoadBalancer",
+          "elasticloadbalancing:CreateTargetGroup"
+        ]
+        Resource = "*"
+        Condition = {
+          Null = {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" = "false"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:CreateListener",
+          "elasticloadbalancing:DeleteListener",
+          "elasticloadbalancing:CreateRule",
+          "elasticloadbalancing:DeleteRule"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:AddTags",
+          "elasticloadbalancing:RemoveTags"
+        ]
+        Resource = [
+          "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+          "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+          "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+        ]
+        Condition = {
+          Null = {
+            "aws:RequestTag/elbv2.k8s.aws/cluster"  = "true"
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" = "false"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:AddTags",
+          "elasticloadbalancing:RemoveTags"
+        ]
+        Resource = [
+          "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
+          "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
+          "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+          "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:ModifyLoadBalancerAttributes",
+          "elasticloadbalancing:SetIpAddressType",
+          "elasticloadbalancing:SetSecurityGroups",
+          "elasticloadbalancing:SetSubnets",
+          "elasticloadbalancing:DeleteLoadBalancer",
+          "elasticloadbalancing:ModifyTargetGroup",
+          "elasticloadbalancing:ModifyTargetGroupAttributes",
+          "elasticloadbalancing:DeleteTargetGroup",
+          "elasticloadbalancing:ModifyListenerAttributes",
+          "elasticloadbalancing:ModifyCapacityReservation"
+        ]
+        Resource = "*"
+        Condition = {
+          Null = {
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" = "false"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = ["elasticloadbalancing:AddTags"]
+        Resource = [
+          "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+          "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+          "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+        ]
+        Condition = {
+          StringEquals = {
+            "elasticloadbalancing:CreateAction" = ["CreateTargetGroup", "CreateLoadBalancer"]
+          }
+          Null = {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" = "false"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:RegisterTargets",
+          "elasticloadbalancing:DeregisterTargets"
+        ]
+        Resource = "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+      }
+    ]
+  })
+
+  tags = var.tags
+}

--- a/examples/aws/eks-public-efa/gateway_sg.tf
+++ b/examples/aws/eks-public-efa/gateway_sg.tf
@@ -1,0 +1,44 @@
+# Frontend security group attached to the Anyscale Envoy Gateway NLB.
+#
+# The AWS Load Balancer Controller attaches this security group to the
+# internet-facing NLB fronting the Envoy Gateway (ports 80/443) and manages the
+# backend node security-group rules. Its ID is surfaced via the
+# gateway_nlb_security_group_id output and consumed by the Helm add-on install.
+resource "aws_security_group" "gateway_nlb" {
+  name_prefix = "${var.eks_cluster_name}-gw-nlb-"
+  description = "Anyscale Envoy Gateway NLB frontend"
+  vpc_id      = module.anyscale_vpc.vpc_id
+
+  tags = merge(var.tags, {
+    Name = "${var.eks_cluster_name}-gateway-nlb"
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "gateway_nlb_https" {
+  security_group_id = aws_security_group.gateway_nlb.id
+  description       = "HTTPS from the internet to the Anyscale Envoy Gateway"
+  ip_protocol       = "tcp"
+  from_port         = 443
+  to_port           = 443
+  cidr_ipv4         = "0.0.0.0/0"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "gateway_nlb_http" {
+  security_group_id = aws_security_group.gateway_nlb.id
+  description       = "HTTP from the internet to the Anyscale Envoy Gateway"
+  ip_protocol       = "tcp"
+  from_port         = 80
+  to_port           = 80
+  cidr_ipv4         = "0.0.0.0/0"
+}
+
+resource "aws_vpc_security_group_egress_rule" "gateway_nlb_all" {
+  security_group_id = aws_security_group.gateway_nlb.id
+  description       = "Allow all egress"
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
+}

--- a/examples/aws/eks-public-efa/gpu_instances.tfvars.example
+++ b/examples/aws/eks-public-efa/gpu_instances.tfvars.example
@@ -1,0 +1,31 @@
+# GPU Instance Types for EKS
+#
+# This file contains additional GPU instance configurations beyond the default (T4).
+# Use this file directly or copy and modify as needed:
+#
+#   terraform plan -var-file="gpu_instances.tfvars.example"
+#   terraform apply -var-file="gpu_instances.tfvars.example"
+
+# GPU types configuration - node groups will be created for each entry
+gpu_instance_types = {
+  "T4" = {
+    product_name   = "Tesla-T4"
+    instance_types = ["g4dn.xlarge", "g4dn.2xlarge", "g4dn.4xlarge"]
+  }
+  "T4-4x" = {
+    product_name   = "Tesla-T4"
+    instance_types = ["g4dn.12xlarge"]
+  }
+  "A10G" = {
+    product_name   = "NVIDIA-A10G"
+    instance_types = ["g5.4xlarge"]
+  }
+  "L4" = {
+    product_name   = "NVIDIA-L4"
+    instance_types = ["g6.2xlarge", "g6.4xlarge"]
+  }
+  "L4-4x" = {
+    product_name   = "NVIDIA-L4"
+    instance_types = ["g6.24xlarge"]
+  }
+}

--- a/examples/aws/eks-public-efa/install-helm-addons.sh
+++ b/examples/aws/eks-public-efa/install-helm-addons.sh
@@ -1,0 +1,434 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK_DIR="$(pwd)"
+DEFAULT_EXAMPLE_DIR="${SCRIPT_DIR}"
+EXAMPLE_DIR="${EXAMPLE_DIR:-${DEFAULT_EXAMPLE_DIR}}"
+
+AWS_PROFILE="${AWS_PROFILE:-}"
+AWS_REGION="${AWS_REGION:-us-east-1}"
+EKS_CLUSTER_NAME="${EKS_CLUSTER_NAME:-}"
+EFA_WORKLOAD_NAME="${EFA_WORKLOAD_NAME:-efa}"
+ECR_REGISTRY="${ECR_REGISTRY:-}"
+ECR_MIRROR_PREFIX="${ECR_MIRROR_PREFIX:-}"
+TF_WORKSPACE_NAME="${TF_WORKSPACE_NAME:-}"
+ANYSCALE_CLOUD_RESOURCE_ID="${ANYSCALE_CLOUD_RESOURCE_ID:-}"
+ANYSCALE_CLOUD_RESOURCE_SOURCE="environment"
+HELM_TIMEOUT="${HELM_TIMEOUT:-15m}"
+
+export AWS_PROFILE AWS_REGION AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-$AWS_REGION}"
+export PATH="$HOME/.local/bin:$PATH"
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+need aws
+need kubectl
+need helm
+need terraform
+
+if [[ -z "$AWS_PROFILE" ]]; then
+  echo "Set AWS_PROFILE to the named AWS CLI profile to use for this deployment." >&2
+  exit 1
+fi
+
+if [[ -z "$EKS_CLUSTER_NAME" ]]; then
+  echo "Set EKS_CLUSTER_NAME before running this script." >&2
+  exit 1
+fi
+
+if [[ -z "$ECR_REGISTRY" || -z "$ECR_MIRROR_PREFIX" ]]; then
+  echo "Set ECR_REGISTRY and ECR_MIRROR_PREFIX before installing Helm add-ons." >&2
+  exit 1
+fi
+
+if [[ ! -d "$EXAMPLE_DIR" ]]; then
+  echo "EXAMPLE_DIR does not exist: ${EXAMPLE_DIR}" >&2
+  echo "Set EXAMPLE_DIR to the terraform-kubernetes-anyscale-foundation-modules/examples/aws/eks-public-efa path." >&2
+  exit 1
+fi
+
+assert_terraform_outputs_match_run() {
+  local current_workspace output_cluster_name
+
+  if [[ -n "$TF_WORKSPACE_NAME" ]]; then
+    current_workspace="$(terraform workspace show)"
+    if [[ "$current_workspace" != "$TF_WORKSPACE_NAME" ]]; then
+      echo "Terraform workspace mismatch in Helm installer." >&2
+      echo "Expected: ${TF_WORKSPACE_NAME}" >&2
+      echo "Current:  ${current_workspace}" >&2
+      exit 1
+    fi
+  fi
+
+  output_cluster_name="$(terraform output -raw eks_cluster_name 2>/dev/null || true)"
+  if [[ -n "$output_cluster_name" && "$output_cluster_name" != "$EKS_CLUSTER_NAME" ]]; then
+    echo "Terraform output mismatch in Helm installer: eks_cluster_name does not match this run." >&2
+    echo "Expected: ${EKS_CLUSTER_NAME}" >&2
+    echo "Output:   ${output_cluster_name}" >&2
+    echo "Refusing to install Helm add-ons against stale Terraform state." >&2
+    exit 1
+  fi
+}
+
+collect_anyscale_operator_diagnostics() {
+  echo "Collecting Anyscale Operator diagnostics..." >&2
+  helm status anyscale-operator -n anyscale-operator >&2 || true
+  kubectl get pods -n anyscale-operator -o wide >&2 || true
+  kubectl get events -n anyscale-operator --sort-by=.lastTimestamp >&2 || true
+
+  local pod
+  for pod in $(kubectl get pods -n anyscale-operator -l app=anyscale-operator -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+    echo "Describing pod ${pod}..." >&2
+    kubectl describe pod "$pod" -n anyscale-operator >&2 || true
+    echo "Current operator logs for ${pod}..." >&2
+    kubectl logs "$pod" -n anyscale-operator -c operator --tail=200 >&2 || true
+    echo "Previous operator logs for ${pod}..." >&2
+    kubectl logs "$pod" -n anyscale-operator -c operator --previous --tail=200 >&2 || true
+  done
+}
+
+cd "$EXAMPLE_DIR"
+
+PREVIOUS_TF_WORKSPACE=""
+if [[ -n "$TF_WORKSPACE_NAME" ]]; then
+  PREVIOUS_TF_WORKSPACE="$(terraform workspace show)"
+  terraform workspace select "$TF_WORKSPACE_NAME" >/dev/null
+fi
+assert_terraform_outputs_match_run
+
+for file in sample-values_efa.yaml sample-values_nvdp.yaml; do
+  if [[ ! -f "$file" ]]; then
+    echo "Missing ${EXAMPLE_DIR}/${file}" >&2
+    exit 1
+  fi
+done
+
+if [[ -z "$ANYSCALE_CLOUD_RESOURCE_ID" && -f values.yaml ]]; then
+  ANYSCALE_CLOUD_RESOURCE_SOURCE="${EXAMPLE_DIR}/values.yaml"
+  ANYSCALE_CLOUD_RESOURCE_ID="$(
+    sed -n 's/^[[:space:]]*cloudDeploymentId:[[:space:]]*//p' values.yaml | head -1
+  )"
+fi
+
+if [[ -z "$ANYSCALE_CLOUD_RESOURCE_ID" ]]; then
+  echo "Set ANYSCALE_CLOUD_RESOURCE_ID=cldrsrc_... before running this script." >&2
+  echo "Use the Cloud Deployment ID printed by 'anyscale cloud register'." >&2
+  exit 1
+fi
+
+ANYSCALE_CLOUD_RESOURCE_DNS_ID="${ANYSCALE_CLOUD_RESOURCE_ID//_/-}"
+RENDER_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$RENDER_DIR"
+  if [[ -n "$PREVIOUS_TF_WORKSPACE" ]]; then
+    terraform workspace select "$PREVIOUS_TF_WORKSPACE" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+render_device_plugin_values() {
+  local source_file="$1"
+  local target_file="$2"
+
+  awk -v workload="$EFA_WORKLOAD_NAME" '
+    /^[[:space:]]*value:[[:space:]]*h100-efa[[:space:]]*$/ {
+      sub(/h100-efa/, workload)
+    }
+    { print }
+  ' "$source_file" > "$target_file"
+}
+
+echo "Rendering device plugin values for workload ${EFA_WORKLOAD_NAME}..."
+render_device_plugin_values sample-values_efa.yaml "${RENDER_DIR}/sample-values_efa.yaml"
+render_device_plugin_values sample-values_nvdp.yaml "${RENDER_DIR}/sample-values_nvdp.yaml"
+
+echo "Using Anyscale Cloud Deployment ID from ${ANYSCALE_CLOUD_RESOURCE_SOURCE}: ${ANYSCALE_CLOUD_RESOURCE_ID}"
+
+echo "Updating kubeconfig for ${EKS_CLUSTER_NAME} in ${AWS_REGION}..."
+aws eks update-kubeconfig \
+  --region "$AWS_REGION" \
+  --name "$EKS_CLUSTER_NAME" \
+  --profile "$AWS_PROFILE"
+
+echo "Adding/updating Helm repositories..."
+helm repo add autoscaler https://kubernetes.github.io/autoscaler >/dev/null
+helm repo add eks https://aws.github.io/eks-charts >/dev/null
+helm repo add nvdp https://nvidia.github.io/k8s-device-plugin >/dev/null
+helm repo add anyscale https://anyscale.github.io/helm-charts >/dev/null
+helm repo update
+
+VPC_ID="$(terraform output -raw vpc_id 2>/dev/null || terraform console <<< 'module.anyscale_vpc.vpc_id' | tr -d '"')"
+GATEWAY_NLB_SECURITY_GROUP_ID="$(terraform output -raw gateway_nlb_security_group_id)"
+
+echo "Installing/upgrading Cluster Autoscaler..."
+helm upgrade cluster-autoscaler autoscaler/cluster-autoscaler \
+  --version 9.46.0 \
+  --namespace kube-system \
+  --set awsRegion="$AWS_REGION" \
+  --set "autoDiscovery.clusterName=$EKS_CLUSTER_NAME" \
+  --set image.repository="${ECR_REGISTRY}/${ECR_MIRROR_PREFIX}/autoscaling/cluster-autoscaler" \
+  --set image.tag="v1.32.0" \
+  --install \
+  --wait \
+  --timeout "$HELM_TIMEOUT"
+
+echo "Installing/upgrading AWS Load Balancer Controller..."
+helm upgrade aws-load-balancer-controller eks/aws-load-balancer-controller \
+  --version 1.13.2 \
+  --namespace kube-system \
+  --set clusterName="$EKS_CLUSTER_NAME" \
+  --set region="$AWS_REGION" \
+  --set vpcId="$VPC_ID" \
+  --set image.repository="${ECR_REGISTRY}/${ECR_MIRROR_PREFIX}/eks/aws-load-balancer-controller" \
+  --set image.tag="v2.13.2" \
+  --set enableShield=false \
+  --set enableWaf=false \
+  --set enableWafv2=false \
+  --install \
+  --wait \
+  --timeout "$HELM_TIMEOUT"
+
+echo "Installing/upgrading EFA device plugin..."
+helm upgrade efa eks/aws-efa-k8s-device-plugin \
+  --namespace kube-system \
+  --set image.repository="${ECR_REGISTRY}/${ECR_MIRROR_PREFIX}/eks/aws-efa-k8s-device-plugin" \
+  --set image.tag="v0.5.19" \
+  --values "${RENDER_DIR}/sample-values_efa.yaml" \
+  --install \
+  --wait \
+  --timeout "$HELM_TIMEOUT"
+
+echo "Installing/upgrading NVIDIA device plugin..."
+helm upgrade nvdp nvdp/nvidia-device-plugin \
+  --namespace nvidia-device-plugin \
+  --version 0.17.1 \
+  --set image.repository="${ECR_REGISTRY}/${ECR_MIRROR_PREFIX}/nvidia/k8s-device-plugin" \
+  --set image.tag="v0.17.1" \
+  --values "${RENDER_DIR}/sample-values_nvdp.yaml" \
+  --create-namespace \
+  --install \
+  --wait \
+  --timeout "$HELM_TIMEOUT"
+
+echo "Restarting Cluster Autoscaler to refresh scale-up backoff..."
+kubectl rollout restart deployment \
+  -n kube-system \
+  -l app.kubernetes.io/name=aws-cluster-autoscaler,app.kubernetes.io/instance=cluster-autoscaler
+kubectl rollout status deployment \
+  -n kube-system \
+  -l app.kubernetes.io/name=aws-cluster-autoscaler,app.kubernetes.io/instance=cluster-autoscaler \
+  --timeout=120s
+
+echo "Installing/upgrading Envoy Gateway..."
+helm upgrade eg oci://docker.io/envoyproxy/gateway-helm \
+  --version v1.7.0 \
+  --namespace envoy-gateway-system \
+  --create-namespace \
+  --set global.images.envoyGateway.image="${ECR_REGISTRY}/${ECR_MIRROR_PREFIX}/envoyproxy/gateway:v1.7.0" \
+  --set global.images.ratelimit.image="${ECR_REGISTRY}/${ECR_MIRROR_PREFIX}/envoyproxy/ratelimit:3fb70258" \
+  --install \
+  --wait \
+  --timeout "$HELM_TIMEOUT"
+
+kubectl wait --for=condition=available deployment/envoy-gateway \
+  -n envoy-gateway-system \
+  --timeout=180s
+
+echo "Applying Gateway API resources..."
+kubectl create namespace anyscale-operator --dry-run=client -o yaml | kubectl apply -f -
+
+cat >"${RENDER_DIR}/envoyproxy.yaml" <<EOF
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: envoy-proxy
+  namespace: envoy-gateway-system
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        container:
+          image: ${ECR_REGISTRY}/${ECR_MIRROR_PREFIX}/envoyproxy/envoy:distroless-v1.36.2
+      envoyService:
+        type: LoadBalancer
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-type: external
+          service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: instance
+          service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+          service.beta.kubernetes.io/aws-load-balancer-security-groups: ${GATEWAY_NLB_SECURITY_GROUP_ID}
+          service.beta.kubernetes.io/aws-load-balancer-manage-backend-security-group-rules: "true"
+EOF
+
+cat >"${RENDER_DIR}/gatewayclass.yaml" <<'EOF'
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: eg
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+  parametersRef:
+    group: gateway.envoyproxy.io
+    kind: EnvoyProxy
+    name: envoy-proxy
+    namespace: envoy-gateway-system
+EOF
+
+cat >"${RENDER_DIR}/gateway.yaml" <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway
+  namespace: anyscale-operator
+spec:
+  gatewayClassName: eg
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https
+      port: 443
+      protocol: HTTPS
+      hostname: "*.i.anyscaleuserdata.com"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: anyscale-${ANYSCALE_CLOUD_RESOURCE_DNS_ID}-certificate
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https-session
+      port: 443
+      protocol: HTTPS
+      hostname: "*.s.anyscaleuserdata.com"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: anyscale-svc-${ANYSCALE_CLOUD_RESOURCE_DNS_ID}-certificate
+      allowedRoutes:
+        namespaces:
+          from: All
+EOF
+
+kubectl apply -f "${RENDER_DIR}/envoyproxy.yaml"
+kubectl apply -f "${RENDER_DIR}/gatewayclass.yaml"
+kubectl apply -f "${RENDER_DIR}/gateway.yaml"
+
+echo "Waiting for Gateway address..."
+kubectl wait --for=condition=Programmed gateway/gateway \
+  -n anyscale-operator \
+  --timeout=300s || true
+
+GATEWAY_ADDRESS=""
+for _ in {1..60}; do
+  GATEWAY_ADDRESS="$(
+    kubectl get gateway gateway -n anyscale-operator \
+      -o jsonpath='{.status.addresses[0].value}' 2>/dev/null || true
+  )"
+  if [[ -n "$GATEWAY_ADDRESS" ]]; then
+    break
+  fi
+  sleep 10
+done
+
+if [[ -z "$GATEWAY_ADDRESS" ]]; then
+  echo "Gateway address did not become available." >&2
+  kubectl get gateway gateway -n anyscale-operator -o yaml >&2 || true
+  exit 1
+fi
+
+echo "Gateway address: ${GATEWAY_ADDRESS}"
+
+cat >"${RENDER_DIR}/values.yaml" <<EOF
+global:
+  cloudDeploymentId: ${ANYSCALE_CLOUD_RESOURCE_ID}
+  cloudProvider: aws
+  aws:
+    region: ${AWS_REGION}
+
+networking:
+  gateway:
+    enabled: true
+    name: gateway
+    namespace: anyscale-operator
+    apiVersion: gateway.networking.k8s.io/v1
+    hostname: ${GATEWAY_ADDRESS}
+
+workloads:
+  serviceAccount:
+    name: anyscale-operator
+  instanceTypes:
+    validationHook:
+      enabled: false
+    additional:
+      P5-48XLARGE-8xH100-EFA:
+        resources:
+          CPU: 190
+          memory: 1800Gi
+          GPU: 8
+          'accelerator_type:H100': 8
+          vpc.amazonaws.com/efa: 32
+        accelerators:
+          - H100
+        nodeSelector:
+          workload: ${EFA_WORKLOAD_NAME}
+          nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3
+          vpc.amazonaws.com/efa.present: "true"
+        tolerations:
+          - key: nvidia.com/gpu
+            operator: Equal
+            value: present
+            effect: NoSchedule
+          - key: node.anyscale.com/accelerator-type
+            operator: Equal
+            value: GPU
+            effect: NoSchedule
+          - key: node.anyscale.com/capacity-type
+            operator: Equal
+            value: CAPACITY_RESERVATION
+            effect: NoSchedule
+          - key: workload
+            operator: Equal
+            value: ${EFA_WORKLOAD_NAME}
+            effect: NoSchedule
+
+operator:
+  container:
+    image:
+      registry: ${ECR_REGISTRY}
+      image: ${ECR_MIRROR_PREFIX}/anyscale/kubernetes_manager
+      tag: ci-2c43cde542a2c6e856c6e49bc99812d7d2f78e17
+  vector:
+    image:
+      registry: ${ECR_REGISTRY}
+      image: ${ECR_MIRROR_PREFIX}/timberio/vector
+      tag: 0.40.0-debian
+EOF
+
+echo "Installing/upgrading Anyscale Operator..."
+if ! helm upgrade anyscale-operator anyscale/anyscale-operator \
+  --namespace anyscale-operator \
+  --version 1.7.0 \
+  --values "${RENDER_DIR}/values.yaml" \
+  --create-namespace \
+  --install \
+  --wait \
+  --timeout "$HELM_TIMEOUT"; then
+  collect_anyscale_operator_diagnostics
+  exit 1
+fi
+
+echo "Helm add-ons installed/upgraded."
+helm list -A

--- a/examples/aws/eks-public-efa/main.tf
+++ b/examples/aws/eks-public-efa/main.tf
@@ -16,10 +16,16 @@ locals {
 module "anyscale_vpc" {
   #checkov:skip=CKV_TF_1: Example code should use the latest version of the module
   #checkov:skip=CKV_TF_2: Example code should use the latest version of the module
-  source = "github.com/anyscale/terraform-aws-anyscale-cloudfoundation-modules//modules/aws-anyscale-vpc"
+  source = "github.com/anyscale/terraform-aws-anyscale-cloudfoundation-modules//modules/aws-anyscale-vpc?ref=v0.38.0"
 
   anyscale_vpc_name = "anyscale-${var.eks_cluster_name}"
   cidr_block        = "172.24.0.0/16"
+
+  # Optional pin for the VPC / EKS control-plane AZs. Leave empty to let the
+  # module auto-select. Pin only if you need EKS-supported AZs with NAT-gateway-
+  # per-AZ quota headroom. The EFA P5 node group always runs in its own dedicated
+  # subnet in the capacity-reservation AZ, independent of these.
+  availability_zones = var.control_plane_availability_zones
 
   public_subnets  = local.public_subnets
   private_subnets = local.private_subnets
@@ -36,7 +42,7 @@ module "anyscale_vpc" {
 module "anyscale_s3" {
   #checkov:skip=CKV_TF_1: Example code should use the latest version of the module
   #checkov:skip=CKV_TF_2: Example code should use the latest version of the module
-  source = "github.com/anyscale/terraform-aws-anyscale-cloudfoundation-modules//modules/aws-anyscale-s3"
+  source = "github.com/anyscale/terraform-aws-anyscale-cloudfoundation-modules//modules/aws-anyscale-s3?ref=v0.38.0"
 
   module_enabled = true
 
@@ -75,7 +81,7 @@ resource "aws_security_group" "allow_all_vpc" {
 module "anyscale_efs" {
   #checkov:skip=CKV_TF_1: Example code should use the latest version of the module
   #checkov:skip=CKV_TF_2: Example code should use the latest version of the module
-  source = "github.com/anyscale/terraform-aws-anyscale-cloudfoundation-modules//modules/aws-anyscale-efs"
+  source = "github.com/anyscale/terraform-aws-anyscale-cloudfoundation-modules//modules/aws-anyscale-efs?ref=v0.38.0"
 
   module_enabled = var.enable_efs
 
@@ -92,7 +98,7 @@ module "anyscale_efs" {
 module "anyscale_iam_roles" {
   #checkov:skip=CKV_TF_1: Example code should use the latest version of the module
   #checkov:skip=CKV_TF_2: Example code should use the latest version of the module
-  source = "github.com/anyscale/terraform-aws-anyscale-cloudfoundation-modules//modules/aws-anyscale-iam"
+  source = "github.com/anyscale/terraform-aws-anyscale-cloudfoundation-modules//modules/aws-anyscale-iam?ref=v0.38.0"
 
   module_enabled = true
 

--- a/examples/aws/eks-public-efa/main.tf
+++ b/examples/aws/eks-public-efa/main.tf
@@ -1,0 +1,106 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Example Anyscale K8s Resources - Public Networking
+#   This template creates EKS resources for Anyscale
+#   It creates:
+#     - VPC
+#     - EFS
+#     - S3 Bucket
+#     - IAM policies
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  public_subnets  = ["172.24.101.0/24", "172.24.102.0/24"]
+  private_subnets = ["172.24.20.0/24", "172.24.21.0/24"]
+}
+
+module "anyscale_vpc" {
+  #checkov:skip=CKV_TF_1: Example code should use the latest version of the module
+  #checkov:skip=CKV_TF_2: Example code should use the latest version of the module
+  source = "github.com/anyscale/terraform-aws-anyscale-cloudfoundation-modules//modules/aws-anyscale-vpc"
+
+  anyscale_vpc_name = "anyscale-${var.eks_cluster_name}"
+  cidr_block        = "172.24.0.0/16"
+
+  public_subnets  = local.public_subnets
+  private_subnets = local.private_subnets
+
+  public_subnet_tags = {
+    "kubernetes.io/role/elb" = "1"
+  }
+  private_subnet_tags = {
+    "kubernetes.io/role/internal-elb" = "1"
+  }
+}
+
+#trivy:ignore:avd-aws-0132
+module "anyscale_s3" {
+  #checkov:skip=CKV_TF_1: Example code should use the latest version of the module
+  #checkov:skip=CKV_TF_2: Example code should use the latest version of the module
+  source = "github.com/anyscale/terraform-aws-anyscale-cloudfoundation-modules//modules/aws-anyscale-s3"
+
+  module_enabled = true
+
+  anyscale_bucket_name = "${var.eks_cluster_name}-${var.aws_region}"
+
+  tags = var.tags
+}
+
+#trivy:ignore:avd-aws-0104
+resource "aws_security_group" "allow_all_vpc" {
+  #checkov:skip=CKV2_AWS_5: "Ensure that Security Groups are attached to another resource"
+  #checkov:skip=CKV_AWS_382: "Egress is allowed to the internet for the Anyscale Control Plane and other services."
+  name        = "allow-all-vpc"
+  description = "Allow all traffic within the VPC"
+  vpc_id      = module.anyscale_vpc.vpc_id
+
+  ingress {
+    description = "Allow all traffic from within the VPC"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = [module.anyscale_vpc.vpc_cidr_block]
+  }
+
+  egress {
+    description = "Allow all traffic to the internet"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = var.tags
+}
+
+module "anyscale_efs" {
+  #checkov:skip=CKV_TF_1: Example code should use the latest version of the module
+  #checkov:skip=CKV_TF_2: Example code should use the latest version of the module
+  source = "github.com/anyscale/terraform-aws-anyscale-cloudfoundation-modules//modules/aws-anyscale-efs"
+
+  module_enabled = var.enable_efs
+
+  anyscale_efs_name          = "anyscale-${var.eks_cluster_name}"
+  mount_targets_subnet_count = length(local.private_subnets)
+  mount_targets_subnets      = module.anyscale_vpc.private_subnet_ids
+
+  associated_security_group_ids = [aws_security_group.allow_all_vpc.id]
+
+  tags = var.tags
+}
+
+#trivy:ignore:avd-aws-0342
+module "anyscale_iam_roles" {
+  #checkov:skip=CKV_TF_1: Example code should use the latest version of the module
+  #checkov:skip=CKV_TF_2: Example code should use the latest version of the module
+  source = "github.com/anyscale/terraform-aws-anyscale-cloudfoundation-modules//modules/aws-anyscale-iam"
+
+  module_enabled = true
+
+  create_anyscale_access_role          = false
+  create_cluster_node_instance_profile = false
+
+  create_iam_s3_policy   = true
+  anyscale_s3_bucket_arn = module.anyscale_s3.s3_bucket_arn
+
+  tags = var.tags
+}

--- a/examples/aws/eks-public-efa/outputs.tf
+++ b/examples/aws/eks-public-efa/outputs.tf
@@ -1,0 +1,52 @@
+locals {
+  kubernetes_zones = join(",", module.anyscale_vpc.availability_zones)
+}
+
+data "aws_iam_role" "default_nodegroup" {
+  name = module.eks.eks_managed_node_groups["default"].iam_role_name
+}
+
+output "eks_cluster_name" {
+  description = "The name of the EKS cluster. This is used for Helm chart values."
+  value       = var.eks_cluster_name
+}
+
+output "aws_region" {
+  description = "The AWS region. This is used for Helm chart values."
+  value       = var.aws_region
+}
+
+locals {
+  registration_command_parts = compact([
+    "anyscale cloud register",
+    "--name <anyscale_cloud_name>",
+    "--region ${var.aws_region}",
+    "--provider aws",
+    "--compute-stack k8s",
+    "--kubernetes-zones ${local.kubernetes_zones}",
+    "--s3-bucket-id ${module.anyscale_s3.s3_bucket_id}",
+    var.enable_efs ? "--efs-id ${module.anyscale_efs.efs_id}" : null,
+    "--anyscale-operator-iam-identity ${data.aws_iam_role.default_nodegroup.arn}",
+  ])
+
+  helm_upgrade_command_parts = compact([
+    "helm upgrade anyscale-operator anyscale/anyscale-operator",
+    "--set-string global.cloudDeploymentId=<cloud-deployment-id>",
+    "--set-string global.cloudProvider=aws",
+    "--set-string global.aws.region=${var.aws_region}",
+    "--set-string workloads.serviceAccount.name=anyscale-operator",
+    "--namespace anyscale-operator",
+    "--create-namespace",
+    "-i"
+  ])
+}
+
+output "anyscale_registration_command" {
+  description = "The Anyscale registration command."
+  value       = join(" \\\n\t", local.registration_command_parts)
+}
+
+output "helm_upgrade_command" {
+  description = "The helm upgrade command."
+  value       = join(" \\\n\t", local.helm_upgrade_command_parts)
+}

--- a/examples/aws/eks-public-efa/outputs.tf
+++ b/examples/aws/eks-public-efa/outputs.tf
@@ -50,3 +50,8 @@ output "helm_upgrade_command" {
   description = "The helm upgrade command."
   value       = join(" \\\n\t", local.helm_upgrade_command_parts)
 }
+
+output "gateway_nlb_security_group_id" {
+  description = "Security group ID attached to the Anyscale Envoy Gateway NLB frontend."
+  value       = aws_security_group.gateway_nlb.id
+}

--- a/examples/aws/eks-public-efa/provision-aws-efa-anyscale.sh
+++ b/examples/aws/eks-public-efa/provision-aws-efa-anyscale.sh
@@ -1,0 +1,1624 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK_DIR="$(pwd)"
+DEFAULT_EXAMPLE_DIR="${SCRIPT_DIR}"
+EXAMPLE_DIR="${EXAMPLE_DIR:-${DEFAULT_EXAMPLE_DIR}}"
+
+AWS_PROFILE="${AWS_PROFILE:-}"
+AWS_REGION="${AWS_REGION:-us-east-1}"
+AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-$AWS_REGION}"
+CLOUD_NAME="${CLOUD_NAME:-}"
+EKS_CLUSTER_NAME="${EKS_CLUSTER_NAME:-}"
+ANYSCALE_CLOUD_NAME="${ANYSCALE_CLOUD_NAME:-}"
+EFA_CAPACITY_RESERVATION_ID="${EFA_CAPACITY_RESERVATION_ID:-}"
+EFA_EXPECTED_INSTANCE_TYPE="${EFA_EXPECTED_INSTANCE_TYPE:-p5.48xlarge}"
+EFA_WORKER_COUNT="${EFA_WORKER_COUNT:-2}"
+EFA_WORKLOAD_NAME="${EFA_WORKLOAD_NAME:-efa}"
+EFA_PRIVATE_SUBNET_CIDR="${EFA_PRIVATE_SUBNET_CIDR:-}"
+NODE_GROUP_DISK_SIZE="${NODE_GROUP_DISK_SIZE:-1000}"
+ENABLE_EFS="${ENABLE_EFS:-false}"
+TAGS_ENVIRONMENT="${TAGS_ENVIRONMENT:-dev}"
+TAGS_TTL_HOURS="${TAGS_TTL_HOURS:-200}"
+TAGS_ANYSCALE_USER="${TAGS_ANYSCALE_USER:-anyscale-efa}"
+TAGS_ANYSCALE_CUSTODIAN="${TAGS_ANYSCALE_CUSTODIAN:-ignore}"
+ECR_REGISTRY="${ECR_REGISTRY:-}"
+ECR_MIRROR_PREFIX="${ECR_MIRROR_PREFIX:-}"
+ANYSCALE_CLOUD_RESOURCE_ID="${ANYSCALE_CLOUD_RESOURCE_ID:-}"
+TF_WORKSPACE_NAME="${TF_WORKSPACE_NAME:-}"
+RUN_DIR="${RUN_DIR:-}"
+RUNTIME_IMAGE_URI="${RUNTIME_IMAGE_URI:-anyscale/image/anyscale-ray-2.55.1-cu128-torch2.8-efa-uccl:1}"
+RUNTIME_RAY_VERSION="${RUNTIME_RAY_VERSION:-2.55.1}"
+RUNTIME_VALIDATION_ACTIONS="${RUNTIME_VALIDATION_ACTIONS:-quick,nccl,uccl-ll,uccl-ht}"
+RUNTIME_WORKSPACE_NAME="${RUNTIME_WORKSPACE_NAME:-}"
+RUNTIME_COMPUTE_CONFIG_NAME="${RUNTIME_COMPUTE_CONFIG_NAME:-}"
+RUNTIME_WAIT_TIMEOUT_SECONDS="${RUNTIME_WAIT_TIMEOUT_SECONDS:-2400}"
+RUNTIME_KUBECTL_WAIT_TIMEOUT="${RUNTIME_KUBECTL_WAIT_TIMEOUT:-1200s}"
+EFA_NODEGROUP_MAX_SIZE="${EFA_NODEGROUP_MAX_SIZE:-4}"
+EFA_WARMUP_TIMEOUT_SECONDS="${EFA_WARMUP_TIMEOUT_SECONDS:-1800}"
+RUNTIME_WARMUP="${RUNTIME_WARMUP:-true}"
+RUNTIME_PREPULL_IMAGE="${RUNTIME_PREPULL_IMAGE:-true}"
+RUNTIME_PREPULL_TIMEOUT_SECONDS="${RUNTIME_PREPULL_TIMEOUT_SECONDS:-1800}"
+ANYSCALE_CLOUD_ID="${ANYSCALE_CLOUD_ID:-}"
+ANYSCALE_CLOUD_REGISTRY="${ANYSCALE_CLOUD_REGISTRY:-}"
+
+APPLY=0
+SKIP_REGISTER=0
+SKIP_HELM=0
+SKIP_VERIFY=0
+RUN_RUNTIME_VALIDATION=0
+KEEP_RUNTIME_WORKSPACE=1
+RUNTIME_WORKSPACE_ID=""
+RUNTIME_COMPUTE_CONFIG_REF=""
+VALIDATION_CLEANUP_DONE=0
+WARMUP_NODEGROUP_ACTIVE=0
+
+usage() {
+  cat <<EOF
+Usage:
+  CLOUD_NAME=<name> EFA_CAPACITY_RESERVATION_ID=cr-... $0 [--apply]
+
+Required input:
+  CLOUD_NAME or both EKS_CLUSTER_NAME and ANYSCALE_CLOUD_NAME
+  AWS_PROFILE
+  EFA_CAPACITY_RESERVATION_ID
+  EFA_PRIVATE_SUBNET_CIDR
+  ECR_REGISTRY and ECR_MIRROR_PREFIX, unless --skip-helm is used
+
+Common options:
+  --apply                         Create/update AWS resources, register the Anyscale cloud, and install Helm add-ons.
+  --name NAME                     Set both EKS_CLUSTER_NAME and ANYSCALE_CLOUD_NAME.
+  --eks-cluster-name NAME         AWS EKS cluster name. Defaults to CLOUD_NAME.
+  --anyscale-cloud-name NAME      Anyscale cloud name. Defaults to CLOUD_NAME.
+  --capacity-reservation-id ID    EC2 Capacity Reservation ID, cr-...
+  --worker-count N                Required available p5 capacity for validation. Default: ${EFA_WORKER_COUNT}
+  --efa-workload-name NAME        Workload label/name for the P5/H100 EFA node group. Default: ${EFA_WORKLOAD_NAME}
+  EFA_PRIVATE_SUBNET_CIDR         Private subnet CIDR for the EFA node group.
+  --ttl-hours HOURS               AWS Cloud Custodian ttl-hours tag for EC2 instances. Default: ${TAGS_TTL_HOURS}
+  --custodian-user VALUE          anyscale-user tag value for Custodian bypass. Default: ${TAGS_ANYSCALE_USER}
+  --terraform-workspace NAME      Terraform workspace. Default: efa-<EKS_CLUSTER_NAME>.
+  --validate-runtime              Launch an Anyscale workspace, run EFA/NCCL/UCCL validation, and leave it running.
+  --validation-actions LIST       Comma-separated actions. Default: ${RUNTIME_VALIDATION_ACTIONS}
+  --docker-image URI              Validation workspace Docker image. Default: ${RUNTIME_IMAGE_URI}
+  --runtime-image-uri URI         Alias for --docker-image.
+  --workspace-image-uri URI       Alias for --docker-image.
+  --image-uri URI                 Alias for --docker-image.
+  --workspace-name NAME           Validation workspace name. Default: timestamped name.
+  --compute-config-name NAME      Validation compute config name. Default: workspace name.
+  --keep-workspace                Deprecated no-op; validation workspaces are always left running.
+  --skip-runtime-warmup           Do not pre-scale and wait for the EFA node group before validation.
+  --skip-image-prepull            Warm EFA nodes, but do not pre-pull the validation image.
+  --skip-register                 Do not run anyscale cloud register. Requires ANYSCALE_CLOUD_RESOURCE_ID for Helm.
+  --skip-helm                     Do not install Kubernetes Helm add-ons.
+  --skip-verify                   Do not run anyscale cloud verify/status.
+  -h, --help                      Show this help.
+
+Plan-only mode is the default and does not create resources.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply)
+      APPLY=1
+      shift
+      ;;
+    --name)
+      CLOUD_NAME="${2:?Missing value for --name}"
+      shift 2
+      ;;
+    --eks-cluster-name)
+      EKS_CLUSTER_NAME="${2:?Missing value for --eks-cluster-name}"
+      shift 2
+      ;;
+    --anyscale-cloud-name)
+      ANYSCALE_CLOUD_NAME="${2:?Missing value for --anyscale-cloud-name}"
+      shift 2
+      ;;
+    --capacity-reservation-id)
+      EFA_CAPACITY_RESERVATION_ID="${2:?Missing value for --capacity-reservation-id}"
+      shift 2
+      ;;
+    --worker-count)
+      EFA_WORKER_COUNT="${2:?Missing value for --worker-count}"
+      shift 2
+      ;;
+    --efa-workload-name)
+      EFA_WORKLOAD_NAME="${2:?Missing value for --efa-workload-name}"
+      shift 2
+      ;;
+    --ttl-hours)
+      TAGS_TTL_HOURS="${2:?Missing value for --ttl-hours}"
+      shift 2
+      ;;
+    --custodian-user)
+      TAGS_ANYSCALE_USER="${2:?Missing value for --custodian-user}"
+      shift 2
+      ;;
+    --terraform-workspace)
+      TF_WORKSPACE_NAME="${2:?Missing value for --terraform-workspace}"
+      shift 2
+      ;;
+    --validate-runtime)
+      RUN_RUNTIME_VALIDATION=1
+      shift
+      ;;
+    --validation-actions)
+      RUNTIME_VALIDATION_ACTIONS="${2:?Missing value for --validation-actions}"
+      shift 2
+      ;;
+    --docker-image|--runtime-image-uri|--workspace-image-uri|--image-uri)
+      RUNTIME_IMAGE_URI="${2:?Missing value for $1}"
+      shift 2
+      ;;
+    --workspace-name)
+      RUNTIME_WORKSPACE_NAME="${2:?Missing value for --workspace-name}"
+      shift 2
+      ;;
+    --compute-config-name)
+      RUNTIME_COMPUTE_CONFIG_NAME="${2:?Missing value for --compute-config-name}"
+      shift 2
+      ;;
+    --keep-workspace)
+      KEEP_RUNTIME_WORKSPACE=1
+      shift
+      ;;
+    --skip-runtime-warmup)
+      RUNTIME_WARMUP=false
+      shift
+      ;;
+    --skip-image-prepull)
+      RUNTIME_PREPULL_IMAGE=false
+      shift
+      ;;
+    --skip-register)
+      SKIP_REGISTER=1
+      shift
+      ;;
+    --skip-helm)
+      SKIP_HELM=1
+      shift
+      ;;
+    --skip-verify)
+      SKIP_VERIFY=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+export AWS_PROFILE AWS_REGION AWS_DEFAULT_REGION
+export PATH="$HOME/.local/bin:$PATH"
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+bool_is_true() {
+  case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+    1|true|yes|y|on)
+      return 0
+      ;;
+    0|false|no|n|off)
+      return 1
+      ;;
+    *)
+      echo "Expected boolean value for $2, got: $1" >&2
+      exit 1
+      ;;
+  esac
+}
+
+require_dnsish_name() {
+  local label="$1"
+  local value="$2"
+  if [[ ! "$value" =~ ^[a-z0-9][a-z0-9-]*[a-z0-9]$ ]]; then
+    echo "${label} must be lowercase DNS-style text: letters, numbers, hyphens, no leading/trailing hyphen." >&2
+    echo "Got: ${value}" >&2
+    exit 1
+  fi
+}
+
+sanitize_workspace_name() {
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9_-]+/-/g; s/^-+//; s/-+$//'
+}
+
+assert_terraform_workspace() {
+  local current_workspace
+
+  current_workspace="$(terraform workspace show)"
+  if [[ "$current_workspace" != "$TF_WORKSPACE_NAME" ]]; then
+    echo "Terraform workspace mismatch." >&2
+    echo "Expected: ${TF_WORKSPACE_NAME}" >&2
+    echo "Current:  ${current_workspace}" >&2
+    exit 1
+  fi
+}
+
+assert_terraform_outputs_match_run() {
+  local output_cluster_name
+
+  assert_terraform_workspace
+  output_cluster_name="$(terraform output -raw eks_cluster_name 2>/dev/null || true)"
+  if [[ -n "$output_cluster_name" && "$output_cluster_name" != "$EKS_CLUSTER_NAME" ]]; then
+    echo "Terraform output mismatch: eks_cluster_name does not match this run." >&2
+    echo "Expected: ${EKS_CLUSTER_NAME}" >&2
+    echo "Output:   ${output_cluster_name}" >&2
+    echo "Refusing to register or install Anyscale against stale Terraform state." >&2
+    exit 1
+  fi
+}
+
+registration_arg() {
+  local command_text="$1"
+  local arg_name="$2"
+
+  printf '%s\n' "$command_text" |
+    sed -n "s/^[[:space:]]*${arg_name}[[:space:]]*//p" |
+    head -1 |
+    sed -E 's/[[:space:]]*\\[[:space:]]*$//; s/^[[:space:]]+//; s/[[:space:]]+$//'
+}
+
+kubectl_context_number() {
+  local target_context="$1"
+  local context
+  local index=0
+
+  while IFS= read -r context; do
+    index=$((index + 1))
+    if [[ "$context" == "$target_context" ]]; then
+      printf '%s\n' "$index"
+      return 0
+    fi
+  done < <(kubectl config get-contexts -o name)
+
+  return 1
+}
+
+runtime_image_has_registry() {
+  local first_component="${1%%/*}"
+
+  [[ "$1" == */* ]] && [[ "$first_component" == *.* || "$first_component" == *:* || "$first_component" == "localhost" ]]
+}
+
+cloud_id_to_dns() {
+  printf '%s' "$1" | tr '_' '-'
+}
+
+find_existing_anyscale_cloud_resource() {
+  local expected_s3_bucket="$1"
+  local expected_operator_identity="$2"
+  local cloud_get_file="${RUN_DIR}/anyscale-cloud-get-existing.yaml"
+  local cloud_get_log="${RUN_DIR}/anyscale-cloud-get-existing.log"
+
+  if ! anyscale cloud get --name "$ANYSCALE_CLOUD_NAME" -o "$cloud_get_file" >"$cloud_get_log" 2>&1; then
+    return 1
+  fi
+
+  awk \
+    -v expected_bucket="s3://${expected_s3_bucket}" \
+    -v expected_identity="$expected_operator_identity" '
+      function trim(value) {
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+        return value
+      }
+      function maybe_print_match() {
+        if (resource_id != "" && bucket_name == expected_bucket && operator_identity == expected_identity) {
+          print resource_id
+          found = 1
+          exit
+        }
+      }
+      /^[[:space:]]*-[[:space:]]*cloud_resource_id:[[:space:]]*/ {
+        maybe_print_match()
+        value = $0
+        sub(/^[[:space:]]*-[[:space:]]*cloud_resource_id:[[:space:]]*/, "", value)
+        resource_id = trim(value)
+        bucket_name = ""
+        operator_identity = ""
+        next
+      }
+      /^[[:space:]]*bucket_name:[[:space:]]*/ {
+        value = $0
+        sub(/^[[:space:]]*bucket_name:[[:space:]]*/, "", value)
+        bucket_name = trim(value)
+        next
+      }
+      /^[[:space:]]*anyscale_operator_iam_identity:[[:space:]]*/ {
+        value = $0
+        sub(/^[[:space:]]*anyscale_operator_iam_identity:[[:space:]]*/, "", value)
+        operator_identity = trim(value)
+        next
+      }
+      END {
+        if (!found) {
+          maybe_print_match()
+        }
+      }
+    ' "$cloud_get_file"
+}
+
+verify_anyscale_cloud_resource() {
+  local expected_s3_bucket="$1"
+  local expected_operator_identity="$2"
+  local cloud_get_file="${RUN_DIR}/anyscale-cloud-get-after-register.yaml"
+  local cloud_get_log="${RUN_DIR}/anyscale-cloud-get-after-register.log"
+
+  if [[ -z "$ANYSCALE_CLOUD_RESOURCE_ID" ]]; then
+    return 0
+  fi
+
+  echo "Verifying Anyscale cloud resource matches Terraform outputs..."
+  if ! anyscale cloud get --name "$ANYSCALE_CLOUD_NAME" -o "$cloud_get_file" >"$cloud_get_log" 2>&1; then
+    cat "$cloud_get_log" >&2
+    echo "Could not read Anyscale cloud metadata for ${ANYSCALE_CLOUD_NAME}." >&2
+    exit 1
+  fi
+
+  if ! grep -q "cloud_resource_id: ${ANYSCALE_CLOUD_RESOURCE_ID}$" "$cloud_get_file"; then
+    cat "$cloud_get_file" >&2
+    echo "Anyscale cloud ${ANYSCALE_CLOUD_NAME} does not include resource ${ANYSCALE_CLOUD_RESOURCE_ID}." >&2
+    exit 1
+  fi
+
+  if [[ -n "$expected_s3_bucket" ]] && ! grep -q "bucket_name: s3://${expected_s3_bucket}$" "$cloud_get_file"; then
+    cat "$cloud_get_file" >&2
+    echo "Anyscale cloud resource is using a different S3 bucket than Terraform output." >&2
+    echo "Expected bucket: s3://${expected_s3_bucket}" >&2
+    exit 1
+  fi
+
+  if [[ -n "$expected_operator_identity" ]] && ! grep -q "anyscale_operator_iam_identity: ${expected_operator_identity}$" "$cloud_get_file"; then
+    cat "$cloud_get_file" >&2
+    echo "Anyscale cloud resource is using a different operator IAM identity than Terraform output." >&2
+    echo "Expected identity: ${expected_operator_identity}" >&2
+    exit 1
+  fi
+}
+
+if [[ -n "$CLOUD_NAME" ]]; then
+  EKS_CLUSTER_NAME="${EKS_CLUSTER_NAME:-$CLOUD_NAME}"
+  ANYSCALE_CLOUD_NAME="${ANYSCALE_CLOUD_NAME:-$CLOUD_NAME}"
+fi
+
+if [[ -z "$EKS_CLUSTER_NAME" && -n "$ANYSCALE_CLOUD_NAME" ]]; then
+  EKS_CLUSTER_NAME="$ANYSCALE_CLOUD_NAME"
+fi
+
+if [[ -z "$ANYSCALE_CLOUD_NAME" && -n "$EKS_CLUSTER_NAME" ]]; then
+  ANYSCALE_CLOUD_NAME="$EKS_CLUSTER_NAME"
+fi
+
+if [[ -z "$EKS_CLUSTER_NAME" || -z "$ANYSCALE_CLOUD_NAME" ]]; then
+  echo "Set CLOUD_NAME, or set both EKS_CLUSTER_NAME and ANYSCALE_CLOUD_NAME." >&2
+  usage >&2
+  exit 1
+fi
+
+if [[ -z "$EFA_CAPACITY_RESERVATION_ID" ]]; then
+  echo "Set EFA_CAPACITY_RESERVATION_ID=cr-... before running this script." >&2
+  exit 1
+fi
+
+if [[ -z "$EFA_PRIVATE_SUBNET_CIDR" ]]; then
+  echo "Set EFA_PRIVATE_SUBNET_CIDR to the private subnet CIDR for the EFA node group." >&2
+  exit 1
+fi
+
+if [[ -z "$AWS_PROFILE" ]]; then
+  echo "Set AWS_PROFILE to the named AWS CLI profile to use for this deployment." >&2
+  exit 1
+fi
+
+if [[ ! -d "$EXAMPLE_DIR" ]]; then
+  echo "EXAMPLE_DIR does not exist: ${EXAMPLE_DIR}" >&2
+  echo "Set EXAMPLE_DIR to the terraform-kubernetes-anyscale-foundation-modules/examples/aws/eks-public-efa path." >&2
+  exit 1
+fi
+
+if [[ ! "$EFA_WORKER_COUNT" =~ ^[0-9]+$ ]]; then
+  echo "EFA_WORKER_COUNT must be a non-negative integer. Got: ${EFA_WORKER_COUNT}" >&2
+  exit 1
+fi
+
+if [[ ! "$TAGS_TTL_HOURS" =~ ^[0-9]+$ ]]; then
+  echo "TAGS_TTL_HOURS must be a non-negative integer. Got: ${TAGS_TTL_HOURS}" >&2
+  exit 1
+fi
+if [[ -z "$TAGS_ANYSCALE_USER" ]]; then
+  echo "TAGS_ANYSCALE_USER must be non-empty." >&2
+  exit 1
+fi
+if [[ "$TAGS_ANYSCALE_CUSTODIAN" != "ignore" ]]; then
+  echo "TAGS_ANYSCALE_CUSTODIAN must be 'ignore' for this automation's protected-node tagging flow. Got: ${TAGS_ANYSCALE_CUSTODIAN}" >&2
+  exit 1
+fi
+
+if (( SKIP_HELM == 0 )); then
+  if [[ -z "$ECR_REGISTRY" || -z "$ECR_MIRROR_PREFIX" ]]; then
+    echo "Set ECR_REGISTRY and ECR_MIRROR_PREFIX before installing Helm add-ons, or use --skip-helm." >&2
+    exit 1
+  fi
+fi
+
+bool_is_true "$RUNTIME_WARMUP" RUNTIME_WARMUP || true
+bool_is_true "$RUNTIME_PREPULL_IMAGE" RUNTIME_PREPULL_IMAGE || true
+
+require_dnsish_name "EKS_CLUSTER_NAME" "$EKS_CLUSTER_NAME"
+require_dnsish_name "ANYSCALE_CLOUD_NAME" "$ANYSCALE_CLOUD_NAME"
+require_dnsish_name "EFA_WORKLOAD_NAME" "$EFA_WORKLOAD_NAME"
+
+if (( ${#EKS_CLUSTER_NAME} + ${#AWS_REGION} + 1 > 63 )); then
+  echo "The generated S3 bucket name '${EKS_CLUSTER_NAME}-${AWS_REGION}' would exceed 63 characters." >&2
+  exit 1
+fi
+
+if [[ -z "$TF_WORKSPACE_NAME" ]]; then
+  TF_WORKSPACE_NAME="efa-$(sanitize_workspace_name "$EKS_CLUSTER_NAME")"
+fi
+
+if (( RUN_RUNTIME_VALIDATION == 1 && APPLY == 0 )); then
+  echo "--validate-runtime requires --apply because it launches an Anyscale workspace." >&2
+  exit 1
+fi
+
+if (( RUN_RUNTIME_VALIDATION == 1 && EFA_WORKER_COUNT == 0 )); then
+  echo "--validate-runtime requires --worker-count greater than zero." >&2
+  exit 1
+fi
+
+if (( RUN_RUNTIME_VALIDATION == 1 )); then
+  validation_suffix="$(date +%Y%m%d-%H%M%S)"
+  if [[ -z "$RUNTIME_WORKSPACE_NAME" ]]; then
+    RUNTIME_WORKSPACE_NAME="${ANYSCALE_CLOUD_NAME}-p5-validation-${validation_suffix}"
+  fi
+  if [[ -z "$RUNTIME_COMPUTE_CONFIG_NAME" ]]; then
+    RUNTIME_COMPUTE_CONFIG_NAME="$RUNTIME_WORKSPACE_NAME"
+  fi
+fi
+
+if [[ -z "$RUN_DIR" ]]; then
+  RUN_DIR="${WORK_DIR}/runs/${EKS_CLUSTER_NAME}"
+fi
+
+TFVARS_FILE="${RUN_DIR}/terraform.tfvars"
+PLAN_FILE="${RUN_DIR}/tfplan"
+OUTPUT_ENV_FILE="${RUN_DIR}/outputs.env"
+RUNTIME_COMPUTE_CONFIG_FILE="${RUN_DIR}/p5-validation-compute.yaml"
+RUNTIME_WORKSPACE_FILE="${RUN_DIR}/p5-validation-workspace.yaml"
+
+need aws
+need terraform
+
+if (( APPLY == 1 )); then
+  if (( SKIP_REGISTER == 0 || SKIP_VERIFY == 0 || RUN_RUNTIME_VALIDATION == 1 )); then
+    need anyscale
+  fi
+  if (( SKIP_HELM == 0 || RUN_RUNTIME_VALIDATION == 1 )); then
+    need kubectl
+  fi
+  if (( SKIP_HELM == 0 )); then
+    need helm
+  fi
+fi
+
+runtime_nodegroup_name() {
+  printf '%s-%s-nodegroup' "$EKS_CLUSTER_NAME" "$EFA_WORKLOAD_NAME"
+}
+
+runtime_node_selector() {
+  printf 'workload=%s,node.kubernetes.io/instance-type=%s' "$EFA_WORKLOAD_NAME" "$EFA_EXPECTED_INSTANCE_TYPE"
+}
+
+count_target_efa_instances() {
+  aws ec2 describe-instances \
+    --profile "$AWS_PROFILE" \
+    --region "$AWS_REGION" \
+    --filters \
+      "Name=tag:eks:nodegroup-name,Values=$(runtime_nodegroup_name)" \
+      "Name=instance-type,Values=${EFA_EXPECTED_INSTANCE_TYPE}" \
+      "Name=instance-state-name,Values=pending,running" \
+    --query 'Reservations[].Instances[].InstanceId' \
+    --output text |
+    wc -w |
+    tr -d ' '
+}
+
+tag_cluster_instances_for_gc() {
+  local log_file="${1:-${RUN_DIR}/cluster-instance-custodian-tags.log}"
+  local instance_ids_text
+  local instance_ids=()
+
+  instance_ids_text="$(
+    aws ec2 describe-instances \
+      --profile "$AWS_PROFILE" \
+      --region "$AWS_REGION" \
+      --filters \
+        "Name=tag:Project,Values=${EKS_CLUSTER_NAME}" \
+        "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+      --query 'Reservations[].Instances[].InstanceId' \
+      --output text
+  )"
+
+  if [[ -z "$instance_ids_text" || "$instance_ids_text" == "None" ]]; then
+    echo "No current EC2 instances found for Project=${EKS_CLUSTER_NAME}; Custodian tags not applied." | tee "$log_file"
+    return 0
+  fi
+
+  read -r -a instance_ids <<<"$instance_ids_text"
+  {
+    echo "Tagging ${#instance_ids[@]} EC2 instance(s) for Cloud Custodian bypass."
+    printf '  %s\n' "${instance_ids[@]}"
+    aws ec2 create-tags \
+      --profile "$AWS_PROFILE" \
+      --region "$AWS_REGION" \
+      --resources "${instance_ids[@]}" \
+      --tags \
+        "Key=ttl-hours,Value=${TAGS_TTL_HOURS}" \
+        "Key=anyscale-user,Value=${TAGS_ANYSCALE_USER}" \
+        "Key=anyscale-custodian,Value=${TAGS_ANYSCALE_CUSTODIAN}"
+  } 2>&1 | tee "$log_file"
+}
+
+tag_cluster_autoscaling_groups_for_gc() {
+  local log_file="${1:-${RUN_DIR}/cluster-asg-custodian-tags.log}"
+  local asg_names_text
+  local asg_names=()
+  local asg
+
+  asg_names_text="$(
+    aws autoscaling describe-auto-scaling-groups \
+      --profile "$AWS_PROFILE" \
+      --region "$AWS_REGION" \
+      --filters "Name=tag:eks:cluster-name,Values=${EKS_CLUSTER_NAME}" \
+      --query 'AutoScalingGroups[].AutoScalingGroupName' \
+      --output text
+  )"
+
+  if [[ -z "$asg_names_text" || "$asg_names_text" == "None" ]]; then
+    asg_names_text="$(
+      aws autoscaling describe-auto-scaling-groups \
+        --profile "$AWS_PROFILE" \
+        --region "$AWS_REGION" \
+        --filters "Name=tag:kubernetes.io/cluster/${EKS_CLUSTER_NAME},Values=owned" \
+        --query 'AutoScalingGroups[].AutoScalingGroupName' \
+        --output text
+    )"
+  fi
+
+  if [[ -z "$asg_names_text" || "$asg_names_text" == "None" ]]; then
+    echo "No Auto Scaling Groups found for EKS cluster ${EKS_CLUSTER_NAME}; propagated Custodian tags not applied." | tee "$log_file"
+    return 0
+  fi
+
+  read -r -a asg_names <<<"$asg_names_text"
+  {
+    echo "Tagging ${#asg_names[@]} Auto Scaling Group(s) for Cloud Custodian bypass with PropagateAtLaunch=true."
+    printf '  %s\n' "${asg_names[@]}"
+    for asg in "${asg_names[@]}"; do
+      aws autoscaling create-or-update-tags \
+        --profile "$AWS_PROFILE" \
+        --region "$AWS_REGION" \
+        --tags \
+          "ResourceId=${asg},ResourceType=auto-scaling-group,Key=ttl-hours,Value=${TAGS_TTL_HOURS},PropagateAtLaunch=true" \
+          "ResourceId=${asg},ResourceType=auto-scaling-group,Key=anyscale-user,Value=${TAGS_ANYSCALE_USER},PropagateAtLaunch=true" \
+          "ResourceId=${asg},ResourceType=auto-scaling-group,Key=anyscale-custodian,Value=${TAGS_ANYSCALE_CUSTODIAN},PropagateAtLaunch=true"
+    done
+  } 2>&1 | tee "$log_file"
+}
+
+scale_runtime_nodegroup_to() {
+  local desired_size="$1"
+  local required="${2:-true}"
+  local nodegroup_name scale_output wait_output
+  nodegroup_name="$(runtime_nodegroup_name)"
+
+  echo "Scaling EFA node group ${nodegroup_name} to desired size ${desired_size}..."
+  if ! scale_output="$(
+    aws eks update-nodegroup-config \
+      --cluster-name "$EKS_CLUSTER_NAME" \
+      --nodegroup-name "$nodegroup_name" \
+      --scaling-config "minSize=0,maxSize=${EFA_NODEGROUP_MAX_SIZE},desiredSize=${desired_size}" \
+      --profile "$AWS_PROFILE" \
+      --region "$AWS_REGION" 2>&1
+  )"; then
+    if grep -qi 'no changes' <<<"$scale_output"; then
+      printf '%s\n' "$scale_output"
+    elif bool_is_true "$required" required; then
+      printf '%s\n' "$scale_output" >&2
+      return 1
+    else
+      printf '%s\n' "$scale_output" >&2
+      echo "Warning: could not request EFA node group scale change. Check ${nodegroup_name} manually." >&2
+      return 0
+    fi
+  else
+    printf '%s\n' "$scale_output" | tee "${RUN_DIR}/runtime-nodegroup-scale-${desired_size}.log"
+  fi
+
+  if ! wait_output="$(
+    aws eks wait nodegroup-active \
+      --cluster-name "$EKS_CLUSTER_NAME" \
+      --nodegroup-name "$nodegroup_name" \
+      --profile "$AWS_PROFILE" \
+      --region "$AWS_REGION" 2>&1
+  )"; then
+    if bool_is_true "$required" required; then
+      printf '%s\n' "$wait_output" >&2
+      return 1
+    fi
+    printf '%s\n' "$wait_output" >&2
+    echo "Warning: EFA node group scale request was submitted, but wait did not finish cleanly." >&2
+  fi
+}
+
+scale_runtime_nodegroup_zero() {
+  local kubectl_context
+
+  if command -v kubectl >/dev/null 2>&1; then
+    kubectl_context="$(kubectl config current-context 2>/dev/null || true)"
+    if [[ -n "$kubectl_context" ]]; then
+      allow_runtime_nodes_scale_down "$kubectl_context"
+    fi
+  fi
+
+  scale_runtime_nodegroup_to 0 false
+  WARMUP_NODEGROUP_ACTIVE=0
+}
+
+cleanup_runtime_validation() {
+  if (( VALIDATION_CLEANUP_DONE == 1 )); then
+    return 0
+  fi
+
+  if [[ -n "$RUNTIME_WORKSPACE_ID" ]]; then
+    return 0
+  fi
+
+  if (( WARMUP_NODEGROUP_ACTIVE == 1 )); then
+    VALIDATION_CLEANUP_DONE=1
+    echo "Cleaning up warmed EFA node group because no handoff workspace was created..."
+    scale_runtime_nodegroup_zero
+  fi
+}
+
+write_runtime_compute_config() {
+  cat >"$RUNTIME_COMPUTE_CONFIG_FILE" <<EOF
+cloud: ${ANYSCALE_CLOUD_NAME}
+zones:
+  - ${CR_AZ}
+head_node:
+  instance_type: 8CPU-32GB
+worker_nodes:
+  - name: 8xh100-190cpu-1800gb
+    instance_type: P5-48XLARGE-8xH100-EFA
+    min_nodes: ${EFA_WORKER_COUNT}
+    max_nodes: ${EFA_WORKER_COUNT}
+    market_type: ON_DEMAND
+    advanced_instance_config:
+      spec:
+        containers:
+          - name: ray
+            resources:
+              requests:
+                cpu: 189600m
+                memory: 1798Gi
+                nvidia.com/gpu: "8"
+                vpc.amazonaws.com/efa: "32"
+              limits:
+                cpu: 189600m
+                memory: 1798Gi
+                nvidia.com/gpu: "8"
+                vpc.amazonaws.com/efa: "32"
+            securityContext:
+              allowPrivilegeEscalation: true
+              capabilities:
+                add:
+                  - SYS_ADMIN
+EOF
+}
+
+write_runtime_workspace_config() {
+  cat >"$RUNTIME_WORKSPACE_FILE" <<EOF
+name: ${RUNTIME_WORKSPACE_NAME}
+cloud: ${ANYSCALE_CLOUD_NAME}
+image_uri: ${RUNTIME_IMAGE_URI}
+ray_version: ${RUNTIME_RAY_VERSION}
+compute_config: ${RUNTIME_COMPUTE_CONFIG_REF}
+idle_termination_minutes: 180
+tags:
+  purpose: efa-runtime-validation
+  capacity_reservation: ${EFA_CAPACITY_RESERVATION_ID}
+EOF
+}
+
+wait_for_pod_count() {
+  local selector="$1"
+  local expected_count="$2"
+  local label="$3"
+  local kubectl_context="$4"
+  local count
+
+  for _ in {1..120}; do
+    count="$(
+      kubectl --context "$kubectl_context" get pods \
+        -n anyscale-operator \
+        -l "$selector" \
+        --no-headers 2>/dev/null |
+        wc -l |
+        tr -d ' '
+    )"
+    if (( count >= expected_count )); then
+      return 0
+    fi
+    sleep 10
+  done
+
+  echo "Timed out waiting for ${expected_count} ${label} pod(s); found ${count:-0}." >&2
+  return 1
+}
+
+runtime_ready_nodes() {
+  local kubectl_context="$1"
+  local selector node ready unschedulable
+  selector="$(runtime_node_selector)"
+
+  kubectl --context "$kubectl_context" get nodes \
+    -l "$selector" \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null |
+    while IFS= read -r node; do
+      [[ -n "$node" ]] || continue
+      ready="$(
+        kubectl --context "$kubectl_context" get node "$node" \
+          -o jsonpath='{range .status.conditions[?(@.type=="Ready")]}{.status}{end}' 2>/dev/null || true
+      )"
+      unschedulable="$(
+        kubectl --context "$kubectl_context" get node "$node" \
+          -o jsonpath='{.spec.unschedulable}' 2>/dev/null || true
+      )"
+      if [[ "$ready" == "True" && "$unschedulable" != "true" ]]; then
+        printf '%s\n' "$node"
+      fi
+    done
+}
+
+wait_for_runtime_nodes_ready() {
+  local kubectl_context="$1"
+  local deadline ready_count last_report=""
+
+  echo "Waiting for ${EFA_WORKER_COUNT} Ready ${EFA_EXPECTED_INSTANCE_TYPE} EFA node(s)..."
+  deadline=$((SECONDS + EFA_WARMUP_TIMEOUT_SECONDS))
+  while (( SECONDS < deadline )); do
+    ready_count="$(runtime_ready_nodes "$kubectl_context" | wc -l | tr -d ' ')"
+    if [[ "$ready_count" != "$last_report" ]]; then
+      echo "Ready EFA nodes: ${ready_count}/${EFA_WORKER_COUNT}"
+      last_report="$ready_count"
+    fi
+    if (( ready_count >= EFA_WORKER_COUNT )); then
+      runtime_ready_nodes "$kubectl_context" | tee "${RUN_DIR}/runtime-warmup-nodes.txt"
+      return 0
+    fi
+    sleep 10
+  done
+
+  kubectl --context "$kubectl_context" get nodes \
+    -L workload,node.kubernetes.io/instance-type,eks.amazonaws.com/nodegroup >&2 || true
+  echo "Timed out waiting for Ready EFA nodes." >&2
+  return 1
+}
+
+protect_runtime_nodes_from_scale_down() {
+  local kubectl_context="$1"
+  local node
+
+  echo "Disabling Cluster Autoscaler scale-down for warmed EFA nodes..."
+  while IFS= read -r node; do
+    [[ -n "$node" ]] || continue
+    kubectl --context "$kubectl_context" annotate node "$node" \
+      cluster-autoscaler.kubernetes.io/scale-down-disabled=true \
+      --overwrite
+  done < <(runtime_ready_nodes "$kubectl_context")
+}
+
+protect_workspace_nodes_from_scale_down() {
+  local kubectl_context="$1"
+  local selector node
+
+  shift
+  echo "Disabling Cluster Autoscaler scale-down for validation workspace nodes..."
+  for selector in "$@"; do
+    while IFS= read -r node; do
+      [[ -n "$node" ]] || continue
+      kubectl --context "$kubectl_context" annotate node "$node" \
+        cluster-autoscaler.kubernetes.io/scale-down-disabled=true \
+        --overwrite
+    done < <(
+      kubectl --context "$kubectl_context" get pods \
+        -n anyscale-operator \
+        -l "$selector" \
+        -o jsonpath='{range .items[*]}{.spec.nodeName}{"\n"}{end}' |
+        sort -u
+    )
+  done
+}
+
+allow_runtime_nodes_scale_down() {
+  local kubectl_context="$1"
+  local node
+
+  while IFS= read -r node; do
+    [[ -n "$node" ]] || continue
+    kubectl --context "$kubectl_context" annotate node "$node" \
+      cluster-autoscaler.kubernetes.io/scale-down-disabled- \
+      --overwrite >/dev/null 2>&1 || true
+  done < <(runtime_ready_nodes "$kubectl_context")
+}
+
+node_has_runtime_resources() {
+  local kubectl_context="$1"
+  local node="$2"
+  local gpu efa
+
+  gpu="$(
+    kubectl --context "$kubectl_context" get node "$node" \
+      -o jsonpath='{.status.allocatable.nvidia\.com/gpu}' 2>/dev/null || true
+  )"
+  efa="$(
+    kubectl --context "$kubectl_context" get node "$node" \
+      -o jsonpath='{.status.allocatable.vpc\.amazonaws\.com/efa}' 2>/dev/null || true
+  )"
+
+  [[ "$gpu" =~ ^[0-9]+$ && "$efa" =~ ^[0-9]+$ ]] && (( gpu >= 8 && efa >= 32 ))
+}
+
+wait_for_runtime_resources() {
+  local kubectl_context="$1"
+  local deadline ready_nodes resource_ready node last_report=""
+
+  echo "Waiting for EFA/NVIDIA device plugins to advertise GPU and EFA resources..."
+  kubectl --context "$kubectl_context" rollout status daemonset/efa-aws-efa-k8s-device-plugin \
+    -n kube-system \
+    --timeout="${EFA_WARMUP_TIMEOUT_SECONDS}s" 2>&1 |
+    tee "${RUN_DIR}/runtime-warmup-efa-device-plugin.log"
+  kubectl --context "$kubectl_context" rollout status daemonset/nvdp-nvidia-device-plugin \
+    -n nvidia-device-plugin \
+    --timeout="${EFA_WARMUP_TIMEOUT_SECONDS}s" 2>&1 |
+    tee "${RUN_DIR}/runtime-warmup-nvidia-device-plugin.log"
+
+  deadline=$((SECONDS + EFA_WARMUP_TIMEOUT_SECONDS))
+  while (( SECONDS < deadline )); do
+    resource_ready=0
+    while IFS= read -r node; do
+      [[ -n "$node" ]] || continue
+      if node_has_runtime_resources "$kubectl_context" "$node"; then
+        resource_ready=$((resource_ready + 1))
+      fi
+    done < <(runtime_ready_nodes "$kubectl_context")
+
+    if [[ "$resource_ready" != "$last_report" ]]; then
+      echo "EFA nodes with allocatable GPU/EFA: ${resource_ready}/${EFA_WORKER_COUNT}"
+      last_report="$resource_ready"
+    fi
+    if (( resource_ready >= EFA_WORKER_COUNT )); then
+      ready_nodes="$(runtime_ready_nodes "$kubectl_context" | paste -sd ',' -)"
+      echo "Runtime EFA resources are ready on: ${ready_nodes}"
+      return 0
+    fi
+    sleep 10
+  done
+
+  kubectl --context "$kubectl_context" describe nodes -l "$(runtime_node_selector)" >&2 || true
+  echo "Timed out waiting for EFA nodes to advertise GPU/EFA resources." >&2
+  return 1
+}
+
+resolve_anyscale_cloud_id() {
+  local cloud_get_file="${RUN_DIR}/anyscale-cloud-get-for-warmup.yaml"
+  local cloud_get_log="${RUN_DIR}/anyscale-cloud-get-for-warmup.log"
+
+  if [[ -n "$ANYSCALE_CLOUD_ID" ]]; then
+    printf '%s\n' "$ANYSCALE_CLOUD_ID"
+    return 0
+  fi
+
+  if ! anyscale cloud get --name "$ANYSCALE_CLOUD_NAME" -o "$cloud_get_file" >"$cloud_get_log" 2>&1; then
+    cat "$cloud_get_log" >&2
+    return 1
+  fi
+
+  ANYSCALE_CLOUD_ID="$(
+    sed -n 's/^id:[[:space:]]*//p' "$cloud_get_file" |
+      head -1 |
+      tr -d '[:space:]'
+  )"
+
+  if [[ -z "$ANYSCALE_CLOUD_ID" ]]; then
+    cat "$cloud_get_file" >&2
+    echo "Could not parse Anyscale cloud ID for ${ANYSCALE_CLOUD_NAME}." >&2
+    return 1
+  fi
+
+  printf '%s\n' "$ANYSCALE_CLOUD_ID"
+}
+
+resolve_runtime_image_pull_uri() {
+  local cloud_id cloud_dns registry
+
+  if runtime_image_has_registry "$RUNTIME_IMAGE_URI"; then
+    printf '%s\n' "$RUNTIME_IMAGE_URI"
+    return 0
+  fi
+
+  if [[ -n "$ANYSCALE_CLOUD_REGISTRY" ]]; then
+    registry="$ANYSCALE_CLOUD_REGISTRY"
+  else
+    cloud_id="$(resolve_anyscale_cloud_id)"
+    cloud_dns="$(cloud_id_to_dns "$cloud_id")"
+    registry="registry-${cloud_dns}.anyscale-cloud.dev:443"
+  fi
+
+  printf '%s/%s\n' "$registry" "$RUNTIME_IMAGE_URI"
+}
+
+prepull_runtime_image() {
+  local kubectl_context="$1"
+  local image_uri prepull_name prepull_file
+
+  if ! bool_is_true "$RUNTIME_PREPULL_IMAGE" RUNTIME_PREPULL_IMAGE; then
+    echo "Skipping runtime image pre-pull."
+    return 0
+  fi
+
+  image_uri="$(resolve_runtime_image_pull_uri)"
+  prepull_name="anyscale-runtime-image-prepull"
+  prepull_file="${RUN_DIR}/runtime-image-prepull-daemonset.yaml"
+
+  echo "Pre-pulling runtime image on EFA nodes: ${image_uri}"
+  kubectl --context "$kubectl_context" delete daemonset "$prepull_name" \
+    -n anyscale-operator \
+    --ignore-not-found=true >/dev/null
+
+  cat >"$prepull_file" <<EOF
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ${prepull_name}
+  namespace: anyscale-operator
+  labels:
+    app.kubernetes.io/name: ${prepull_name}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ${prepull_name}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ${prepull_name}
+    spec:
+      serviceAccountName: anyscale-operator
+      imagePullSecrets:
+        - name: anyscale-registry-credentials
+      nodeSelector:
+        workload: ${EFA_WORKLOAD_NAME}
+        node.kubernetes.io/instance-type: ${EFA_EXPECTED_INSTANCE_TYPE}
+        nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3
+        vpc.amazonaws.com/efa.present: "true"
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+        - key: vpc.amazonaws.com/efa
+          operator: Exists
+          effect: NoSchedule
+        - key: node.anyscale.com/capacity-type
+          operator: Exists
+          effect: NoSchedule
+        - key: node.anyscale.com/accelerator-type
+          operator: Exists
+          effect: NoSchedule
+        - key: workload
+          operator: Equal
+          value: ${EFA_WORKLOAD_NAME}
+          effect: NoSchedule
+      containers:
+        - name: prepull
+          image: ${image_uri}
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-lc", "sleep 3600"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+EOF
+
+  kubectl --context "$kubectl_context" apply -f "$prepull_file" 2>&1 |
+    tee "${RUN_DIR}/runtime-image-prepull-apply.log"
+
+  if ! kubectl --context "$kubectl_context" rollout status daemonset/"$prepull_name" \
+    -n anyscale-operator \
+    --timeout="${RUNTIME_PREPULL_TIMEOUT_SECONDS}s" 2>&1 |
+    tee "${RUN_DIR}/runtime-image-prepull-rollout.log"; then
+    kubectl --context "$kubectl_context" describe daemonset "$prepull_name" -n anyscale-operator >&2 || true
+    kubectl --context "$kubectl_context" get pods -n anyscale-operator -l app.kubernetes.io/name="$prepull_name" -o wide >&2 || true
+    kubectl --context "$kubectl_context" get events -n anyscale-operator --sort-by=.lastTimestamp | tail -80 >&2 || true
+    echo "Runtime image pre-pull failed. Rerun with --skip-image-prepull to skip this optimization." >&2
+    return 1
+  fi
+
+  kubectl --context "$kubectl_context" delete daemonset "$prepull_name" \
+    -n anyscale-operator \
+    --ignore-not-found=true 2>&1 |
+    tee "${RUN_DIR}/runtime-image-prepull-delete.log"
+  kubectl --context "$kubectl_context" wait pod \
+    -n anyscale-operator \
+    -l app.kubernetes.io/name="$prepull_name" \
+    --for=delete \
+    --timeout=120s >/dev/null 2>&1 || true
+}
+
+warmup_runtime_efa_nodes() {
+  local kubectl_context
+
+  if ! bool_is_true "$RUNTIME_WARMUP" RUNTIME_WARMUP; then
+    echo "Skipping runtime EFA node warm-up."
+    return 0
+  fi
+
+  echo "Warming EFA node group before runtime validation..."
+  aws eks update-kubeconfig \
+    --name "$EKS_CLUSTER_NAME" \
+    --profile "$AWS_PROFILE" \
+    --region "$AWS_REGION" 2>&1 |
+    tee "${RUN_DIR}/runtime-warmup-update-kubeconfig.log"
+  kubectl_context="$(kubectl config current-context)"
+
+  scale_runtime_nodegroup_to "$EFA_WORKER_COUNT" true
+  WARMUP_NODEGROUP_ACTIVE=1
+
+  wait_for_runtime_nodes_ready "$kubectl_context"
+  protect_runtime_nodes_from_scale_down "$kubectl_context"
+  wait_for_runtime_resources "$kubectl_context"
+  prepull_runtime_image "$kubectl_context"
+  echo "Runtime EFA warm-up complete."
+}
+
+run_validation_command() {
+  local kubectl_context="$1"
+  local head_pod="$2"
+  local log_file="$3"
+  shift 3
+
+  kubectl --context "$kubectl_context" exec \
+    -n anyscale-operator \
+    "$head_pod" \
+    -c ray \
+    -- "$@" 2>&1 |
+    tee "$log_file"
+}
+
+run_runtime_validation() {
+  local create_output create_code workspace_output workspace_code
+  local kubectl_context head_selector worker_selector head_pod action
+  local validation_logs_dir
+  local validation_status=0
+
+  echo "Writing runtime validation configs..."
+  write_runtime_compute_config
+
+  echo "Creating Anyscale compute config ${RUNTIME_COMPUTE_CONFIG_NAME}..."
+  set +e
+  create_output="$(
+    anyscale compute-config create \
+      -n "$RUNTIME_COMPUTE_CONFIG_NAME" \
+      -f "$RUNTIME_COMPUTE_CONFIG_FILE" 2>&1
+  )"
+  create_code=$?
+  set -e
+  printf '%s\n' "$create_output" | tee "${RUN_DIR}/runtime-compute-config-create.log"
+  if (( create_code != 0 )); then
+    echo "Anyscale compute config creation failed. See ${RUN_DIR}/runtime-compute-config-create.log" >&2
+    exit "$create_code"
+  fi
+
+  RUNTIME_COMPUTE_CONFIG_REF="$(
+    printf '%s\n' "$create_output" |
+      sed -n "s/.*Created compute config: '\([^']*\)'.*/\1/p" |
+      head -1
+  )"
+
+  if [[ -z "$RUNTIME_COMPUTE_CONFIG_REF" ]]; then
+    echo "Could not parse compute config reference from Anyscale output." >&2
+    exit 1
+  fi
+
+  write_runtime_workspace_config
+
+  echo "Creating validation workspace ${RUNTIME_WORKSPACE_NAME}..."
+  set +e
+  workspace_output="$(anyscale workspace_v2 create -f "$RUNTIME_WORKSPACE_FILE" 2>&1)"
+  workspace_code=$?
+  set -e
+  printf '%s\n' "$workspace_output" | tee "${RUN_DIR}/runtime-workspace-create.log"
+  if (( workspace_code != 0 )); then
+    echo "Validation workspace creation failed. See ${RUN_DIR}/runtime-workspace-create.log" >&2
+    exit "$workspace_code"
+  fi
+
+  RUNTIME_WORKSPACE_ID="$(
+    printf '%s\n' "$workspace_output" |
+      grep -Eo 'expwrk_[A-Za-z0-9]+' |
+      head -1 || true
+  )"
+
+  if [[ -z "$RUNTIME_WORKSPACE_ID" ]]; then
+    echo "Could not parse workspace ID (expwrk_...) from Anyscale output." >&2
+    exit 1
+  fi
+
+  echo "Starting validation workspace ${RUNTIME_WORKSPACE_ID}..."
+  anyscale workspace_v2 start --id "$RUNTIME_WORKSPACE_ID" 2>&1 |
+    tee "${RUN_DIR}/runtime-workspace-start.log"
+
+  anyscale workspace_v2 wait \
+    --id "$RUNTIME_WORKSPACE_ID" \
+    --state RUNNING \
+    --timeout-s "$RUNTIME_WAIT_TIMEOUT_SECONDS" 2>&1 |
+    tee "${RUN_DIR}/runtime-workspace-wait-running.log"
+
+  echo "Refreshing kubeconfig for ${EKS_CLUSTER_NAME}..."
+  aws eks update-kubeconfig \
+    --name "$EKS_CLUSTER_NAME" \
+    --profile "$AWS_PROFILE" \
+    --region "$AWS_REGION" 2>&1 |
+    tee "${RUN_DIR}/runtime-update-kubeconfig.log"
+  kubectl_context="$(kubectl config current-context)"
+
+  head_selector="anyscale-workspace-id=${RUNTIME_WORKSPACE_ID},ray-node-type=head"
+  worker_selector="anyscale-workspace-id=${RUNTIME_WORKSPACE_ID},ray-node-type=worker"
+
+  wait_for_pod_count "$head_selector" 1 "head" "$kubectl_context"
+  wait_for_pod_count "$worker_selector" "$EFA_WORKER_COUNT" "worker" "$kubectl_context"
+
+  kubectl --context "$kubectl_context" wait \
+    --for=condition=Ready pod \
+    -n anyscale-operator \
+    -l "$head_selector" \
+    --timeout="$RUNTIME_KUBECTL_WAIT_TIMEOUT" 2>&1 |
+    tee "${RUN_DIR}/runtime-kubectl-wait-head.log"
+
+  kubectl --context "$kubectl_context" wait \
+    --for=condition=Ready pod \
+    -n anyscale-operator \
+    -l "$worker_selector" \
+    --timeout="$RUNTIME_KUBECTL_WAIT_TIMEOUT" 2>&1 |
+    tee "${RUN_DIR}/runtime-kubectl-wait-workers.log"
+
+  protect_workspace_nodes_from_scale_down "$kubectl_context" "$head_selector" "$worker_selector"
+  tag_cluster_autoscaling_groups_for_gc "${RUN_DIR}/cluster-asg-custodian-tags-after-validation.log"
+  tag_cluster_instances_for_gc "${RUN_DIR}/cluster-instance-custodian-tags-after-validation.log"
+
+  head_pod="$(
+    kubectl --context "$kubectl_context" get pods \
+      -n anyscale-operator \
+      -l "$head_selector" \
+      -o jsonpath='{.items[0].metadata.name}'
+  )"
+
+  echo "Detecting Ray compute nodes from ${head_pod}..."
+  if ! run_validation_command \
+    "$kubectl_context" \
+    "$head_pod" \
+    "${RUN_DIR}/runtime-detect-compute-nodes.log" \
+    bash -lc 'export PATH="/opt/efa-middle/scripts:$PATH"; detect_compute_nodes --details'; then
+    validation_status=1
+  fi
+
+  IFS=',' read -ra validation_actions <<<"$RUNTIME_VALIDATION_ACTIONS"
+  for action in "${validation_actions[@]}"; do
+    if (( validation_status != 0 )); then
+      break
+    fi
+    action="$(printf '%s' "$action" | xargs)"
+    if [[ -z "$action" ]]; then
+      continue
+    fi
+    echo "Running validation action: ${action}"
+    if ! run_validation_command \
+      "$kubectl_context" \
+      "$head_pod" \
+      "${RUN_DIR}/runtime-validation-${action}.log" \
+      bash -lc 'export PATH="/opt/efa-middle/scripts:$PATH"; validate_compute_nodes "$1"' _ "$action"; then
+      validation_status=1
+    fi
+  done
+
+  validation_logs_dir="${RUN_DIR}/efa_validation_logs"
+  rm -rf "$validation_logs_dir"
+  if ! kubectl --context "$kubectl_context" cp \
+    -n anyscale-operator \
+    -c ray \
+    "${head_pod}:/home/ray/default/efa_validation_logs" \
+    "$validation_logs_dir" 2>&1 |
+    tee "${RUN_DIR}/runtime-copy-validation-logs.log"; then
+    echo "Warning: could not copy validation logs from workspace head pod." >&2
+  fi
+
+  cat >>"$OUTPUT_ENV_FILE" <<EOF
+export RUNTIME_WORKSPACE_ID="${RUNTIME_WORKSPACE_ID}"
+export RUNTIME_WORKSPACE_NAME="${RUNTIME_WORKSPACE_NAME}"
+export RUNTIME_COMPUTE_CONFIG_REF="${RUNTIME_COMPUTE_CONFIG_REF}"
+export RUNTIME_IMAGE_URI="${RUNTIME_IMAGE_URI}"
+export RUNTIME_VALIDATION_ACTIONS="${RUNTIME_VALIDATION_ACTIONS}"
+EOF
+
+  if (( validation_status != 0 )); then
+    echo "Runtime validation failed. See logs in ${RUN_DIR}." >&2
+    echo "Validation workspace was left running for debugging and handoff: ${RUNTIME_WORKSPACE_ID}" >&2
+    return "$validation_status"
+  fi
+
+  echo "Runtime validation passed. Workspace is running for handoff: ${RUNTIME_WORKSPACE_ID}"
+  echo "Workspace head and worker nodes are protected from Cluster Autoscaler scale-down."
+}
+
+mkdir -p "$RUN_DIR"
+
+echo "Checking AWS identity..."
+aws sts get-caller-identity \
+  --profile "$AWS_PROFILE" \
+  --region "$AWS_REGION" \
+  --query '{Account:Account,Arn:Arn}' \
+  --output table
+
+echo "Inspecting capacity reservation ${EFA_CAPACITY_RESERVATION_ID}..."
+reservation_row="$(
+  aws ec2 describe-capacity-reservations \
+    --capacity-reservation-ids "$EFA_CAPACITY_RESERVATION_ID" \
+    --profile "$AWS_PROFILE" \
+    --region "$AWS_REGION" \
+    --query 'CapacityReservations[0].[State,AvailabilityZone,AvailabilityZoneId,InstanceType,AvailableInstanceCount,TotalInstanceCount,InstanceMatchCriteria]' \
+    --output text
+)"
+
+read -r CR_STATE CR_AZ CR_AZ_ID CR_INSTANCE_TYPE CR_AVAILABLE CR_TOTAL CR_MATCH <<<"$reservation_row"
+
+if [[ -z "${CR_STATE:-}" || "$CR_STATE" == "None" ]]; then
+  echo "Capacity reservation not found: ${EFA_CAPACITY_RESERVATION_ID}" >&2
+  exit 1
+fi
+
+if [[ "$CR_AZ_ID" == "None" || -z "$CR_AZ_ID" ]]; then
+  CR_AZ_ID="$(
+    aws ec2 describe-availability-zones \
+      --zone-names "$CR_AZ" \
+      --profile "$AWS_PROFILE" \
+      --region "$AWS_REGION" \
+      --query 'AvailabilityZones[0].ZoneId' \
+      --output text
+  )"
+fi
+
+cat <<EOF
+Capacity reservation:
+  state:          ${CR_STATE}
+  az:             ${CR_AZ}
+  az_id:          ${CR_AZ_ID}
+  instance_type:  ${CR_INSTANCE_TYPE}
+  available:      ${CR_AVAILABLE}
+  total:          ${CR_TOTAL}
+  match:          ${CR_MATCH}
+EOF
+
+if [[ "$CR_STATE" != "active" ]]; then
+  echo "Capacity reservation must be active." >&2
+  exit 1
+fi
+
+if [[ "$CR_INSTANCE_TYPE" != "$EFA_EXPECTED_INSTANCE_TYPE" ]]; then
+  echo "Expected reservation instance type ${EFA_EXPECTED_INSTANCE_TYPE}, got ${CR_INSTANCE_TYPE}." >&2
+  exit 1
+fi
+
+TARGET_EFA_INSTANCE_COUNT="$(count_target_efa_instances)"
+CR_USABLE_FOR_RUN=$((CR_AVAILABLE + TARGET_EFA_INSTANCE_COUNT))
+
+if (( EFA_WORKER_COUNT > 0 && CR_USABLE_FOR_RUN < EFA_WORKER_COUNT )); then
+  echo "Capacity reservation has ${CR_AVAILABLE} available instance(s) plus ${TARGET_EFA_INSTANCE_COUNT} running target EFA node(s), but EFA_WORKER_COUNT=${EFA_WORKER_COUNT}." >&2
+  echo "Reduce EFA_WORKER_COUNT for infra-only testing, or free reservation capacity before workspace validation." >&2
+  exit 1
+fi
+
+if [[ "$CR_MATCH" != "targeted" ]]; then
+  echo "Warning: reservation match criteria is '${CR_MATCH}', not 'targeted'." >&2
+fi
+
+cat >"$TFVARS_FILE" <<EOF
+eks_cluster_name = "${EKS_CLUSTER_NAME}"
+aws_region       = "${AWS_REGION}"
+
+gpu_instance_types = {}
+
+node_group_disk_size = ${NODE_GROUP_DISK_SIZE}
+enable_efs           = ${ENABLE_EFS}
+
+efa_capacity_reservation_id    = "${EFA_CAPACITY_RESERVATION_ID}"
+efa_capacity_reservation_az_id = "${CR_AZ_ID}"
+efa_private_subnet_cidr        = "${EFA_PRIVATE_SUBNET_CIDR}"
+efa_workload_name              = "${EFA_WORKLOAD_NAME}"
+
+tags = {
+  Project                  = "${EKS_CLUSTER_NAME}"
+  Environment              = "${TAGS_ENVIRONMENT}"
+  ManagedBy                = "pipeline/provision-aws-efa-anyscale.sh"
+  EfaCapacityReservationId = "${EFA_CAPACITY_RESERVATION_ID}"
+  "ttl-hours"              = "${TAGS_TTL_HOURS}"
+  "anyscale-user"          = "${TAGS_ANYSCALE_USER}"
+  "anyscale-custodian"     = "${TAGS_ANYSCALE_CUSTODIAN}"
+}
+EOF
+
+cat >"${RUN_DIR}/inputs.env" <<EOF
+export AWS_PROFILE="${AWS_PROFILE}"
+export AWS_REGION="${AWS_REGION}"
+export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION}"
+export CLOUD_NAME="${CLOUD_NAME:-$EKS_CLUSTER_NAME}"
+export EKS_CLUSTER_NAME="${EKS_CLUSTER_NAME}"
+export ANYSCALE_CLOUD_NAME="${ANYSCALE_CLOUD_NAME}"
+export EFA_CAPACITY_RESERVATION_ID="${EFA_CAPACITY_RESERVATION_ID}"
+export EFA_CAPACITY_RESERVATION_AZ_NAME="${CR_AZ}"
+export EFA_CAPACITY_RESERVATION_AZ_ID="${CR_AZ_ID}"
+export EFA_WORKER_COUNT="${EFA_WORKER_COUNT}"
+export EFA_WORKLOAD_NAME="${EFA_WORKLOAD_NAME}"
+export TAGS_TTL_HOURS="${TAGS_TTL_HOURS}"
+export TAGS_ANYSCALE_USER="${TAGS_ANYSCALE_USER}"
+export TAGS_ANYSCALE_CUSTODIAN="${TAGS_ANYSCALE_CUSTODIAN}"
+export TF_WORKSPACE_NAME="${TF_WORKSPACE_NAME}"
+export RUN_DIR="${RUN_DIR}"
+export RUN_RUNTIME_VALIDATION="${RUN_RUNTIME_VALIDATION}"
+export RUNTIME_WORKSPACE_NAME="${RUNTIME_WORKSPACE_NAME}"
+export RUNTIME_COMPUTE_CONFIG_NAME="${RUNTIME_COMPUTE_CONFIG_NAME}"
+export RUNTIME_IMAGE_URI="${RUNTIME_IMAGE_URI}"
+export RUNTIME_RAY_VERSION="${RUNTIME_RAY_VERSION}"
+export RUNTIME_VALIDATION_ACTIONS="${RUNTIME_VALIDATION_ACTIONS}"
+export RUNTIME_WARMUP="${RUNTIME_WARMUP}"
+export RUNTIME_PREPULL_IMAGE="${RUNTIME_PREPULL_IMAGE}"
+export EFA_WARMUP_TIMEOUT_SECONDS="${EFA_WARMUP_TIMEOUT_SECONDS}"
+export RUNTIME_PREPULL_TIMEOUT_SECONDS="${RUNTIME_PREPULL_TIMEOUT_SECONDS}"
+EOF
+
+echo "Wrote ${TFVARS_FILE}"
+
+cd "$EXAMPLE_DIR"
+
+echo "Initializing Terraform in ${EXAMPLE_DIR}..."
+terraform init
+
+PREVIOUS_TF_WORKSPACE="$(terraform workspace show)"
+cleanup() {
+  cleanup_runtime_validation
+  terraform workspace select "$PREVIOUS_TF_WORKSPACE" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+if terraform workspace select "$TF_WORKSPACE_NAME" >/dev/null 2>&1; then
+  echo "Using existing Terraform workspace: ${TF_WORKSPACE_NAME}"
+else
+  echo "Creating Terraform workspace: ${TF_WORKSPACE_NAME}"
+  terraform workspace new "$TF_WORKSPACE_NAME" >/dev/null
+fi
+assert_terraform_workspace
+
+terraform validate
+
+echo "Planning Terraform changes..."
+terraform plan \
+  -var-file="$TFVARS_FILE" \
+  -out="$PLAN_FILE"
+
+if (( APPLY == 0 )); then
+  cat <<EOF
+
+Plan saved to:
+  ${PLAN_FILE}
+
+No resources were created. To apply this exact path, run:
+  CLOUD_NAME="${CLOUD_NAME:-$EKS_CLUSTER_NAME}" \\
+  EFA_CAPACITY_RESERVATION_ID="${EFA_CAPACITY_RESERVATION_ID}" \\
+  AWS_PROFILE="${AWS_PROFILE}" \\
+  AWS_REGION="${AWS_REGION}" \\
+  EFA_WORKER_COUNT="${EFA_WORKER_COUNT}" \\
+  EFA_WORKLOAD_NAME="${EFA_WORKLOAD_NAME}" \\
+  $0 --apply
+
+Generated run files:
+  ${RUN_DIR}
+EOF
+  exit 0
+fi
+
+echo "Applying Terraform plan..."
+terraform apply -auto-approve "$PLAN_FILE"
+assert_terraform_outputs_match_run
+tag_cluster_autoscaling_groups_for_gc "${RUN_DIR}/cluster-asg-custodian-tags-after-apply.log"
+tag_cluster_instances_for_gc "${RUN_DIR}/cluster-instance-custodian-tags-after-apply.log"
+
+REGISTER_COMMAND="$(
+  terraform output -raw anyscale_registration_command |
+    sed "s/<anyscale_cloud_name>/${ANYSCALE_CLOUD_NAME}/g"
+)"
+EXPECTED_S3_BUCKET_ID="$(registration_arg "$REGISTER_COMMAND" "--s3-bucket-id")"
+EXPECTED_OPERATOR_IAM_IDENTITY="$(registration_arg "$REGISTER_COMMAND" "--anyscale-operator-iam-identity")"
+
+if [[ -z "$EXPECTED_S3_BUCKET_ID" || -z "$EXPECTED_OPERATOR_IAM_IDENTITY" ]]; then
+  printf '%s\n' "$REGISTER_COMMAND" >&2
+  echo "Could not parse expected S3 bucket or operator IAM identity from Terraform registration command." >&2
+  exit 1
+fi
+
+if (( SKIP_REGISTER == 0 )); then
+  if [[ -n "$ANYSCALE_CLOUD_RESOURCE_ID" ]]; then
+    echo "Using existing ANYSCALE_CLOUD_RESOURCE_ID=${ANYSCALE_CLOUD_RESOURCE_ID}; skipping registration."
+  else
+    ANYSCALE_CLOUD_RESOURCE_ID="$(
+      find_existing_anyscale_cloud_resource "$EXPECTED_S3_BUCKET_ID" "$EXPECTED_OPERATOR_IAM_IDENTITY" || true
+    )"
+
+    if [[ -n "$ANYSCALE_CLOUD_RESOURCE_ID" ]]; then
+      echo "Using existing Anyscale cloud resource ${ANYSCALE_CLOUD_RESOURCE_ID} for ${ANYSCALE_CLOUD_NAME}; skipping registration."
+    else
+    printf '%s\n' "$REGISTER_COMMAND" >"${RUN_DIR}/anyscale-register-command.sh"
+    chmod +x "${RUN_DIR}/anyscale-register-command.sh"
+
+    echo "Registering Anyscale cloud ${ANYSCALE_CLOUD_NAME}..."
+    set +e
+    REGISTER_OUTPUT="$(bash -lc "$REGISTER_COMMAND" 2>&1)"
+    REGISTER_CODE=$?
+    set -e
+    printf '%s\n' "$REGISTER_OUTPUT" | tee "${RUN_DIR}/anyscale-register.log"
+    if (( REGISTER_CODE != 0 )); then
+      if grep -q 'already exists' "${RUN_DIR}/anyscale-register.log"; then
+        echo "Cloud ${ANYSCALE_CLOUD_NAME} already exists, but no matching cloud resource was found for this Terraform output." >&2
+        echo "Set ANYSCALE_CLOUD_RESOURCE_ID=cldrsrc_... with --skip-register, or choose a new ANYSCALE_CLOUD_NAME." >&2
+      fi
+      echo "anyscale cloud register failed. See ${RUN_DIR}/anyscale-register.log" >&2
+      exit "$REGISTER_CODE"
+    fi
+
+    ANYSCALE_CLOUD_RESOURCE_ID="$(
+      printf '%s\n' "$REGISTER_OUTPUT" |
+        grep -Eo 'cldrsrc_[A-Za-z0-9]+' |
+        head -1 || true
+    )"
+
+    if [[ -z "$ANYSCALE_CLOUD_RESOURCE_ID" ]]; then
+      echo "Could not parse Cloud Deployment ID (cldrsrc_...) from registration output." >&2
+      echo "Set ANYSCALE_CLOUD_RESOURCE_ID manually and rerun with --skip-register." >&2
+      exit 1
+    fi
+    fi
+  fi
+elif [[ -z "$ANYSCALE_CLOUD_RESOURCE_ID" && "$SKIP_HELM" == "0" ]]; then
+  echo "--skip-register requires ANYSCALE_CLOUD_RESOURCE_ID=cldrsrc_... unless --skip-helm is also set." >&2
+  exit 1
+fi
+
+verify_anyscale_cloud_resource "$EXPECTED_S3_BUCKET_ID" "$EXPECTED_OPERATOR_IAM_IDENTITY"
+
+cat >"$OUTPUT_ENV_FILE" <<EOF
+export AWS_PROFILE="${AWS_PROFILE}"
+export AWS_REGION="${AWS_REGION}"
+export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION}"
+export CLOUD_NAME="${CLOUD_NAME:-$EKS_CLUSTER_NAME}"
+export EKS_CLUSTER_NAME="${EKS_CLUSTER_NAME}"
+export ANYSCALE_CLOUD_NAME="${ANYSCALE_CLOUD_NAME}"
+export ANYSCALE_CLOUD_RESOURCE_ID="${ANYSCALE_CLOUD_RESOURCE_ID}"
+export EFA_CAPACITY_RESERVATION_ID="${EFA_CAPACITY_RESERVATION_ID}"
+export EFA_CAPACITY_RESERVATION_AZ_NAME="${CR_AZ}"
+export EFA_CAPACITY_RESERVATION_AZ_ID="${CR_AZ_ID}"
+export EFA_WORKER_COUNT="${EFA_WORKER_COUNT}"
+export EFA_WORKLOAD_NAME="${EFA_WORKLOAD_NAME}"
+export TF_WORKSPACE_NAME="${TF_WORKSPACE_NAME}"
+export RUN_DIR="${RUN_DIR}"
+export RUN_RUNTIME_VALIDATION="${RUN_RUNTIME_VALIDATION}"
+export RUNTIME_WORKSPACE_NAME="${RUNTIME_WORKSPACE_NAME}"
+export RUNTIME_COMPUTE_CONFIG_NAME="${RUNTIME_COMPUTE_CONFIG_NAME}"
+export RUNTIME_IMAGE_URI="${RUNTIME_IMAGE_URI}"
+export RUNTIME_RAY_VERSION="${RUNTIME_RAY_VERSION}"
+export RUNTIME_VALIDATION_ACTIONS="${RUNTIME_VALIDATION_ACTIONS}"
+export RUNTIME_WARMUP="${RUNTIME_WARMUP}"
+export RUNTIME_PREPULL_IMAGE="${RUNTIME_PREPULL_IMAGE}"
+export EFA_WARMUP_TIMEOUT_SECONDS="${EFA_WARMUP_TIMEOUT_SECONDS}"
+export RUNTIME_PREPULL_TIMEOUT_SECONDS="${RUNTIME_PREPULL_TIMEOUT_SECONDS}"
+EOF
+
+if (( SKIP_HELM == 0 )); then
+  echo "Installing Helm add-ons and Anyscale operator..."
+  AWS_PROFILE="$AWS_PROFILE" \
+  AWS_REGION="$AWS_REGION" \
+  EKS_CLUSTER_NAME="$EKS_CLUSTER_NAME" \
+  EFA_WORKLOAD_NAME="$EFA_WORKLOAD_NAME" \
+  ECR_REGISTRY="$ECR_REGISTRY" \
+  ECR_MIRROR_PREFIX="$ECR_MIRROR_PREFIX" \
+  ANYSCALE_CLOUD_RESOURCE_ID="$ANYSCALE_CLOUD_RESOURCE_ID" \
+  TF_WORKSPACE_NAME="$TF_WORKSPACE_NAME" \
+  EXAMPLE_DIR="$EXAMPLE_DIR" \
+    "${SCRIPT_DIR}/install-helm-addons.sh" 2>&1 | tee "${RUN_DIR}/install-helm-addons.log"
+fi
+
+if (( SKIP_VERIFY == 0 )); then
+  echo "Verifying Anyscale cloud..."
+  aws eks update-kubeconfig \
+    --name "$EKS_CLUSTER_NAME" \
+    --profile "$AWS_PROFILE" \
+    --region "$AWS_REGION" >/dev/null
+  VERIFY_CONTEXT="$(kubectl config current-context)"
+  if ! VERIFY_CONTEXT_NUMBER="$(kubectl_context_number "$VERIFY_CONTEXT")"; then
+    echo "Could not find kubectl context number for ${VERIFY_CONTEXT}." >&2
+    kubectl config get-contexts -o name >&2
+    exit 1
+  fi
+  echo "Using kubectl context ${VERIFY_CONTEXT_NUMBER}: ${VERIFY_CONTEXT}"
+  set +e
+  VERIFY_OUTPUT="$(
+    printf '%s\nanyscale-operator\n' "$VERIFY_CONTEXT_NUMBER" |
+      anyscale cloud verify --name "$ANYSCALE_CLOUD_NAME" 2>&1
+  )"
+  VERIFY_CODE=$?
+  set -e
+  printf '%s\n' "$VERIFY_OUTPUT" | tee "${RUN_DIR}/anyscale-cloud-verify.log"
+  if (( VERIFY_CODE != 0 )) || ! grep -q 'Overall Result: ALL .* verified successfully' "${RUN_DIR}/anyscale-cloud-verify.log"; then
+    echo "anyscale cloud verify did not report success. See ${RUN_DIR}/anyscale-cloud-verify.log" >&2
+    exit 1
+  fi
+
+  anyscale cloud status --name "$ANYSCALE_CLOUD_NAME" 2>&1 |
+    tee "${RUN_DIR}/anyscale-cloud-status.log"
+fi
+
+if (( RUN_RUNTIME_VALIDATION == 1 )); then
+  warmup_runtime_efa_nodes
+  run_runtime_validation
+fi
+
+cat <<EOF
+
+Provisioning complete.
+
+Run metadata:
+  ${OUTPUT_ENV_FILE}
+
+Terraform workspace:
+  ${TF_WORKSPACE_NAME}
+
+Anyscale cloud:
+  ${ANYSCALE_CLOUD_NAME}
+
+Cloud Deployment ID:
+  ${ANYSCALE_CLOUD_RESOURCE_ID}
+EOF
+
+if (( RUN_RUNTIME_VALIDATION == 1 )); then
+  cat <<EOF
+
+Runtime validation:
+  workspace:       ${RUNTIME_WORKSPACE_NAME}
+  workspace_id:    ${RUNTIME_WORKSPACE_ID}
+  compute_config:  ${RUNTIME_COMPUTE_CONFIG_REF}
+  actions:         ${RUNTIME_VALIDATION_ACTIONS}
+  logs:            ${RUN_DIR}/efa_validation_logs
+EOF
+fi

--- a/examples/aws/eks-public-efa/provision-aws-efa-anyscale.sh
+++ b/examples/aws/eks-public-efa/provision-aws-efa-anyscale.sh
@@ -28,6 +28,9 @@ ECR_MIRROR_PREFIX="${ECR_MIRROR_PREFIX:-}"
 ANYSCALE_CLOUD_RESOURCE_ID="${ANYSCALE_CLOUD_RESOURCE_ID:-}"
 TF_WORKSPACE_NAME="${TF_WORKSPACE_NAME:-}"
 RUN_DIR="${RUN_DIR:-}"
+# Runtime image (EFA + UCCL). Not yet public: build from
+# https://github.com/jinghanyao1-hub/AWS_EFA_DOCKER, push to a registry the cloud can pull
+# (e.g. the account ECR), then `anyscale image register` and pass the registered URI here.
 RUNTIME_IMAGE_URI="${RUNTIME_IMAGE_URI:-anyscale/image/anyscale-ray-2.55.1-cu128-torch2.8-efa-uccl:1}"
 RUNTIME_RAY_VERSION="${RUNTIME_RAY_VERSION:-2.55.1}"
 RUNTIME_VALIDATION_ACTIONS="${RUNTIME_VALIDATION_ACTIONS:-quick,nccl,uccl-ll,uccl-ht}"

--- a/examples/aws/eks-public-efa/provision-aws-efa-anyscale.sh
+++ b/examples/aws/eks-public-efa/provision-aws-efa-anyscale.sh
@@ -28,9 +28,9 @@ ECR_MIRROR_PREFIX="${ECR_MIRROR_PREFIX:-}"
 ANYSCALE_CLOUD_RESOURCE_ID="${ANYSCALE_CLOUD_RESOURCE_ID:-}"
 TF_WORKSPACE_NAME="${TF_WORKSPACE_NAME:-}"
 RUN_DIR="${RUN_DIR:-}"
-# Runtime image (EFA + UCCL). Not yet public: build from
-# https://github.com/jinghanyao1-hub/AWS_EFA_DOCKER, push to a registry the cloud can pull
-# (e.g. the account ECR), then `anyscale image register` and pass the registered URI here.
+# Runtime image (EFA + UCCL). Not yet published: build from the co-located ./docker/ dir
+# (see docker/README.md), push to a registry the cloud can pull (e.g. the account ECR),
+# then `anyscale image register` and pass the registered URI here.
 RUNTIME_IMAGE_URI="${RUNTIME_IMAGE_URI:-anyscale/image/anyscale-ray-2.55.1-cu128-torch2.8-efa-uccl:1}"
 RUNTIME_RAY_VERSION="${RUNTIME_RAY_VERSION:-2.55.1}"
 RUNTIME_VALIDATION_ACTIONS="${RUNTIME_VALIDATION_ACTIONS:-quick,nccl,uccl-ll,uccl-ht}"

--- a/examples/aws/eks-public-efa/sample-compute-config_efa.yaml
+++ b/examples/aws/eks-public-efa/sample-compute-config_efa.yaml
@@ -1,0 +1,26 @@
+cloud: <anyscale_cloud_name>
+zones:
+  - <efa_node_availability_zone>
+head_node:
+  instance_type: 8CPU-32GB
+worker_nodes:
+  - name: 8xh100-190cpu-1800gb
+    instance_type: P5-48XLARGE-8xH100-EFA
+    min_nodes: <min_p5_workers>
+    max_nodes: <max_p5_workers>
+    market_type: ON_DEMAND
+    advanced_instance_config:
+      spec:
+        containers:
+          - name: ray
+            resources:
+              requests:
+                cpu: 189600m
+                memory: 1798Gi
+                nvidia.com/gpu: "8"
+                vpc.amazonaws.com/efa: "32"
+              limits:
+                cpu: 189600m
+                memory: 1798Gi
+                nvidia.com/gpu: "8"
+                vpc.amazonaws.com/efa: "32"

--- a/examples/aws/eks-public-efa/sample-compute-config_efa.yaml
+++ b/examples/aws/eks-public-efa/sample-compute-config_efa.yaml
@@ -2,7 +2,7 @@ cloud: <anyscale_cloud_name>
 zones:
   - <efa_node_availability_zone>
 head_node:
-  instance_type: 8CPU-32GB
+  instance_type: 16CPU-64GB
 worker_nodes:
   - name: 8xh100-190cpu-1800gb
     instance_type: P5-48XLARGE-8xH100-EFA

--- a/examples/aws/eks-public-efa/sample-values_efa.yaml
+++ b/examples/aws/eks-public-efa/sample-values_efa.yaml
@@ -1,0 +1,24 @@
+# Helm values for the AWS EFA Kubernetes device plugin (eks/aws-efa-k8s-device-plugin).
+#
+# The device plugin DaemonSet must land on the P5/H100 EFA node group created by
+# this example and tolerate its GPU/accelerator/workload taints. The `workload`
+# toleration value below (h100-efa) is rewritten to the deployment's
+# efa_workload_name by the provisioning automation before install.
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: "vpc.amazonaws.com/efa.present"
+              operator: Exists
+tolerations:
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule
+  - key: node.anyscale.com/accelerator-type
+    operator: Exists
+    effect: NoSchedule
+  - key: workload
+    operator: Equal
+    value: h100-efa
+    effect: NoSchedule

--- a/examples/aws/eks-public-efa/sample-values_nginx.yaml
+++ b/examples/aws/eks-public-efa/sample-values_nginx.yaml
@@ -1,0 +1,13 @@
+controller:
+  service:
+    type: LoadBalancer
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+      service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+      service.beta.kubernetes.io/aws-load-balancer-type: nlb
+  allowSnippetAnnotations: true
+  config:
+    enable-underscores-in-headers: true
+    annotations-risk-level: "Critical"
+  autoscaling:
+    enabled: true

--- a/examples/aws/eks-public-efa/sample-values_nvdp.yaml
+++ b/examples/aws/eks-public-efa/sample-values_nvdp.yaml
@@ -1,0 +1,18 @@
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        # We allow a GPU deployment to be forced by setting the following label to "true"
+        - key: "nvidia.com/gpu.product"
+          operator: Exists
+tolerations:
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule
+  - key: node.anyscale.com/capacity-type
+    operator: Exists
+    effect: NoSchedule
+  - key: node.anyscale.com/accelerator-type
+    operator: Exists
+    effect: NoSchedule

--- a/examples/aws/eks-public-efa/sample-workspace_efa.yaml
+++ b/examples/aws/eks-public-efa/sample-workspace_efa.yaml
@@ -1,0 +1,8 @@
+name: <workspace_name>
+cloud: <anyscale_cloud_name>
+image_uri: anyscale/image/anyscale-ray-2.55.1-cu128-torch2.8-efa-uccl:1
+ray_version: 2.55.1
+compute_config: <compute_config_name>:1
+idle_termination_minutes: 180
+tags:
+  purpose: efa-runtime-validation

--- a/examples/aws/eks-public-efa/variables.tf
+++ b/examples/aws/eks-public-efa/variables.tf
@@ -1,0 +1,139 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# ENVIRONMENT VARIABLES
+# Define these secrets as environment variables
+# ---------------------------------------------------------------------------------------------------------------------
+
+# AWS_ACCESS_KEY_ID
+# AWS_SECRET_ACCESS_KEY
+
+# ---------------------------------------------------------------------------------------------------------------------
+# REQUIRED VARIABLES
+# These variables must be set when using this module.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------------------------------------------------
+# OPTIONAL VARIABLES
+# These variables have defaults but must be included when using this module.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "aws_region" {
+  description = <<-EOT
+    (Optional) The AWS region in which all resources will be created.
+
+    ex:
+    ```
+    aws_region = "us-east-2"
+    ```
+  EOT
+  type        = string
+  default     = "us-east-2"
+}
+
+variable "tags" {
+  description = <<-EOT
+    (Optional) A map of tags to all resources that accept tags.
+
+    ex:
+    ```
+    tags = {
+      Environment = "dev"
+      Repo        = "terraform-kubernetes-anyscale-foundation-modules",
+    }
+    ```
+  EOT
+  type        = map(string)
+  default = {
+    Test        = "true"
+    Environment = "dev"
+    Repo        = "terraform-kubernetes-anyscale-foundation-modules",
+    Example     = "aws/eks-public-efa"
+  }
+}
+
+variable "eks_cluster_name" {
+  description = <<-EOT
+    (Optional) The name of the EKS cluster.
+
+    This will be used for naming resources created by this module including the EKS cluster and the S3 bucket.
+
+    ex:
+    ```
+    eks_cluster_name = "anyscale-eks-public-efa"
+    ```
+  EOT
+  type        = string
+  default     = "anyscale-eks-public-efa"
+}
+
+variable "eks_cluster_version" {
+  description = <<-EOT
+    (Optional) The Kubernetes version of the EKS cluster.
+
+    ex:
+    ```
+    eks_cluster_version = "1.32"
+    ```
+  EOT
+  type        = string
+  default     = "1.32"
+}
+
+variable "gpu_instance_types" {
+  description = <<-EOT
+    (Optional) GPU types configuration for the EKS cluster.
+    See gpu_instances.tfvars.example for additional GPU types.
+
+    ex:
+    ```
+    gpu_instance_types = {
+      "T4" = {
+        product_name   = "Tesla-T4"
+        instance_types = ["g4dn.xlarge", "g4dn.2xlarge", "g4dn.4xlarge"]
+      }
+      "A10G" = {
+        product_name   = "NVIDIA-A10G"
+        instance_types = ["g5.4xlarge"]
+      }
+    }
+    ```
+  EOT
+  type = map(object({
+    product_name   = string
+    instance_types = list(string)
+  }))
+  default = {
+    "T4" = {
+      product_name   = "Tesla-T4"
+      instance_types = ["g4dn.4xlarge"]
+    }
+  }
+}
+
+variable "node_group_disk_size" {
+  description = <<-EOT
+    (Optional) The disk size (GB) of the EKS nodes.
+    Possible values: [500, 1000]
+
+    ex:
+    ```
+    node_group_disk_size = 1000
+    ```
+  EOT
+  type        = number
+  default     = 500
+}
+
+variable "enable_efs" {
+  description = <<-EOT
+    (Optional) Enable the creation of an EFS instance.
+
+    This is optional for Anyscale deployments. EFS is used for shared storage between nodes.
+
+    ex:
+    ```
+    enable_efs = true
+    ```
+  EOT
+  type        = bool
+  default     = false
+}

--- a/examples/aws/eks-public-efa/variables_efa.tf
+++ b/examples/aws/eks-public-efa/variables_efa.tf
@@ -59,3 +59,15 @@ variable "efa_private_subnet_cidr" {
   type        = string
   default     = "172.24.22.0/24"
 }
+
+variable "control_plane_availability_zones" {
+  description = <<-EOT
+    (Optional) Explicit AZs for the VPC subnets and EKS control plane. Empty means
+    the module auto-selects. Pin this only when you must avoid AZs that lack
+    EKS control-plane support or are at the NAT-gateway-per-AZ quota, e.g.
+    ["us-east-1c", "us-east-1d"]. The EFA P5 node group runs in its own subnet in
+    the capacity-reservation AZ regardless of this value.
+  EOT
+  type        = list(string)
+  default     = []
+}

--- a/examples/aws/eks-public-efa/variables_efa.tf
+++ b/examples/aws/eks-public-efa/variables_efa.tf
@@ -1,0 +1,28 @@
+variable "efa_capacity_reservation_id" {
+  description = "(Optional) Targeted EC2 Capacity Reservation ID for the p5.48xlarge EFA node group."
+  type        = string
+  default     = null
+}
+
+variable "efa_capacity_reservation_az_id" {
+  description = "(Optional) Availability Zone ID for the targeted EFA capacity reservation, for example use1-az3."
+  type        = string
+  default     = null
+}
+
+variable "efa_workload_name" {
+  description = "(Optional) Workload name used for the P5/H100 EFA node group name, labels, taints, and Cluster Autoscaler template tags."
+  type        = string
+  default     = "h100-efa"
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]*[a-z0-9]$", var.efa_workload_name))
+    error_message = "efa_workload_name must be lowercase DNS-style text: letters, numbers, hyphens, no leading/trailing hyphen."
+  }
+}
+
+variable "efa_private_subnet_cidr" {
+  description = "(Optional) CIDR block for the private EFA subnet created in the capacity reservation AZ."
+  type        = string
+  default     = "172.24.22.0/24"
+}

--- a/examples/aws/eks-public-efa/variables_efa.tf
+++ b/examples/aws/eks-public-efa/variables_efa.tf
@@ -21,6 +21,39 @@ variable "efa_workload_name" {
   }
 }
 
+variable "efa_node_group_min_size" {
+  description = "(Optional) Minimum number of P5/H100 EFA worker nodes in the EKS managed node group."
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = var.efa_node_group_min_size >= 0
+    error_message = "efa_node_group_min_size must be greater than or equal to 0."
+  }
+}
+
+variable "efa_node_group_desired_size" {
+  description = "(Optional) Desired number of P5/H100 EFA worker nodes in the EKS managed node group."
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = var.efa_node_group_desired_size >= 0
+    error_message = "efa_node_group_desired_size must be greater than or equal to 0."
+  }
+}
+
+variable "efa_node_group_max_size" {
+  description = "(Optional) Maximum number of P5/H100 EFA worker nodes in the EKS managed node group. Set this at least as high as the largest Anyscale compute config max_nodes value you plan to run."
+  type        = number
+  default     = 4
+
+  validation {
+    condition     = var.efa_node_group_max_size >= 1
+    error_message = "efa_node_group_max_size must be greater than or equal to 1."
+  }
+}
+
 variable "efa_private_subnet_cidr" {
   description = "(Optional) CIDR block for the private EFA subnet created in the capacity reservation AZ."
   type        = string

--- a/examples/aws/eks-public-efa/versions.tf
+++ b/examples/aws/eks-public-efa/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/examples/aws/eks-public-efa/versions.tf
+++ b/examples/aws/eks-public-efa/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.79, < 6.0"
     }
   }
 }

--- a/examples/gcp/gke-a4-b200-rdma/docker/Dockerfile.gcp-rdma-uccl.fragment
+++ b/examples/gcp/gke-a4-b200-rdma/docker/Dockerfile.gcp-rdma-uccl.fragment
@@ -1,0 +1,80 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+SHELL ["/bin/bash", "-lc"]
+
+ARG UCCL_URL=https://github.com/uccl-project/uccl.git
+ARG UCCL_REF=v0.1.1
+ARG UCCL_FORCE_DMABUF=1
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV CUDA_HOME=/usr/local/cuda
+ENV TORCH_CUDA_ARCH_LIST=10.0
+ENV EFA_HOME=/opt/gcp-no-efa
+ENV PER_EXPERT_BATCHING=1
+ENV USE_DMABUF=1
+ENV UCCL_FORCE_DMABUF=${UCCL_FORCE_DMABUF}
+ENV MAX_JOBS=16
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    autoconf \
+    automake \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    ibverbs-providers \
+    iproute2 \
+    libhwloc-dev \
+    libibverbs-dev \
+    libnl-3-dev \
+    libnl-route-3-dev \
+    libnuma-dev \
+    librdmacm-dev \
+    libtool \
+    perl \
+    pciutils \
+    pkg-config \
+    rdma-core \
+    wget \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN python -m pip install --no-cache-dir --upgrade pip setuptools wheel \
+  && python -m pip install --no-cache-dir nanobind intervaltree sortedcontainers
+
+RUN git clone "${UCCL_URL}" /opt/uccl \
+  && cd /opt/uccl \
+  && git checkout "${UCCL_REF}" \
+  && if [ "${UCCL_FORCE_DMABUF}" = "1" ] && ! grep -q "GCP_FORCE_DMABUF" ep/include/common.hpp; then \
+       perl -0pi -e 's{// Intel RDMA NIC support}{#ifndef USE_DMABUF\n#define USE_DMABUF  // GCP_FORCE_DMABUF: force DMA-BUF for GKE A4 RoCE\n#endif\n\n// Intel RDMA NIC support}' ep/include/common.hpp; \
+     fi
+
+RUN python -m pip install --no-cache-dir /opt/uccl \
+  && rm -rf /tmp/uccl_ep_build \
+  && cp -a /opt/uccl /tmp/uccl_ep_build \
+  && cd /tmp/uccl_ep_build/ep \
+  && python setup.py install \
+  && cd /tmp/uccl_ep_build/ep/deep_ep_wrapper \
+  && for name in buffer.py test_internode.py utils.py; do \
+       rm -f "deep_ep/${name}"; \
+       cp "../bench/${name}" "deep_ep/${name}"; \
+     done \
+  && python -m pip install --no-cache-dir . \
+  && rm -rf /tmp/uccl_ep_build
+
+COPY env/ /opt/gcp-middle/env/
+COPY scripts/ /opt/gcp-middle/scripts/
+
+RUN chmod +x /opt/gcp-middle/env/*.sh /opt/gcp-middle/scripts/*.sh
+
+ENV PATH=/opt/gcp-middle/scripts:/usr/local/cuda/bin:${PATH}
+ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib64:/usr/local/gib/lib64:${LD_LIBRARY_PATH}
+ENV CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+ENV OMP_NUM_THREADS=8
+ENV PYTHONUNBUFFERED=1
+ENV NCCL_DEBUG=WARN
+ENV NCCL_DEBUG_SUBSYS=INIT,NET
+ENV GLOO_SOCKET_IFNAME=eth0
+ENV UCCL_SOCKET_IFNAME=eth0
+
+WORKDIR /workspace

--- a/examples/gcp/gke-a4-b200-rdma/docker/Dockerfile.nvcr-pytorch-25.04-gcp-rdma-uccl
+++ b/examples/gcp/gke-a4-b200-rdma/docker/Dockerfile.nvcr-pytorch-25.04-gcp-rdma-uccl
@@ -1,0 +1,80 @@
+ARG BASE_IMAGE=nvcr.io/nvidia/pytorch:25.04-py3
+FROM ${BASE_IMAGE}
+
+SHELL ["/bin/bash", "-lc"]
+
+ARG UCCL_URL=https://github.com/uccl-project/uccl.git
+ARG UCCL_REF=v0.1.1
+ARG UCCL_FORCE_DMABUF=1
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV CUDA_HOME=/usr/local/cuda
+ENV TORCH_CUDA_ARCH_LIST=10.0
+ENV EFA_HOME=/opt/gcp-no-efa
+ENV PER_EXPERT_BATCHING=1
+ENV USE_DMABUF=1
+ENV UCCL_FORCE_DMABUF=${UCCL_FORCE_DMABUF}
+ENV MAX_JOBS=16
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    autoconf \
+    automake \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    ibverbs-providers \
+    iproute2 \
+    libhwloc-dev \
+    libibverbs-dev \
+    libnl-3-dev \
+    libnl-route-3-dev \
+    libnuma-dev \
+    librdmacm-dev \
+    libtool \
+    perl \
+    pciutils \
+    pkg-config \
+    rdma-core \
+    wget \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN python -m pip install --no-cache-dir --upgrade pip setuptools wheel \
+  && python -m pip install --no-cache-dir nanobind intervaltree sortedcontainers
+
+RUN git clone "${UCCL_URL}" /opt/uccl \
+  && cd /opt/uccl \
+  && git checkout "${UCCL_REF}" \
+  && if [ "${UCCL_FORCE_DMABUF}" = "1" ] && ! grep -q "GCP_FORCE_DMABUF" ep/include/common.hpp; then \
+       perl -0pi -e 's{// Intel RDMA NIC support}{#ifndef USE_DMABUF\n#define USE_DMABUF  // GCP_FORCE_DMABUF: force DMA-BUF for GKE A4 RoCE\n#endif\n\n// Intel RDMA NIC support}' ep/include/common.hpp; \
+     fi
+
+RUN python -m pip install --no-cache-dir /opt/uccl \
+  && rm -rf /tmp/uccl_ep_build \
+  && cp -a /opt/uccl /tmp/uccl_ep_build \
+  && cd /tmp/uccl_ep_build/ep \
+  && python setup.py install \
+  && cd /tmp/uccl_ep_build/ep/deep_ep_wrapper \
+  && for name in buffer.py test_internode.py utils.py; do \
+       rm -f "deep_ep/${name}"; \
+       cp "../bench/${name}" "deep_ep/${name}"; \
+     done \
+  && python -m pip install --no-cache-dir . \
+  && rm -rf /tmp/uccl_ep_build
+
+COPY env/ /opt/gcp-middle/env/
+COPY scripts/ /opt/gcp-middle/scripts/
+
+RUN chmod +x /opt/gcp-middle/env/*.sh /opt/gcp-middle/scripts/*.sh
+
+ENV PATH=/opt/gcp-middle/scripts:/usr/local/cuda/bin:${PATH}
+ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib64:/usr/local/gib/lib64:${LD_LIBRARY_PATH}
+ENV CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+ENV OMP_NUM_THREADS=8
+ENV PYTHONUNBUFFERED=1
+ENV NCCL_DEBUG=WARN
+ENV NCCL_DEBUG_SUBSYS=INIT,NET
+ENV GLOO_SOCKET_IFNAME=eth0
+ENV UCCL_SOCKET_IFNAME=eth0
+
+WORKDIR /workspace

--- a/examples/gcp/gke-a4-b200-rdma/docker/README.md
+++ b/examples/gcp/gke-a4-b200-rdma/docker/README.md
@@ -1,0 +1,31 @@
+# GCP RDMA/UCCL Docker layer
+
+These Dockerfiles, env, and scripts build the GCP A4/B200 RDMA + UCCL/DeepEP container
+layer. They are the canonical source for the (not-yet-public) image, also mirrored at:
+
+- https://github.com/jinghanyao1-hub/GCP_RDMA_DOCKER
+
+The default GCP validation flow does **not** require a prebuilt image — it runs Ray pods on
+`nvcr.io/nvidia/pytorch:25.04-py3` and compiles UCCL in the pods at runtime
+(`scripts/install-uccl-in-ray-workers.sh`). Build an image here only if you want to prebake
+UCCL/DeepEP; then push it to a registry your cluster can pull and set `ray.image` in
+`../helm/gke-b200-rdma-addons/values.yaml` to that image.
+
+Build:
+
+```bash
+BASE_IMAGE=nvcr.io/nvidia/pytorch:25.04-py3 IMAGE=<your-registry>/gcp-rdma-uccl:dev bash scripts/build_image.sh
+```
+
+Or with Cloud Build (set `PROJECT`, `_REGION`, repository, image, and tag explicitly):
+
+```bash
+gcloud builds submit --config cloudbuild.yaml --substitutions=_IMAGE=<region>-docker.pkg.dev/<project>/<repo>/gcp-rdma-uccl:dev .
+```
+
+Notes:
+
+- UCCL v0.1.1 needs DMA-BUF compiled into `uccl.ep` (a guarded `#define USE_DMABUF`), not
+  just exported at runtime; the build applies this patch.
+- `env/` and `scripts/` are also copied into running pods by the validation flow, so keep
+  them in sync with this layer.

--- a/examples/gcp/gke-a4-b200-rdma/docker/README.md
+++ b/examples/gcp/gke-a4-b200-rdma/docker/README.md
@@ -1,9 +1,7 @@
 # GCP RDMA/UCCL Docker layer
 
 These Dockerfiles, env, and scripts build the GCP A4/B200 RDMA + UCCL/DeepEP container
-layer. They are the canonical source for the (not-yet-public) image, also mirrored at:
-
-- https://github.com/jinghanyao1-hub/GCP_RDMA_DOCKER
+layer (the image is not yet published; build it from here).
 
 The default GCP validation flow does **not** require a prebuilt image — it runs Ray pods on
 `nvcr.io/nvidia/pytorch:25.04-py3` and compiles UCCL in the pods at runtime

--- a/examples/gcp/gke-a4-b200-rdma/docker/cloudbuild.yaml
+++ b/examples/gcp/gke-a4-b200-rdma/docker/cloudbuild.yaml
@@ -1,0 +1,18 @@
+substitutions:
+  _BASE_IMAGE: nvcr.io/nvidia/pytorch:25.04-py3
+  _IMAGE: us-central1-docker.pkg.dev/$PROJECT_ID/gcp-rdma-uccl/gcp-rdma-uccl:dev
+
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - -f
+      - Dockerfile.gcp-rdma-uccl.fragment
+      - --build-arg
+      - BASE_IMAGE=${_BASE_IMAGE}
+      - -t
+      - ${_IMAGE}
+      - .
+
+images:
+  - ${_IMAGE}

--- a/examples/gcp/gke-a4-b200-rdma/docker/env/gcp_rdma_uccl_env.sh
+++ b/examples/gcp/gke-a4-b200-rdma/docker/env/gcp_rdma_uccl_env.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+if [ -z "${BASH_VERSION:-}" ]; then
+  exec bash "$0" "$@"
+fi
+
+export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
+export GIB_HOME="${GIB_HOME:-/usr/local/gib}"
+export NVIDIA_HOST_HOME="${NVIDIA_HOST_HOME:-/usr/local/nvidia}"
+
+if [ -x "${GIB_HOME}/scripts/set_nccl_env.sh" ]; then
+  # shellcheck disable=SC1091
+  source "${GIB_HOME}/scripts/set_nccl_env.sh"
+fi
+
+export PATH="${CUDA_HOME}/bin:${PATH}"
+export LD_LIBRARY_PATH="${NVIDIA_HOST_HOME}/lib64:${GIB_HOME}/lib64:${LD_LIBRARY_PATH:-}"
+
+export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0,1,2,3,4,5,6,7}"
+export OMP_NUM_THREADS="${OMP_NUM_THREADS:-8}"
+export PYTHONUNBUFFERED="${PYTHONUNBUFFERED:-1}"
+
+export GLOO_SOCKET_IFNAME="${GLOO_SOCKET_IFNAME:-eth0}"
+export UCCL_SOCKET_IFNAME="${UCCL_SOCKET_IFNAME:-eth0}"
+export NCCL_DEBUG="${NCCL_DEBUG:-WARN}"
+export NCCL_DEBUG_SUBSYS="${NCCL_DEBUG_SUBSYS:-INIT,NET}"
+
+export USE_DMABUF="${USE_DMABUF:-1}"
+export UCCL_FORCE_DMABUF="${UCCL_FORCE_DMABUF:-1}"
+export PER_EXPERT_BATCHING="${PER_EXPERT_BATCHING:-1}"

--- a/examples/gcp/gke-a4-b200-rdma/docker/scripts/build_image.sh
+++ b/examples/gcp/gke-a4-b200-rdma/docker/scripts/build_image.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOCKER=${DOCKER:-docker}
+BASE_IMAGE=${BASE_IMAGE:-nvcr.io/nvidia/pytorch:25.04-py3}
+IMAGE=${IMAGE:-gcp-b200-rdma-uccl:dev}
+
+cd "$(dirname "$0")/.."
+
+"$DOCKER" build \
+  -f Dockerfile.gcp-rdma-uccl.fragment \
+  --build-arg BASE_IMAGE="$BASE_IMAGE" \
+  -t "$IMAGE" \
+  .
+

--- a/examples/gcp/gke-a4-b200-rdma/docker/scripts/cloud_build_image.sh
+++ b/examples/gcp/gke-a4-b200-rdma/docker/scripts/cloud_build_image.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GCLOUD=${GCLOUD:-}
+if [ -z "$GCLOUD" ]; then
+  if command -v gcloud >/dev/null 2>&1; then
+    GCLOUD=$(command -v gcloud)
+  else
+    echo "gcloud not found; set GCLOUD=/path/to/gcloud" >&2
+    exit 127
+  fi
+fi
+gcloud() { "$GCLOUD" "$@"; }
+
+PROJECT=${PROJECT:?Set PROJECT to your Google Cloud project ID}
+REGION=${REGION:-us-central1}
+REPOSITORY=${REPOSITORY:-gcp-rdma-uccl}
+IMAGE_NAME=${IMAGE_NAME:-gcp-rdma-uccl}
+TAG=${TAG:-dev}
+BASE_IMAGE=${BASE_IMAGE:-nvcr.io/nvidia/pytorch:25.04-py3}
+IMAGE=${IMAGE:-${REGION}-docker.pkg.dev/${PROJECT}/${REPOSITORY}/${IMAGE_NAME}:${TAG}}
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+
+gcloud services enable cloudbuild.googleapis.com artifactregistry.googleapis.com \
+  --project="$PROJECT"
+
+if ! gcloud artifacts repositories describe "$REPOSITORY" \
+  --project="$PROJECT" \
+  --location="$REGION" >/dev/null 2>&1; then
+  gcloud artifacts repositories create "$REPOSITORY" \
+    --project="$PROJECT" \
+    --location="$REGION" \
+    --repository-format=docker \
+    --description="GKE B200 RDMA/UCCL images"
+fi
+
+gcloud builds submit "$ROOT" \
+  --project="$PROJECT" \
+  --config="$ROOT/cloudbuild.yaml" \
+  --machine-type=e2-highcpu-32 \
+  --disk-size=300 \
+  --substitutions="_BASE_IMAGE=${BASE_IMAGE},_IMAGE=${IMAGE}"
+
+echo "$IMAGE"

--- a/examples/gcp/gke-a4-b200-rdma/docker/scripts/validate_gcp_rdma_devices.sh
+++ b/examples/gcp/gke-a4-b200-rdma/docker/scripts/validate_gcp_rdma_devices.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+source "${SCRIPT_DIR}/../env/gcp_rdma_uccl_env.sh"
+
+EXPECTED_GPUS=${EXPECTED_GPUS:-8}
+EXPECTED_RDMA_DEVICES=${EXPECTED_RDMA_DEVICES:-8}
+EXPECT_GDRDRV=${EXPECT_GDRDRV:-1}
+
+section() {
+  printf '\n== %s ==\n' "$1"
+}
+
+section "Host"
+hostname
+
+section "GPU Devices"
+nvidia-smi --query-gpu=index,name,pci.bus_id --format=csv,noheader |
+  awk -F', *' '{printf "GPU%-2s  %-24s  pci=%s\n", $1, $2, tolower($3)}'
+gpu_count=$(nvidia-smi --query-gpu=index --format=csv,noheader | wc -l | tr -d ' ')
+echo "GPU count: ${gpu_count}"
+if [ "$gpu_count" -lt "$EXPECTED_GPUS" ]; then
+  echo "Expected at least ${EXPECTED_GPUS} GPUs, found ${gpu_count}" >&2
+  exit 1
+fi
+
+section "RDMA Interfaces"
+for iface in eth2 eth3 eth4 eth5 eth6 eth7 eth8 eth9; do
+  ip -br addr show "$iface"
+done
+
+section "Infiniband Devices"
+if [ ! -d /sys/class/infiniband ]; then
+  echo "/sys/class/infiniband not found" >&2
+  exit 1
+fi
+for dev in /sys/class/infiniband/*; do
+  [ -e "$dev" ] || continue
+  basename "$dev"
+done | sort
+rdma_count=$(find /sys/class/infiniband -mindepth 1 -maxdepth 1 | wc -l | tr -d ' ')
+echo "RDMA device count: ${rdma_count}"
+if [ "$rdma_count" -lt "$EXPECTED_RDMA_DEVICES" ]; then
+  echo "Expected at least ${EXPECTED_RDMA_DEVICES} RDMA devices, found ${rdma_count}" >&2
+  exit 1
+fi
+
+section "gIB"
+test -x /usr/local/gib/scripts/set_nccl_env.sh
+env | grep -E '^(LD_LIBRARY_PATH|NCCL_|GLOO_SOCKET_IFNAME|UCCL_SOCKET_IFNAME|CUDA_VISIBLE_DEVICES|USE_DMABUF|PER_EXPERT_BATCHING)=' | sort
+
+section "gdrdrv"
+if [ "$EXPECT_GDRDRV" = "1" ]; then
+  grep -q '^gdrdrv ' /proc/modules
+  grep -q '[[:space:]]gdrdrv$' /proc/devices
+  test -c /dev/gdrdrv
+  ls -l /dev/gdrdrv
+else
+  ls -l /dev/gdrdrv 2>/dev/null || true
+fi
+
+section "ibv_devices"
+if command -v ibv_devices >/dev/null 2>&1; then
+  ibv_devices | sed -n '1,80p'
+else
+  echo "ibv_devices not found" >&2
+  exit 1
+fi
+
+echo
+echo "GCP RDMA device validation passed"

--- a/examples/gcp/gke-a4-b200-rdma/docker/scripts/validate_uccl_ep.sh
+++ b/examples/gcp/gke-a4-b200-rdma/docker/scripts/validate_uccl_ep.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE=${1:-}
+if [ "$MODE" != "ll" ] && [ "$MODE" != "ht" ]; then
+  echo "Usage: $0 ll|ht" >&2
+  exit 2
+fi
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+source "${SCRIPT_DIR}/../env/gcp_rdma_uccl_env.sh"
+
+PYTHON=${PYTHON:-python}
+NNODES=${NNODES:-1}
+NPROC_PER_NODE=${NPROC_PER_NODE:-8}
+NODE_RANK=${NODE_RANK:-0}
+MASTER_ADDR=${MASTER_ADDR:-127.0.0.1}
+
+LL_PORT=${LL_PORT:-6123}
+HT_PORT=${HT_PORT:-6124}
+LL_TOKENS=${LL_TOKENS:-128}
+HT_TOKENS=${HT_TOKENS:-4096}
+HIDDEN=${HIDDEN:-7168}
+TOPK=${TOPK:-8}
+EXPERTS=${EXPERTS:-288}
+
+UCCL_BENCH_DIR=${UCCL_BENCH_DIR:-/opt/uccl/ep/bench}
+if [ ! -d "$UCCL_BENCH_DIR" ]; then
+  echo "Cannot find UCCL bench dir. Set UCCL_BENCH_DIR=/path/to/uccl/ep/bench" >&2
+  exit 1
+fi
+
+if [ "$MODE" = "ll" ]; then
+  MASTER_PORT=${MASTER_PORT:-$LL_PORT}
+  BENCH_SCRIPT=test_low_latency.py
+  BENCH_ARGS=(--num-tokens="$LL_TOKENS" --hidden="$HIDDEN" --num-topk="$TOPK" --num-experts="$EXPERTS")
+else
+  MASTER_PORT=${MASTER_PORT:-$HT_PORT}
+  BENCH_SCRIPT=test_internode.py
+  BENCH_ARGS=(--num-tokens="$HT_TOKENS" --hidden="$HIDDEN" --num-topk="$TOPK" --num-experts="$EXPERTS" --test-ll-compatibility)
+fi
+
+echo "Running UCCL-EP ${MODE} validation"
+echo "NNODES=$NNODES NPROC_PER_NODE=$NPROC_PER_NODE NODE_RANK=$NODE_RANK MASTER=$MASTER_ADDR:$MASTER_PORT"
+echo "UCCL_BENCH_DIR=$UCCL_BENCH_DIR"
+
+cd "$UCCL_BENCH_DIR"
+"$PYTHON" -u -m torch.distributed.run \
+  --nnodes="$NNODES" \
+  --nproc_per_node="$NPROC_PER_NODE" \
+  --node_rank="$NODE_RANK" \
+  --master_addr="$MASTER_ADDR" \
+  --master_port="$MASTER_PORT" \
+  "$BENCH_SCRIPT" \
+  "${BENCH_ARGS[@]}"
+

--- a/examples/gcp/gke-a4-b200-rdma/docker/scripts/validate_uccl_imports.sh
+++ b/examples/gcp/gke-a4-b200-rdma/docker/scripts/validate_uccl_imports.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+source "${SCRIPT_DIR}/../env/gcp_rdma_uccl_env.sh"
+
+PYTHON=${PYTHON:-python}
+
+"$PYTHON" - <<'PY'
+import importlib
+import torch
+
+print("torch", torch.__version__)
+print("cuda available", torch.cuda.is_available())
+print("cuda devices", torch.cuda.device_count())
+
+for name in ("uccl", "uccl.ep", "deep_ep"):
+    mod = importlib.import_module(name)
+    print(name, getattr(mod, "__file__", "builtin"))
+PY
+
+echo "UCCL import validation passed"

--- a/examples/gcp/gke-a4-b200-rdma/helm/gke-b200-rdma-addons/Chart.yaml
+++ b/examples/gcp/gke-a4-b200-rdma/helm/gke-b200-rdma-addons/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: gke-b200-rdma-addons
+description: GKE A4/B200 GPUDirect RDMA add-ons for Ray, gdrdrv, and multi-network pods.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/examples/gcp/gke-a4-b200-rdma/helm/gke-b200-rdma-addons/templates/NOTES.txt
+++ b/examples/gcp/gke-a4-b200-rdma/helm/gke-b200-rdma-addons/templates/NOTES.txt
@@ -1,0 +1,13 @@
+Install the Google nccl-rdma-installer DaemonSet before or alongside this chart:
+
+  kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/refs/heads/master/gpudirect-rdma/nccl-rdma-installer.yaml
+  kubectl rollout status daemonset/nccl-rdma-installer -n kube-system --timeout=10m
+
+This chart installs:
+
+  * GKE Network objects: gvnic-1 and rdma-0..rdma-N
+  * gdrdrv-loader in kube-system
+  * ray-head plus ray-worker-* shell pods
+
+The worker pods expect one full A4 node per pod, all 8 B200 GPUs, all 8 RDMA NICs,
+/home/kubernetes/bin/gib, /home/kubernetes/bin/nvidia, and /dev/gdrdrv.

--- a/examples/gcp/gke-a4-b200-rdma/helm/gke-b200-rdma-addons/templates/gdrdrv-loader-daemonset.yaml
+++ b/examples/gcp/gke-a4-b200-rdma/helm/gke-b200-rdma-addons/templates/gdrdrv-loader-daemonset.yaml
@@ -1,0 +1,79 @@
+{{- if .Values.gdrdrvLoader.enabled }}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: gdrdrv-loader
+  namespace: kube-system
+  labels:
+    app: gdrdrv-loader
+spec:
+  selector:
+    matchLabels:
+      app: gdrdrv-loader
+  template:
+    metadata:
+      labels:
+        app: gdrdrv-loader
+    spec:
+      hostPID: true
+      nodeSelector:
+        cloud.google.com/gke-accelerator: nvidia-b200
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: loader
+          image: {{ .Values.gdrdrvLoader.image | quote }}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          command: ["/bin/bash", "-lc"]
+          args:
+            - |
+              set -euo pipefail
+              driver=/host-nvidia/drivers/gdrdrv.ko
+              host_driver=/home/kubernetes/bin/nvidia/drivers/gdrdrv.ko
+              host_dummy=/home/kubernetes/bin/nvidia/drivers/nv-p2p-dummy.ko
+              echo "Waiting for ${driver} from nccl-rdma-installer"
+              for _ in $(seq 1 120); do
+                [ -f "${driver}" ] && break
+                sleep 5
+              done
+              if [ ! -f "${driver}" ]; then
+                echo "Missing ${driver}; nccl-rdma-installer may not have completed" >&2
+                exit 1
+              fi
+              if ! grep -q '^gdrdrv ' /proc/modules; then
+                if [ -f "${host_dummy}" ] && ! grep -q '^nv_p2p_dummy ' /proc/modules; then
+                  nsenter --mount=/proc/1/ns/mnt -- /sbin/insmod "${host_dummy}" || true
+                fi
+                nsenter --mount=/proc/1/ns/mnt -- /sbin/insmod "${host_driver}"
+              fi
+              if ! grep -q '^gdrdrv ' /proc/modules; then
+                echo "gdrdrv did not load" >&2
+                exit 1
+              fi
+              major=$(awk '$2 == "gdrdrv" {print $1}' /proc/devices | tail -n 1)
+              if [ -z "${major}" ]; then
+                echo "gdrdrv is loaded but no /proc/devices major was found" >&2
+                exit 1
+              fi
+              rm -f /host-dev/gdrdrv
+              mknod /host-dev/gdrdrv c "${major}" 0
+              chmod 0666 /host-dev/gdrdrv
+              ls -l /host-dev/gdrdrv
+              sleep infinity
+          volumeMounts:
+            - name: host-nvidia
+              mountPath: /host-nvidia
+              readOnly: true
+            - name: host-dev
+              mountPath: /host-dev
+      volumes:
+        - name: host-nvidia
+          hostPath:
+            path: /home/kubernetes/bin/nvidia
+        - name: host-dev
+          hostPath:
+            path: /dev
+{{- end }}

--- a/examples/gcp/gke-a4-b200-rdma/helm/gke-b200-rdma-addons/templates/network-objects.yaml
+++ b/examples/gcp/gke-a4-b200-rdma/helm/gke-b200-rdma-addons/templates/network-objects.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: networking.gke.io/v1
+kind: GKENetworkParamSet
+metadata:
+  name: gvnic-1
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name | quote }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace | quote }}
+spec:
+  vpc: {{ .Values.gvnic.network | quote }}
+  vpcSubnet: {{ .Values.gvnic.subnet | quote }}
+  deviceMode: NetDevice
+---
+apiVersion: networking.gke.io/v1
+kind: Network
+metadata:
+  name: gvnic-1
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name | quote }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace | quote }}
+spec:
+  parametersRef:
+    group: networking.gke.io
+    kind: GKENetworkParamSet
+    name: gvnic-1
+  type: Device
+{{- range $i := until (int .Values.rdma.count) }}
+---
+apiVersion: networking.gke.io/v1
+kind: GKENetworkParamSet
+metadata:
+  name: rdma-{{ $i }}
+  labels:
+    app.kubernetes.io/managed-by: {{ $.Release.Service | quote }}
+  annotations:
+    meta.helm.sh/release-name: {{ $.Release.Name | quote }}
+    meta.helm.sh/release-namespace: {{ $.Release.Namespace | quote }}
+spec:
+  vpc: {{ $.Values.rdma.network | quote }}
+  vpcSubnet: {{ printf "%s-%d" $.Values.rdma.subnetPrefix $i | quote }}
+  deviceMode: RDMA
+---
+apiVersion: networking.gke.io/v1
+kind: Network
+metadata:
+  name: rdma-{{ $i }}
+  labels:
+    app.kubernetes.io/managed-by: {{ $.Release.Service | quote }}
+  annotations:
+    meta.helm.sh/release-name: {{ $.Release.Name | quote }}
+    meta.helm.sh/release-namespace: {{ $.Release.Namespace | quote }}
+spec:
+  parametersRef:
+    group: networking.gke.io
+    kind: GKENetworkParamSet
+    name: rdma-{{ $i }}
+  type: Device
+{{- end }}

--- a/examples/gcp/gke-a4-b200-rdma/helm/gke-b200-rdma-addons/templates/ray-head.yaml
+++ b/examples/gcp/gke-a4-b200-rdma/helm/gke-b200-rdma-addons/templates/ray-head.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ray-head
+spec:
+  clusterIP: None
+  selector:
+    app: ray
+    role: head
+  ports:
+    - name: gcs
+      port: 6379
+      targetPort: 6379
+    - name: dashboard
+      port: 8265
+      targetPort: 8265
+    - name: client
+      port: 10001
+      targetPort: 10001
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ray-head
+  labels:
+    app: ray
+    role: head
+spec:
+  nodeSelector:
+    cloud.google.com/gke-nodepool: {{ .Values.nodePools.cpu | quote }}
+  restartPolicy: Always
+  volumes:
+    - name: shared-memory
+      emptyDir:
+        medium: Memory
+        sizeLimit: {{ .Values.ray.head.shmSize }}
+    - name: workspace
+      emptyDir:
+        sizeLimit: {{ .Values.ray.head.workspaceSize }}
+  containers:
+    - name: ray
+      image: {{ .Values.ray.image | quote }}
+      imagePullPolicy: {{ .Values.ray.imagePullPolicy }}
+      resources:
+        requests:
+          cpu: {{ .Values.ray.head.cpuRequest | quote }}
+          memory: {{ .Values.ray.head.memoryRequest }}
+        limits:
+          cpu: {{ .Values.ray.head.cpuLimit | quote }}
+          memory: {{ .Values.ray.head.memoryLimit }}
+      ports:
+        - containerPort: 6379
+          name: gcs
+        - containerPort: 8265
+          name: dashboard
+        - containerPort: 10001
+          name: client
+      volumeMounts:
+        - name: shared-memory
+          mountPath: /dev/shm
+        - name: workspace
+          mountPath: /workspace
+      command: ["/bin/bash", "-lc"]
+      args:
+        - |
+          if [ -f /etc/ld.so.conf.d/00-cuda-compat.conf ]; then
+            mv /etc/ld.so.conf.d/00-cuda-compat.conf /etc/ld.so.conf.d/00-cuda-compat.conf.disabled
+            ldconfig
+          fi
+          sleep infinity

--- a/examples/gcp/gke-a4-b200-rdma/helm/gke-b200-rdma-addons/templates/ray-workers.yaml
+++ b/examples/gcp/gke-a4-b200-rdma/helm/gke-b200-rdma-addons/templates/ray-workers.yaml
@@ -1,0 +1,81 @@
+{{- range $worker := until (int .Values.ray.workerCount) }}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ray-worker-{{ $worker }}
+  labels:
+    app: ray
+    role: worker
+  annotations:
+    networking.gke.io/default-interface: "eth0"
+    networking.gke.io/interfaces: |
+      [
+        {"interfaceName":"eth0","network":"default"}{{- range $i := until (int $.Values.rdma.count) }},
+        {"interfaceName":"eth{{ add $i 2 }}","network":"rdma-{{ $i }}"}{{- end }}
+      ]
+spec:
+  nodeSelector:
+    cloud.google.com/gke-accelerator: nvidia-b200
+    cloud.google.com/gke-nodepool: {{ $.Values.nodePools.gpu | quote }}
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app: ray
+              role: worker
+          topologyKey: kubernetes.io/hostname
+  restartPolicy: Always
+  volumes:
+    - name: library-dir-host
+      hostPath:
+        path: /home/kubernetes/bin/nvidia
+    - name: gib
+      hostPath:
+        path: /home/kubernetes/bin/gib
+    - name: gdrdrv
+      hostPath:
+        path: /dev/gdrdrv
+        type: CharDevice
+    - name: shared-memory
+      emptyDir:
+        medium: Memory
+        sizeLimit: {{ $.Values.ray.worker.shmSize }}
+    - name: workspace
+      emptyDir:
+        sizeLimit: {{ $.Values.ray.worker.workspaceSize }}
+  containers:
+    - name: ray
+      image: {{ $.Values.ray.image | quote }}
+      imagePullPolicy: {{ $.Values.ray.imagePullPolicy }}
+      env:
+        - name: LD_LIBRARY_PATH
+          value: /usr/local/nvidia/lib64:/usr/local/gib/lib64
+      securityContext:
+        capabilities:
+          add: ["IPC_LOCK", "SYS_PTRACE"]
+      resources:
+        limits:
+          nvidia.com/gpu: {{ $.Values.ray.worker.gpuCount }}
+      volumeMounts:
+        - name: library-dir-host
+          mountPath: /usr/local/nvidia
+        - name: gib
+          mountPath: /usr/local/gib
+        - name: gdrdrv
+          mountPath: /dev/gdrdrv
+        - name: shared-memory
+          mountPath: /dev/shm
+        - name: workspace
+          mountPath: /workspace
+      command: ["/bin/bash", "-lc"]
+      args:
+        - |
+          if [ -f /etc/ld.so.conf.d/00-cuda-compat.conf ]; then
+            mv /etc/ld.so.conf.d/00-cuda-compat.conf /etc/ld.so.conf.d/00-cuda-compat.conf.disabled
+            ldconfig
+          fi
+          source /usr/local/gib/scripts/set_nccl_env.sh
+          sleep infinity
+{{- end }}

--- a/examples/gcp/gke-a4-b200-rdma/helm/gke-b200-rdma-addons/values.yaml
+++ b/examples/gcp/gke-a4-b200-rdma/helm/gke-b200-rdma-addons/values.yaml
@@ -1,0 +1,32 @@
+gvnic:
+  network: b200-gvnic
+  subnet: b200-gvnic-subnet
+
+rdma:
+  network: b200-rdma
+  subnetPrefix: b200-rdma-subnet
+  count: 8
+
+gdrdrvLoader:
+  enabled: true
+  image: ubuntu:22.04
+
+nodePools:
+  cpu: cpu-head
+  gpu: a4-spot
+
+ray:
+  image: nvcr.io/nvidia/pytorch:25.04-py3
+  imagePullPolicy: IfNotPresent
+  workerCount: 2
+  head:
+    shmSize: 32Gi
+    workspaceSize: 100Gi
+    cpuRequest: "8"
+    cpuLimit: "14"
+    memoryRequest: 32Gi
+    memoryLimit: 56Gi
+  worker:
+    shmSize: 250Gi
+    workspaceSize: 200Gi
+    gpuCount: 8

--- a/examples/gcp/gke-a4-b200-rdma/manifests/gdrdrv-loader-daemonset.yaml
+++ b/examples/gcp/gke-a4-b200-rdma/manifests/gdrdrv-loader-daemonset.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: gdrdrv-loader
+  namespace: kube-system
+  labels:
+    app: gdrdrv-loader
+spec:
+  selector:
+    matchLabels:
+      app: gdrdrv-loader
+  template:
+    metadata:
+      labels:
+        app: gdrdrv-loader
+    spec:
+      hostPID: true
+      nodeSelector:
+        cloud.google.com/gke-accelerator: nvidia-b200
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: loader
+          image: ubuntu:22.04
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          command: ["/bin/bash", "-lc"]
+          args:
+            - |
+              set -euo pipefail
+              driver=/host-nvidia/drivers/gdrdrv.ko
+              host_driver=/home/kubernetes/bin/nvidia/drivers/gdrdrv.ko
+              host_dummy=/home/kubernetes/bin/nvidia/drivers/nv-p2p-dummy.ko
+              echo "Waiting for ${driver} from nccl-rdma-installer"
+              for _ in $(seq 1 120); do
+                [ -f "${driver}" ] && break
+                sleep 5
+              done
+              if [ ! -f "${driver}" ]; then
+                echo "Missing ${driver}; nccl-rdma-installer may not have completed" >&2
+                exit 1
+              fi
+              if ! grep -q '^gdrdrv ' /proc/modules; then
+                if [ -f "${host_dummy}" ] && ! grep -q '^nv_p2p_dummy ' /proc/modules; then
+                  nsenter --mount=/proc/1/ns/mnt -- /sbin/insmod "${host_dummy}" || true
+                fi
+                nsenter --mount=/proc/1/ns/mnt -- /sbin/insmod "${host_driver}"
+              fi
+              if ! grep -q '^gdrdrv ' /proc/modules; then
+                echo "gdrdrv did not load" >&2
+                exit 1
+              fi
+              major=$(awk '$2 == "gdrdrv" {print $1}' /proc/devices | tail -n 1)
+              if [ -z "${major}" ]; then
+                echo "gdrdrv is loaded but no /proc/devices major was found" >&2
+                exit 1
+              fi
+              rm -f /host-dev/gdrdrv
+              mknod /host-dev/gdrdrv c "${major}" 0
+              chmod 0666 /host-dev/gdrdrv
+              ls -l /host-dev/gdrdrv
+              sleep infinity
+          volumeMounts:
+            - name: host-nvidia
+              mountPath: /host-nvidia
+              readOnly: true
+            - name: host-dev
+              mountPath: /host-dev
+      volumes:
+        - name: host-nvidia
+          hostPath:
+            path: /home/kubernetes/bin/nvidia
+        - name: host-dev
+          hostPath:
+            path: /dev

--- a/examples/gcp/gke-a4-b200-rdma/manifests/kustomization.yaml
+++ b/examples/gcp/gke-a4-b200-rdma/manifests/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+  - network-objects.yaml
+  - gdrdrv-loader-daemonset.yaml
+  - ray-head.yaml
+  - ray-workers-2.yaml
+

--- a/examples/gcp/gke-a4-b200-rdma/manifests/network-objects.yaml
+++ b/examples/gcp/gke-a4-b200-rdma/manifests/network-objects.yaml
@@ -1,0 +1,180 @@
+---
+apiVersion: networking.gke.io/v1
+kind: GKENetworkParamSet
+metadata:
+  name: gvnic-1
+spec:
+  vpc: b200-gvnic
+  vpcSubnet: b200-gvnic-subnet
+  deviceMode: NetDevice
+---
+apiVersion: networking.gke.io/v1
+kind: Network
+metadata:
+  name: gvnic-1
+spec:
+  parametersRef:
+    group: networking.gke.io
+    kind: GKENetworkParamSet
+    name: gvnic-1
+  type: Device
+---
+apiVersion: networking.gke.io/v1
+kind: GKENetworkParamSet
+metadata:
+  name: rdma-0
+spec:
+  vpc: b200-rdma
+  vpcSubnet: b200-rdma-subnet-0
+  deviceMode: RDMA
+---
+apiVersion: networking.gke.io/v1
+kind: Network
+metadata:
+  name: rdma-0
+spec:
+  parametersRef:
+    group: networking.gke.io
+    kind: GKENetworkParamSet
+    name: rdma-0
+  type: Device
+---
+apiVersion: networking.gke.io/v1
+kind: GKENetworkParamSet
+metadata:
+  name: rdma-1
+spec:
+  vpc: b200-rdma
+  vpcSubnet: b200-rdma-subnet-1
+  deviceMode: RDMA
+---
+apiVersion: networking.gke.io/v1
+kind: Network
+metadata:
+  name: rdma-1
+spec:
+  parametersRef:
+    group: networking.gke.io
+    kind: GKENetworkParamSet
+    name: rdma-1
+  type: Device
+---
+apiVersion: networking.gke.io/v1
+kind: GKENetworkParamSet
+metadata:
+  name: rdma-2
+spec:
+  vpc: b200-rdma
+  vpcSubnet: b200-rdma-subnet-2
+  deviceMode: RDMA
+---
+apiVersion: networking.gke.io/v1
+kind: Network
+metadata:
+  name: rdma-2
+spec:
+  parametersRef:
+    group: networking.gke.io
+    kind: GKENetworkParamSet
+    name: rdma-2
+  type: Device
+---
+apiVersion: networking.gke.io/v1
+kind: GKENetworkParamSet
+metadata:
+  name: rdma-3
+spec:
+  vpc: b200-rdma
+  vpcSubnet: b200-rdma-subnet-3
+  deviceMode: RDMA
+---
+apiVersion: networking.gke.io/v1
+kind: Network
+metadata:
+  name: rdma-3
+spec:
+  parametersRef:
+    group: networking.gke.io
+    kind: GKENetworkParamSet
+    name: rdma-3
+  type: Device
+---
+apiVersion: networking.gke.io/v1
+kind: GKENetworkParamSet
+metadata:
+  name: rdma-4
+spec:
+  vpc: b200-rdma
+  vpcSubnet: b200-rdma-subnet-4
+  deviceMode: RDMA
+---
+apiVersion: networking.gke.io/v1
+kind: Network
+metadata:
+  name: rdma-4
+spec:
+  parametersRef:
+    group: networking.gke.io
+    kind: GKENetworkParamSet
+    name: rdma-4
+  type: Device
+---
+apiVersion: networking.gke.io/v1
+kind: GKENetworkParamSet
+metadata:
+  name: rdma-5
+spec:
+  vpc: b200-rdma
+  vpcSubnet: b200-rdma-subnet-5
+  deviceMode: RDMA
+---
+apiVersion: networking.gke.io/v1
+kind: Network
+metadata:
+  name: rdma-5
+spec:
+  parametersRef:
+    group: networking.gke.io
+    kind: GKENetworkParamSet
+    name: rdma-5
+  type: Device
+---
+apiVersion: networking.gke.io/v1
+kind: GKENetworkParamSet
+metadata:
+  name: rdma-6
+spec:
+  vpc: b200-rdma
+  vpcSubnet: b200-rdma-subnet-6
+  deviceMode: RDMA
+---
+apiVersion: networking.gke.io/v1
+kind: Network
+metadata:
+  name: rdma-6
+spec:
+  parametersRef:
+    group: networking.gke.io
+    kind: GKENetworkParamSet
+    name: rdma-6
+  type: Device
+---
+apiVersion: networking.gke.io/v1
+kind: GKENetworkParamSet
+metadata:
+  name: rdma-7
+spec:
+  vpc: b200-rdma
+  vpcSubnet: b200-rdma-subnet-7
+  deviceMode: RDMA
+---
+apiVersion: networking.gke.io/v1
+kind: Network
+metadata:
+  name: rdma-7
+spec:
+  parametersRef:
+    group: networking.gke.io
+    kind: GKENetworkParamSet
+    name: rdma-7
+  type: Device

--- a/examples/gcp/gke-a4-b200-rdma/manifests/ray-head.yaml
+++ b/examples/gcp/gke-a4-b200-rdma/manifests/ray-head.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ray-head
+spec:
+  clusterIP: None
+  selector:
+    app: ray
+    role: head
+  ports:
+    - name: gcs
+      port: 6379
+      targetPort: 6379
+    - name: dashboard
+      port: 8265
+      targetPort: 8265
+    - name: client
+      port: 10001
+      targetPort: 10001
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ray-head
+  labels:
+    app: ray
+    role: head
+spec:
+  nodeSelector:
+    cloud.google.com/gke-nodepool: cpu-head
+  restartPolicy: Always
+  volumes:
+    - name: shared-memory
+      emptyDir:
+        medium: Memory
+        sizeLimit: 32Gi
+    - name: workspace
+      emptyDir:
+        sizeLimit: 100Gi
+  containers:
+    - name: ray
+      image: nvcr.io/nvidia/pytorch:25.04-py3
+      imagePullPolicy: IfNotPresent
+      resources:
+        requests:
+          cpu: "8"
+          memory: 32Gi
+        limits:
+          cpu: "14"
+          memory: 56Gi
+      ports:
+        - containerPort: 6379
+          name: gcs
+        - containerPort: 8265
+          name: dashboard
+        - containerPort: 10001
+          name: client
+      volumeMounts:
+        - name: shared-memory
+          mountPath: /dev/shm
+        - name: workspace
+          mountPath: /workspace
+      command: ["/bin/bash", "-lc"]
+      args:
+        - |
+          if [ -f /etc/ld.so.conf.d/00-cuda-compat.conf ]; then
+            mv /etc/ld.so.conf.d/00-cuda-compat.conf /etc/ld.so.conf.d/00-cuda-compat.conf.disabled
+            ldconfig
+          fi
+          sleep infinity
+

--- a/examples/gcp/gke-a4-b200-rdma/manifests/ray-workers-2.yaml
+++ b/examples/gcp/gke-a4-b200-rdma/manifests/ray-workers-2.yaml
@@ -1,0 +1,173 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ray-worker-0
+  labels:
+    app: ray
+    role: worker
+  annotations:
+    networking.gke.io/default-interface: "eth0"
+    networking.gke.io/interfaces: |
+      [
+        {"interfaceName":"eth0","network":"default"},
+        {"interfaceName":"eth2","network":"rdma-0"},
+        {"interfaceName":"eth3","network":"rdma-1"},
+        {"interfaceName":"eth4","network":"rdma-2"},
+        {"interfaceName":"eth5","network":"rdma-3"},
+        {"interfaceName":"eth6","network":"rdma-4"},
+        {"interfaceName":"eth7","network":"rdma-5"},
+        {"interfaceName":"eth8","network":"rdma-6"},
+        {"interfaceName":"eth9","network":"rdma-7"}
+      ]
+spec:
+  nodeSelector:
+    cloud.google.com/gke-accelerator: nvidia-b200
+    cloud.google.com/gke-nodepool: a4-spot
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app: ray
+              role: worker
+          topologyKey: kubernetes.io/hostname
+  restartPolicy: Always
+  volumes:
+    - name: library-dir-host
+      hostPath:
+        path: /home/kubernetes/bin/nvidia
+    - name: gib
+      hostPath:
+        path: /home/kubernetes/bin/gib
+    - name: gdrdrv
+      hostPath:
+        path: /dev/gdrdrv
+        type: CharDevice
+    - name: shared-memory
+      emptyDir:
+        medium: Memory
+        sizeLimit: 250Gi
+    - name: workspace
+      emptyDir:
+        sizeLimit: 200Gi
+  containers:
+    - name: ray
+      image: nvcr.io/nvidia/pytorch:25.04-py3
+      imagePullPolicy: IfNotPresent
+      env:
+        - name: LD_LIBRARY_PATH
+          value: /usr/local/nvidia/lib64:/usr/local/gib/lib64
+      securityContext:
+        capabilities:
+          add: ["IPC_LOCK", "SYS_PTRACE"]
+      resources:
+        limits:
+          nvidia.com/gpu: 8
+      volumeMounts:
+        - name: library-dir-host
+          mountPath: /usr/local/nvidia
+        - name: gib
+          mountPath: /usr/local/gib
+        - name: gdrdrv
+          mountPath: /dev/gdrdrv
+        - name: shared-memory
+          mountPath: /dev/shm
+        - name: workspace
+          mountPath: /workspace
+      command: ["/bin/bash", "-lc"]
+      args:
+        - |
+          if [ -f /etc/ld.so.conf.d/00-cuda-compat.conf ]; then
+            mv /etc/ld.so.conf.d/00-cuda-compat.conf /etc/ld.so.conf.d/00-cuda-compat.conf.disabled
+            ldconfig
+          fi
+          source /usr/local/gib/scripts/set_nccl_env.sh
+          sleep infinity
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ray-worker-1
+  labels:
+    app: ray
+    role: worker
+  annotations:
+    networking.gke.io/default-interface: "eth0"
+    networking.gke.io/interfaces: |
+      [
+        {"interfaceName":"eth0","network":"default"},
+        {"interfaceName":"eth2","network":"rdma-0"},
+        {"interfaceName":"eth3","network":"rdma-1"},
+        {"interfaceName":"eth4","network":"rdma-2"},
+        {"interfaceName":"eth5","network":"rdma-3"},
+        {"interfaceName":"eth6","network":"rdma-4"},
+        {"interfaceName":"eth7","network":"rdma-5"},
+        {"interfaceName":"eth8","network":"rdma-6"},
+        {"interfaceName":"eth9","network":"rdma-7"}
+      ]
+spec:
+  nodeSelector:
+    cloud.google.com/gke-accelerator: nvidia-b200
+    cloud.google.com/gke-nodepool: a4-spot
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app: ray
+              role: worker
+          topologyKey: kubernetes.io/hostname
+  restartPolicy: Always
+  volumes:
+    - name: library-dir-host
+      hostPath:
+        path: /home/kubernetes/bin/nvidia
+    - name: gib
+      hostPath:
+        path: /home/kubernetes/bin/gib
+    - name: gdrdrv
+      hostPath:
+        path: /dev/gdrdrv
+        type: CharDevice
+    - name: shared-memory
+      emptyDir:
+        medium: Memory
+        sizeLimit: 250Gi
+    - name: workspace
+      emptyDir:
+        sizeLimit: 200Gi
+  containers:
+    - name: ray
+      image: nvcr.io/nvidia/pytorch:25.04-py3
+      imagePullPolicy: IfNotPresent
+      env:
+        - name: LD_LIBRARY_PATH
+          value: /usr/local/nvidia/lib64:/usr/local/gib/lib64
+      securityContext:
+        capabilities:
+          add: ["IPC_LOCK", "SYS_PTRACE"]
+      resources:
+        limits:
+          nvidia.com/gpu: 8
+      volumeMounts:
+        - name: library-dir-host
+          mountPath: /usr/local/nvidia
+        - name: gib
+          mountPath: /usr/local/gib
+        - name: gdrdrv
+          mountPath: /dev/gdrdrv
+        - name: shared-memory
+          mountPath: /dev/shm
+        - name: workspace
+          mountPath: /workspace
+      command: ["/bin/bash", "-lc"]
+      args:
+        - |
+          if [ -f /etc/ld.so.conf.d/00-cuda-compat.conf ]; then
+            mv /etc/ld.so.conf.d/00-cuda-compat.conf /etc/ld.so.conf.d/00-cuda-compat.conf.disabled
+            ldconfig
+          fi
+          source /usr/local/gib/scripts/set_nccl_env.sh
+          sleep infinity
+

--- a/examples/gcp/gke-a4-b200-rdma/scripts/delete-a4-pool-when-unlocked.sh
+++ b/examples/gcp/gke-a4-b200-rdma/scripts/delete-a4-pool-when-unlocked.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GCLOUD=${GCLOUD:-}
+if [ -z "$GCLOUD" ]; then
+  if command -v gcloud >/dev/null 2>&1; then
+    GCLOUD=$(command -v gcloud)
+  else
+    echo "gcloud not found; set GCLOUD=/path/to/gcloud" >&2
+    exit 127
+  fi
+fi
+gcloud() { "$GCLOUD" "$@"; }
+
+PROJECT=${PROJECT:?Set PROJECT to your Google Cloud project ID}
+REGION=${REGION:?Set REGION to the GKE region}
+CLUSTER=${CLUSTER:?Set CLUSTER to the GKE cluster name}
+POOL=${POOL:-a4-spot}
+WAIT_SECONDS=${WAIT_SECONDS:-1800}
+SLEEP_SECONDS=${SLEEP_SECONDS:-30}
+DELETE_A4_POOL=${DELETE_A4_POOL:-false}
+
+target_fragment="clusters/${CLUSTER}/nodePools/${POOL}"
+deadline=$((SECONDS + WAIT_SECONDS))
+
+echo "Project: ${PROJECT}"
+echo "Region:  ${REGION}"
+echo "Cluster: ${CLUSTER}"
+echo "Pool:    ${POOL}"
+echo
+
+while true; do
+  running_ops=$(
+    gcloud container operations list \
+      --project="$PROJECT" \
+      --location="$REGION" \
+      --filter="status=RUNNING AND targetLink~${target_fragment}" \
+      --format='value(name)' || true
+  )
+
+  if [ -z "$running_ops" ]; then
+    break
+  fi
+
+  echo "Waiting for GKE operation(s) to unlock ${POOL}:"
+  echo "$running_ops" | sed 's/^/  /'
+
+  if [ "$SECONDS" -ge "$deadline" ]; then
+    echo "Timed out waiting after ${WAIT_SECONDS}s. Re-run this script later." >&2
+    exit 124
+  fi
+  sleep "$SLEEP_SECONDS"
+done
+
+if ! gcloud container node-pools describe "$POOL" \
+  --project="$PROJECT" \
+  --cluster="$CLUSTER" \
+  --location="$REGION" >/dev/null 2>&1; then
+  echo "Node pool ${POOL} is already absent."
+  exit 0
+fi
+
+if [ "$DELETE_A4_POOL" != "true" ]; then
+  cat <<EOF
+Node pool ${POOL} exists and is no longer locked by a running operation.
+
+Deletion is intentionally opt-in. To delete this test GPU pool, run:
+
+  DELETE_A4_POOL=true PROJECT=${PROJECT} REGION=${REGION} CLUSTER=${CLUSTER} POOL=${POOL} bash scripts/delete-a4-pool-when-unlocked.sh
+EOF
+  exit 2
+fi
+
+gcloud container node-pools delete "$POOL" \
+  --project="$PROJECT" \
+  --cluster="$CLUSTER" \
+  --location="$REGION" \
+  --quiet

--- a/examples/gcp/gke-a4-b200-rdma/scripts/install-addons-helm.sh
+++ b/examples/gcp/gke-a4-b200-rdma/scripts/install-addons-helm.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GCLOUD=${GCLOUD:-}
+if [ -z "$GCLOUD" ]; then
+  if command -v gcloud >/dev/null 2>&1; then
+    GCLOUD=$(command -v gcloud)
+  else
+    echo "gcloud not found; set GCLOUD=/path/to/gcloud" >&2
+    exit 127
+  fi
+fi
+gcloud() { "$GCLOUD" "$@"; }
+export PATH="$(dirname "$GCLOUD"):$PATH"
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+PROJECT=${PROJECT:?Set PROJECT to your Google Cloud project ID}
+REGION=${REGION:?Set REGION to the GKE region}
+CLUSTER=${CLUSTER:?Set CLUSTER to the GKE cluster name}
+RELEASE=${RELEASE:-gke-b200-rdma-addons}
+NAMESPACE=${NAMESPACE:-default}
+GVNIC_NETWORK=${GVNIC_NETWORK:?Set GVNIC_NETWORK to the extra gVNIC network name}
+GVNIC_SUBNET=${GVNIC_SUBNET:?Set GVNIC_SUBNET to the extra gVNIC subnet name}
+RDMA_NETWORK=${RDMA_NETWORK:?Set RDMA_NETWORK to the RDMA network name}
+RDMA_SUBNET_PREFIX=${RDMA_SUBNET_PREFIX:?Set RDMA_SUBNET_PREFIX to the RDMA subnet name prefix}
+RESET_LOCAL_ADDONS=${RESET_LOCAL_ADDONS:-0}
+network_names=(gvnic-1 rdma-0 rdma-1 rdma-2 rdma-3 rdma-4 rdma-5 rdma-6 rdma-7)
+
+if ! command -v helm >/dev/null 2>&1; then
+  echo "helm not found; install Helm or use scripts/install-addons.sh" >&2
+  exit 127
+fi
+
+gcloud container clusters get-credentials "$CLUSTER" --location="$REGION" --project="$PROJECT"
+
+if [ "$RESET_LOCAL_ADDONS" = "1" ]; then
+  echo "RESET_LOCAL_ADDONS=1: removing local manifest/Helm-owned add-ons before reinstall."
+  helm uninstall "$RELEASE" --namespace "$NAMESPACE" >/dev/null 2>&1 || true
+  kubectl delete pod/ray-head --namespace="$NAMESPACE" --ignore-not-found --force --grace-period=0 --wait=false
+  kubectl delete pod -l app=ray,role=worker --namespace="$NAMESPACE" --ignore-not-found --force --grace-period=0 --wait=false
+  kubectl delete service/ray-head --namespace="$NAMESPACE" --ignore-not-found
+  kubectl delete daemonset/gdrdrv-loader -n kube-system --ignore-not-found
+  for name in "${network_names[@]}"; do
+    kubectl delete network "$name" --ignore-not-found
+  done
+  for name in "${network_names[@]}"; do
+    kubectl delete gkenetworkparamset "$name" --ignore-not-found
+  done
+fi
+
+kubectl apply -f \
+  https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/refs/heads/master/gpudirect-rdma/nccl-rdma-installer.yaml
+kubectl rollout status daemonset/nccl-rdma-installer -n kube-system --timeout=10m
+
+echo "Applying GKE Network objects before creating worker pods."
+helm template "$RELEASE" "$ROOT/helm/gke-b200-rdma-addons" \
+  --namespace "$NAMESPACE" \
+  --show-only templates/network-objects.yaml \
+  --set "gvnic.network=${GVNIC_NETWORK}" \
+  --set "gvnic.subnet=${GVNIC_SUBNET}" \
+  --set "rdma.network=${RDMA_NETWORK}" \
+  --set "rdma.subnetPrefix=${RDMA_SUBNET_PREFIX}" |
+  kubectl apply -f -
+
+for name in "${network_names[@]}"; do
+  kubectl get network "$name" >/dev/null
+  kubectl get gkenetworkparamset "$name" >/dev/null
+done
+
+echo "Waiting briefly for GKE networking admission to observe Network objects."
+sleep 10
+
+helm upgrade --install "$RELEASE" "$ROOT/helm/gke-b200-rdma-addons" \
+  --namespace "$NAMESPACE" \
+  --set "gvnic.network=${GVNIC_NETWORK}" \
+  --set "gvnic.subnet=${GVNIC_SUBNET}" \
+  --set "rdma.network=${RDMA_NETWORK}" \
+  --set "rdma.subnetPrefix=${RDMA_SUBNET_PREFIX}"
+
+kubectl rollout status daemonset/gdrdrv-loader -n kube-system --timeout=10m
+kubectl wait --for=condition=Ready pod/ray-head --namespace="$NAMESPACE" --timeout=10m
+kubectl wait --for=condition=Ready pod -l app=ray,role=worker --namespace="$NAMESPACE" --timeout=15m
+kubectl get pods --namespace="$NAMESPACE" -o wide

--- a/examples/gcp/gke-a4-b200-rdma/scripts/install-addons.sh
+++ b/examples/gcp/gke-a4-b200-rdma/scripts/install-addons.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GCLOUD=${GCLOUD:-}
+if [ -z "$GCLOUD" ]; then
+  if command -v gcloud >/dev/null 2>&1; then
+    GCLOUD=$(command -v gcloud)
+  else
+    echo "gcloud not found; set GCLOUD=/path/to/gcloud" >&2
+    exit 127
+  fi
+fi
+gcloud() { "$GCLOUD" "$@"; }
+export PATH="$(dirname "$GCLOUD"):$PATH"
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+PROJECT=${PROJECT:?Set PROJECT to your Google Cloud project ID}
+REGION=${REGION:?Set REGION to the GKE region}
+CLUSTER=${CLUSTER:?Set CLUSTER to the GKE cluster name}
+
+gcloud container clusters get-credentials "$CLUSTER" --location="$REGION" --project="$PROJECT"
+
+bash "$ROOT/scripts/render-network-objects.sh" | kubectl apply -f -
+
+kubectl apply -f \
+  https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/refs/heads/master/gpudirect-rdma/nccl-rdma-installer.yaml
+kubectl rollout status daemonset/nccl-rdma-installer -n kube-system --timeout=10m
+
+kubectl apply -f "$ROOT/manifests/gdrdrv-loader-daemonset.yaml"
+kubectl rollout status daemonset/gdrdrv-loader -n kube-system --timeout=10m
+
+kubectl apply -f "$ROOT/manifests/ray-head.yaml"
+kubectl apply -f "$ROOT/manifests/ray-workers-2.yaml"
+kubectl wait --for=condition=Ready pod/ray-head --timeout=10m
+kubectl wait --for=condition=Ready pod -l app=ray,role=worker --timeout=15m
+
+kubectl get pods -o wide

--- a/examples/gcp/gke-a4-b200-rdma/scripts/install-uccl-in-ray-workers.sh
+++ b/examples/gcp/gke-a4-b200-rdma/scripts/install-uccl-in-ray-workers.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GCLOUD=${GCLOUD:-}
+if [ -z "$GCLOUD" ]; then
+  if command -v gcloud >/dev/null 2>&1; then
+    GCLOUD=$(command -v gcloud)
+  else
+    echo "gcloud not found; set GCLOUD=/path/to/gcloud" >&2
+    exit 127
+  fi
+fi
+gcloud() { "$GCLOUD" "$@"; }
+export PATH="$(dirname "$GCLOUD"):$PATH"
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+PROJECT=${PROJECT:?Set PROJECT to your Google Cloud project ID}
+REGION=${REGION:?Set REGION to the GKE region}
+CLUSTER=${CLUSTER:?Set CLUSTER to the GKE cluster name}
+PODS=${PODS:-ray-worker-0 ray-worker-1}
+UCCL_URL=${UCCL_URL:-https://github.com/uccl-project/uccl.git}
+UCCL_REF=${UCCL_REF:-v0.1.1}
+PYTHON=${PYTHON:-/workspace/rayenv/.venv/bin/python}
+UV=${UV:-/root/.local/bin/uv}
+UCCL_TORCH_CUDA_ARCH_LIST=${UCCL_TORCH_CUDA_ARCH_LIST:-10.0}
+EFA_HOME=${EFA_HOME:-/opt/gcp-no-efa}
+UCCL_FORCE_DMABUF=${UCCL_FORCE_DMABUF:-1}
+SKIP_READY_INSTALLS=${SKIP_READY_INSTALLS:-1}
+INSTALL_RETRIES=${INSTALL_RETRIES:-2}
+
+gcloud container clusters get-credentials "$CLUSTER" --location="$REGION" --project="$PROJECT"
+
+for pod in $PODS; do
+  echo "Copying GCP middle-layer helpers to ${pod}"
+  kubectl exec "$pod" -- bash -lc 'mkdir -p /opt/gcp-middle/env /opt/gcp-middle/scripts'
+  kubectl cp "$ROOT/docker/env/." "${pod}:/opt/gcp-middle/env"
+  kubectl cp "$ROOT/docker/scripts/." "${pod}:/opt/gcp-middle/scripts"
+  kubectl exec "$pod" -- bash -lc 'chmod +x /opt/gcp-middle/env/*.sh /opt/gcp-middle/scripts/*.sh'
+
+  if [ "$SKIP_READY_INSTALLS" = "1" ] && kubectl exec "$pod" -- env PYTHON="$PYTHON" bash -lc '
+    test -f /opt/uccl/ep/include/common.hpp
+    grep -q GCP_FORCE_DMABUF /opt/uccl/ep/include/common.hpp
+    "$PYTHON" - <<"PY"
+import uccl
+import uccl.ep
+import deep_ep
+print("uccl ready")
+PY
+  '; then
+    echo "UCCL/UCCL-EP/DeepEP already installed in ${pod}; skipping install."
+    continue
+  fi
+
+  echo "Installing UCCL/UCCL-EP/DeepEP wrapper in ${pod}"
+  installed=0
+  for attempt in $(seq 1 "$INSTALL_RETRIES"); do
+    if kubectl exec "$pod" -- env UCCL_URL="$UCCL_URL" UCCL_REF="$UCCL_REF" PYTHON="$PYTHON" UV="$UV" UCCL_TORCH_CUDA_ARCH_LIST="$UCCL_TORCH_CUDA_ARCH_LIST" EFA_HOME="$EFA_HOME" UCCL_FORCE_DMABUF="$UCCL_FORCE_DMABUF" bash -lc '
+    set -euo pipefail
+    export DEBIAN_FRONTEND=noninteractive
+    export CUDA_HOME=${CUDA_HOME:-/usr/local/cuda}
+    export TORCH_CUDA_ARCH_LIST=${UCCL_TORCH_CUDA_ARCH_LIST}
+    export EFA_HOME=${EFA_HOME}
+    export PER_EXPERT_BATCHING=${PER_EXPERT_BATCHING:-1}
+    export USE_DMABUF=${USE_DMABUF:-1}
+    export UCCL_FORCE_DMABUF=${UCCL_FORCE_DMABUF:-1}
+    export MAX_JOBS=${MAX_JOBS:-16}
+
+    apt-get update
+    apt-get install -y --no-install-recommends \
+      autoconf \
+      automake \
+      build-essential \
+      ca-certificates \
+      curl \
+      git \
+      ibverbs-providers \
+      iproute2 \
+      libhwloc-dev \
+      libibverbs-dev \
+      libnl-3-dev \
+      libnl-route-3-dev \
+      libnuma-dev \
+      librdmacm-dev \
+      libtool \
+      perl \
+      pciutils \
+      pkg-config \
+      rdma-core \
+      wget
+    rm -rf /var/lib/apt/lists/*
+
+    test -x "$UV"
+    "$UV" pip install --python "$PYTHON" --no-cache --upgrade pip setuptools wheel
+    "$UV" pip install --python "$PYTHON" --no-cache nanobind intervaltree sortedcontainers
+
+    if [ ! -d /opt/uccl/.git ]; then
+      rm -rf /opt/uccl
+      git clone "$UCCL_URL" /opt/uccl
+    fi
+    cd /opt/uccl
+    git fetch --tags
+    git checkout "$UCCL_REF"
+    if [ "$UCCL_FORCE_DMABUF" = "1" ]; then
+      if ! grep -q "GCP_FORCE_DMABUF" ep/include/common.hpp; then
+        perl -0pi -e "s{// Intel RDMA NIC support}{#ifndef USE_DMABUF\\n#define USE_DMABUF  // GCP_FORCE_DMABUF: force DMA-BUF for GKE A4 RoCE\\n#endif\\n\\n// Intel RDMA NIC support}" ep/include/common.hpp
+      fi
+    fi
+
+    "$UV" pip install --python "$PYTHON" --no-cache /opt/uccl
+    rm -rf /tmp/uccl_ep_build
+    cp -a /opt/uccl /tmp/uccl_ep_build
+    cd /tmp/uccl_ep_build/ep
+    "$PYTHON" setup.py install
+    cd /tmp/uccl_ep_build/ep/deep_ep_wrapper
+    for name in buffer.py test_internode.py utils.py; do
+      rm -f "deep_ep/${name}"
+      cp "../bench/${name}" "deep_ep/${name}"
+    done
+    "$UV" pip install --python "$PYTHON" --no-cache --no-build-isolation .
+    rm -rf /tmp/uccl_ep_build
+  '; then
+      installed=1
+      break
+    fi
+    echo "Install attempt ${attempt}/${INSTALL_RETRIES} failed in ${pod}." >&2
+    sleep 10
+  done
+  if [ "$installed" != "1" ]; then
+    echo "Failed to install UCCL/UCCL-EP/DeepEP in ${pod} after ${INSTALL_RETRIES} attempts." >&2
+    exit 1
+  fi
+done

--- a/examples/gcp/gke-a4-b200-rdma/scripts/preflight.sh
+++ b/examples/gcp/gke-a4-b200-rdma/scripts/preflight.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GCLOUD=${GCLOUD:-}
+if [ -z "$GCLOUD" ]; then
+  if command -v gcloud >/dev/null 2>&1; then
+    GCLOUD=$(command -v gcloud)
+  else
+    echo "gcloud not found; set GCLOUD=/path/to/gcloud" >&2
+    exit 127
+  fi
+fi
+gcloud() { "$GCLOUD" "$@"; }
+export PATH="$(dirname "$GCLOUD"):$PATH"
+
+PROJECT=${PROJECT:?Set PROJECT to your Google Cloud project ID}
+REGION=${REGION:?Set REGION to the GKE region}
+ZONE=${ZONE:?Set ZONE to the A4/B200 worker zone}
+CLUSTER=${CLUSTER:?Set CLUSTER to the GKE cluster name}
+ALLOW_EXISTING_CLUSTER=${ALLOW_EXISTING_CLUSTER:-0}
+
+echo "Project: ${PROJECT}"
+echo "Region:  ${REGION}"
+echo "Zone:    ${ZONE}"
+echo "Cluster: ${CLUSTER}"
+
+for tool in terraform kubectl; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "Missing required tool: ${tool}" >&2
+    exit 1
+  fi
+done
+if ! command -v gke-gcloud-auth-plugin >/dev/null 2>&1; then
+  echo "Missing required tool: gke-gcloud-auth-plugin" >&2
+  echo "It is usually in the same Google Cloud SDK bin directory as gcloud." >&2
+  exit 1
+fi
+echo "gcloud: ${GCLOUD}"
+
+# Terraform authenticates with Application Default Credentials (ADC), which are
+# separate from the gcloud user login. Without them, terraform fails at apply.
+if [ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ] && [ -f "${GOOGLE_APPLICATION_CREDENTIALS}" ]; then
+  echo "ADC: GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS}"
+elif [ -f "${CLOUDSDK_CONFIG:-$HOME/.config/gcloud}/application_default_credentials.json" ]; then
+  echo "ADC: application_default_credentials.json present"
+else
+  echo "Missing Application Default Credentials (needed by Terraform)." >&2
+  echo "Run: gcloud auth application-default login" >&2
+  echo "Then: gcloud auth application-default set-quota-project ${PROJECT}" >&2
+  exit 1
+fi
+
+echo
+echo "Existing GKE clusters:"
+gcloud container clusters list --project="$PROJECT" \
+  --format='table(name,location,status,currentMasterVersion)'
+
+echo
+echo "Planned cluster collision check:"
+if gcloud container clusters describe "$CLUSTER" --location="$REGION" --project="$PROJECT" >/dev/null 2>&1; then
+  if [ "$ALLOW_EXISTING_CLUSTER" != "1" ]; then
+    echo "Cluster ${CLUSTER} already exists in ${REGION}" >&2
+    echo "Set ALLOW_EXISTING_CLUSTER=1 when intentionally rebuilding node pools on an existing control plane." >&2
+    exit 1
+  fi
+  echo "Cluster ${CLUSTER} already exists in ${REGION}; ALLOW_EXISTING_CLUSTER=1 so this is treated as an intentional reuse."
+  echo
+  echo "Existing node pools for ${CLUSTER}:"
+  gcloud container node-pools list \
+    --cluster="$CLUSTER" \
+    --region="$REGION" \
+    --project="$PROJECT" \
+    --format='table(name,status,version,config.machineType,autoscaling.enabled,initialNodeCount)' || true
+else
+  echo "No cluster named ${CLUSTER} exists in ${REGION}."
+fi
+
+echo
+echo "VPC networks quota check (module creates 2 new VPCs: gVNIC + RDMA):"
+NET_COUNT=$(gcloud compute networks list --project="$PROJECT" --format='value(name)' 2>/dev/null | wc -l | tr -d ' ')
+NET_LIMIT=$(gcloud compute project-info describe --project="$PROJECT" \
+  --format='value(quotas.filter("metric:NETWORKS").extract("limit").flatten())' 2>/dev/null | head -1)
+NET_LIMIT=${NET_LIMIT:-30}
+echo "  networks in use: ${NET_COUNT} / limit ${NET_LIMIT%.*}"
+if [ "$NET_COUNT" -gt $(( ${NET_LIMIT%.*} - 2 )) ]; then
+  echo "  WARNING: fewer than 2 free network slots; terraform apply will fail with 'Quota NETWORKS exceeded'." >&2
+  echo "  Raise the NETWORKS quota (Cloud Quotas API / console) or free unused VPC networks before applying." >&2
+fi
+
+echo
+echo "A4/B200 Spot usage by region (QUOTA HEURISTIC, assumes 64-GPU/8-node quota):"
+echo "  NOTE: this is a quota estimate from running-node counts, NOT live spot"
+echo "  capacity. A zone can show headroom here yet fail with GCE_STOCKOUT."
+echo "  Run scripts/probe-b200-capacity.sh to find zones with real capacity now."
+gcloud compute instances list --project="$PROJECT" \
+  --filter='machineType:a4-highgpu-8g AND status=RUNNING' \
+  --format='value(zone)' |
+awk '{
+  split($1, a, "-");
+  region = a[1] "-" a[2];
+  count[region]++;
+}
+END {
+  for (r in count) {
+    printf "%s %d running_nodes %d_used_B200_GPUs %d_remaining_nodes_by_64_gpu_quota\n", r, count[r], count[r] * 8, 8 - count[r];
+  }
+}' | sort
+
+echo
+echo "Safety: this workflow targets only the configured GKE cluster and node pools."

--- a/examples/gcp/gke-a4-b200-rdma/scripts/probe-b200-capacity.sh
+++ b/examples/gcp/gke-a4-b200-rdma/scripts/probe-b200-capacity.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Probe live A4/B200 spot capacity across RoCE-capable zones.
+#
+# GKE node-pool creation retries a stocked-out zone for ~35 minutes before it
+# fails, so blindly picking a zone can cost 30+ minutes per miss. This helper
+# fires short-lived spot VM create attempts that fail in seconds on STOCKOUT or
+# QUOTA and are deleted immediately on success, so you can pick a zone with real
+# capacity BEFORE running terraform.
+#
+# It changes no long-lived resources: any probe VM that provisions is deleted.
+#
+# Output ends with a "ZONES WITH CAPACITY" list. Present that list to the user
+# and let them choose the target zone; do not silently pick one.
+set -euo pipefail
+
+GCLOUD=${GCLOUD:-}
+if [ -z "$GCLOUD" ]; then
+  if command -v gcloud >/dev/null 2>&1; then
+    GCLOUD=$(command -v gcloud)
+  else
+    echo "gcloud not found; set GCLOUD=/path/to/gcloud" >&2
+    exit 127
+  fi
+fi
+gcloud() { "$GCLOUD" "$@"; }
+export PATH="$(dirname "$GCLOUD"):$PATH"
+
+PROJECT=${PROJECT:?Set PROJECT to your Google Cloud project ID}
+MACHINE_TYPE=${MACHINE_TYPE:-a4-highgpu-8g}
+PROVISIONING_MODEL=${PROVISIONING_MODEL:-SPOT}
+PROBE_NETWORK=${PROBE_NETWORK:-default}
+PROBE_IMAGE_FAMILY=${PROBE_IMAGE_FAMILY:-debian-12}
+PROBE_IMAGE_PROJECT=${PROBE_IMAGE_PROJECT:-debian-cloud}
+
+# ZONES: space-separated override. Default: every zone that has a matching
+# "<zone>-vpc-roce" network profile (i.e. supports B200 GPUDirect RDMA).
+ZONES=${ZONES:-}
+if [ -z "$ZONES" ]; then
+  echo "Deriving RoCE-capable zones from network profiles..."
+  ZONES=$(gcloud compute network-profiles list --project="$PROJECT" \
+    --format='value(name)' 2>/dev/null \
+    | grep -- '-vpc-roce$' | sed 's/-vpc-roce$//' | sort -u | tr '\n' ' ')
+fi
+
+if [ -z "${ZONES// /}" ]; then
+  echo "No candidate zones. Set ZONES=\"us-west3-c us-east1-b ...\"" >&2
+  exit 1
+fi
+
+echo "Project:            ${PROJECT}"
+echo "Machine type:       ${MACHINE_TYPE}"
+echo "Provisioning model: ${PROVISIONING_MODEL}"
+echo "Candidate zones:    ${ZONES}"
+echo
+echo "NOTE: this reflects capacity at this instant; spot capacity can change."
+echo
+
+AVAILABLE=()
+for Z in $ZONES; do
+  NAME="probe-b200-${Z}-$$"
+  OUT=$(gcloud compute instances create "$NAME" \
+    --project="$PROJECT" --zone="$Z" \
+    --machine-type="$MACHINE_TYPE" \
+    --provisioning-model="$PROVISIONING_MODEL" --instance-termination-action=DELETE \
+    --maintenance-policy=TERMINATE --no-address --network="$PROBE_NETWORK" \
+    --image-family="$PROBE_IMAGE_FAMILY" --image-project="$PROBE_IMAGE_PROJECT" \
+    --boot-disk-size=50GB 2>&1 || true)
+
+  if echo "$OUT" | grep -qiE 'STOCKOUT|does not have enough resources'; then
+    printf '  %-20s STOCKOUT\n' "$Z"
+  elif echo "$OUT" | grep -qiE 'Quota .*exceeded|quota'; then
+    printf '  %-20s QUOTA_EXCEEDED\n' "$Z"
+  elif echo "$OUT" | grep -qiE "does not have machine type|Invalid value for field 'resource.machineType'"; then
+    printf '  %-20s NO_%s\n' "$Z" "$MACHINE_TYPE"
+  elif echo "$OUT" | grep -qiE "Created|instances/${NAME}"; then
+    printf '  %-20s *** CAPACITY AVAILABLE ***\n' "$Z"
+    AVAILABLE+=("$Z")
+    gcloud compute instances delete "$NAME" --project="$PROJECT" --zone="$Z" --quiet >/dev/null 2>&1 \
+      && printf '  %-20s (probe deleted)\n' "$Z" \
+      || printf '  %-20s WARNING: could not delete probe %s\n' "$Z" "$NAME" >&2
+  else
+    printf '  %-20s OTHER: %s\n' "$Z" "$(echo "$OUT" | tail -1)"
+  fi
+done
+
+echo
+echo "ZONES WITH CAPACITY: ${AVAILABLE[*]:-none}"
+if [ "${#AVAILABLE[@]}" -eq 0 ]; then
+  echo "No zone had live ${PROVISIONING_MODEL} ${MACHINE_TYPE} capacity. Retry later or ask the user."
+  exit 2
+fi
+echo "Present these to the user and let them choose the target zone before terraform apply."

--- a/examples/gcp/gke-a4-b200-rdma/scripts/render-network-objects.sh
+++ b/examples/gcp/gke-a4-b200-rdma/scripts/render-network-objects.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GVNIC_NETWORK=${GVNIC_NETWORK:?Set GVNIC_NETWORK to the extra gVNIC network name}
+GVNIC_SUBNET=${GVNIC_SUBNET:?Set GVNIC_SUBNET to the extra gVNIC subnet name}
+RDMA_NETWORK=${RDMA_NETWORK:?Set RDMA_NETWORK to the RDMA network name}
+RDMA_SUBNET_PREFIX=${RDMA_SUBNET_PREFIX:?Set RDMA_SUBNET_PREFIX to the RDMA subnet name prefix}
+
+cat <<EOF
+---
+apiVersion: networking.gke.io/v1
+kind: GKENetworkParamSet
+metadata:
+  name: gvnic-1
+spec:
+  vpc: ${GVNIC_NETWORK}
+  vpcSubnet: ${GVNIC_SUBNET}
+  deviceMode: NetDevice
+---
+apiVersion: networking.gke.io/v1
+kind: Network
+metadata:
+  name: gvnic-1
+spec:
+  parametersRef:
+    group: networking.gke.io
+    kind: GKENetworkParamSet
+    name: gvnic-1
+  type: Device
+EOF
+
+for n in $(seq 0 7); do
+  cat <<EOF
+---
+apiVersion: networking.gke.io/v1
+kind: GKENetworkParamSet
+metadata:
+  name: rdma-${n}
+spec:
+  vpc: ${RDMA_NETWORK}
+  vpcSubnet: ${RDMA_SUBNET_PREFIX}-${n}
+  deviceMode: RDMA
+---
+apiVersion: networking.gke.io/v1
+kind: Network
+metadata:
+  name: rdma-${n}
+spec:
+  parametersRef:
+    group: networking.gke.io
+    kind: GKENetworkParamSet
+    name: rdma-${n}
+  type: Device
+EOF
+done
+

--- a/examples/gcp/gke-a4-b200-rdma/scripts/run-nccl-test.sh
+++ b/examples/gcp/gke-a4-b200-rdma/scripts/run-nccl-test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GCLOUD=${GCLOUD:-}
+if [ -z "$GCLOUD" ]; then
+  if command -v gcloud >/dev/null 2>&1; then
+    GCLOUD=$(command -v gcloud)
+  else
+    echo "gcloud not found; set GCLOUD=/path/to/gcloud" >&2
+    exit 127
+  fi
+fi
+gcloud() { "$GCLOUD" "$@"; }
+export PATH="$(dirname "$GCLOUD"):$PATH"
+
+PROJECT=${PROJECT:?Set PROJECT to your Google Cloud project ID}
+REGION=${REGION:?Set REGION to the GKE region}
+CLUSTER=${CLUSTER:?Set CLUSTER to the GKE cluster name}
+TEST_URL=${TEST_URL:-https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/refs/heads/master/gpudirect-rdma/nccl-test-a4.yaml}
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+NAMESPACE=${NAMESPACE:-default}
+SUSPEND_RAY_WORKERS=${SUSPEND_RAY_WORKERS:-0}
+RESTORE_RAY_WORKERS=${RESTORE_RAY_WORKERS:-$SUSPEND_RAY_WORKERS}
+GVNIC_NETWORK=${GVNIC_NETWORK:?Set GVNIC_NETWORK to the extra gVNIC network name}
+GVNIC_SUBNET=${GVNIC_SUBNET:?Set GVNIC_SUBNET to the extra gVNIC subnet name}
+RDMA_NETWORK=${RDMA_NETWORK:?Set RDMA_NETWORK to the RDMA network name}
+RDMA_SUBNET_PREFIX=${RDMA_SUBNET_PREFIX:?Set RDMA_SUBNET_PREFIX to the RDMA subnet name prefix}
+
+gcloud container clusters get-credentials "$CLUSTER" --location="$REGION" --project="$PROJECT"
+
+wait_for_no_ray_workers() {
+  for _ in $(seq 1 120); do
+    if ! kubectl get pod -l app=ray,role=worker --namespace="$NAMESPACE" --no-headers 2>/dev/null | grep -q .; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "Timed out waiting for Ray worker pods to disappear." >&2
+  return 1
+}
+
+cleanup_nccl_test() {
+  if [ "${DELETE_NCCL_TEST:-0}" = "1" ] || [ "$RESTORE_RAY_WORKERS" = "1" ]; then
+    kubectl delete -f "$TEST_URL" --ignore-not-found >/dev/null 2>&1 || true
+  fi
+}
+
+restore_ray_workers() {
+  if [ "$RESTORE_RAY_WORKERS" = "1" ]; then
+    echo "Restoring Ray workers with Helm add-on installer."
+    PROJECT="$PROJECT" \
+    REGION="$REGION" \
+    CLUSTER="$CLUSTER" \
+    NAMESPACE="$NAMESPACE" \
+    GVNIC_NETWORK="$GVNIC_NETWORK" \
+    GVNIC_SUBNET="$GVNIC_SUBNET" \
+    RDMA_NETWORK="$RDMA_NETWORK" \
+    RDMA_SUBNET_PREFIX="$RDMA_SUBNET_PREFIX" \
+    bash "$ROOT/scripts/install-addons-helm.sh"
+  fi
+}
+
+finish() {
+  status=$?
+  cleanup_nccl_test
+  restore_ray_workers
+  exit "$status"
+}
+trap finish EXIT
+
+if [ "$SUSPEND_RAY_WORKERS" = "1" ]; then
+  echo "Suspending Ray worker pods so NCCL test pods can reserve all A4 GPUs."
+  kubectl delete pod -l app=ray,role=worker \
+    --namespace="$NAMESPACE" \
+    --ignore-not-found \
+    --force \
+    --grace-period=0 \
+    --wait=false
+  wait_for_no_ray_workers
+fi
+
+kubectl apply -f "$TEST_URL"
+kubectl wait --for=condition=Ready pod/nccl-test-host-1 pod/nccl-test-host-2 --timeout=15m
+
+echo "== all_gather =="
+kubectl exec nccl-test-host-1 -- \
+  /usr/local/gib/scripts/run_nccl_tests.sh \
+    -t all_gather -b 1K -e 8G nccl-host-1 nccl-host-2
+
+echo
+echo "== all_reduce =="
+kubectl exec nccl-test-host-1 -- \
+  /usr/local/gib/scripts/run_nccl_tests.sh \
+    -t all_reduce -b 1K -e 8G nccl-host-1 nccl-host-2

--- a/examples/gcp/gke-a4-b200-rdma/scripts/run-uccl-ep-test.sh
+++ b/examples/gcp/gke-a4-b200-rdma/scripts/run-uccl-ep-test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GCLOUD=${GCLOUD:-}
+if [ -z "$GCLOUD" ]; then
+  if command -v gcloud >/dev/null 2>&1; then
+    GCLOUD=$(command -v gcloud)
+  else
+    echo "gcloud not found; set GCLOUD=/path/to/gcloud" >&2
+    exit 127
+  fi
+fi
+gcloud() { "$GCLOUD" "$@"; }
+export PATH="$(dirname "$GCLOUD"):$PATH"
+
+PROJECT=${PROJECT:?Set PROJECT to your Google Cloud project ID}
+REGION=${REGION:?Set REGION to the GKE region}
+CLUSTER=${CLUSTER:?Set CLUSTER to the GKE cluster name}
+MODE=${1:-${MODE:-ll}}
+POD0=${POD0:-ray-worker-0}
+POD1=${POD1:-ray-worker-1}
+PYTHON=${PYTHON:-/workspace/rayenv/.venv/bin/python}
+NPROC_PER_NODE=${NPROC_PER_NODE:-8}
+TIMEOUT=${TIMEOUT:-300s}
+
+case "$MODE" in
+  ll)
+    MASTER_PORT=${MASTER_PORT:-6423}
+    TOKEN_ENV="LL_TOKENS=${LL_TOKENS:-128}"
+    SUMMARY_PATTERN="All correctness tests passed|Dispatch|Combine|Destination ctx missing"
+    ;;
+  ht)
+    MASTER_PORT=${MASTER_PORT:-6424}
+    TOKEN_ENV="HT_TOKENS=${HT_TOKENS:-4096}"
+    SUMMARY_PATTERN="All correctness tests passed|Best dispatch|Best combine|Destination ctx missing"
+    ;;
+  *)
+    echo "Usage: $0 [ll|ht]" >&2
+    exit 2
+    ;;
+esac
+
+gcloud container clusters get-credentials "$CLUSTER" --location="$REGION" --project="$PROJECT"
+
+MASTER_ADDR=$(kubectl get pod "$POD0" -o jsonpath='{.status.podIP}')
+LOG0=${LOG0:-/tmp/uccl-${MODE}-r0.log}
+LOG1=${LOG1:-/tmp/uccl-${MODE}-r1.log}
+rm -f "$LOG0" "$LOG1"
+
+run_rank() {
+  local pod=$1
+  local rank=$2
+  local log=$3
+
+  kubectl exec "$pod" -- bash -lc \
+    "PATH=$(dirname "$PYTHON"):\$PATH \
+     PYTHON=$PYTHON \
+     NNODES=2 NPROC_PER_NODE=$NPROC_PER_NODE NODE_RANK=$rank \
+     MASTER_ADDR=$MASTER_ADDR MASTER_PORT=$MASTER_PORT $TOKEN_ENV \
+     timeout $TIMEOUT /opt/gcp-middle/scripts/validate_uccl_ep.sh $MODE" \
+    >"$log" 2>&1 &
+}
+
+run_rank "$POD0" 0 "$LOG0"
+pid0=$!
+sleep 5
+run_rank "$POD1" 1 "$LOG1"
+pid1=$!
+
+wait "$pid0"; s0=$?
+wait "$pid1"; s1=$?
+echo "rank0_status=$s0 rank1_status=$s1"
+echo "rank0_log=$LOG0"
+echo "rank1_log=$LOG1"
+
+echo
+echo "== rank0 summary =="
+grep -E "$SUMMARY_PATTERN" "$LOG0" || true
+tail -80 "$LOG0"
+
+echo
+echo "== rank1 summary =="
+grep -E "$SUMMARY_PATTERN" "$LOG1" || true
+tail -80 "$LOG1"
+
+if [ "$s0" != "0" ] || [ "$s1" != "0" ]; then
+  exit 1
+fi

--- a/examples/gcp/gke-a4-b200-rdma/scripts/setup-ray-in-pods.sh
+++ b/examples/gcp/gke-a4-b200-rdma/scripts/setup-ray-in-pods.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GCLOUD=${GCLOUD:-}
+if [ -z "$GCLOUD" ]; then
+  if command -v gcloud >/dev/null 2>&1; then
+    GCLOUD=$(command -v gcloud)
+  else
+    echo "gcloud not found; set GCLOUD=/path/to/gcloud" >&2
+    exit 127
+  fi
+fi
+gcloud() { "$GCLOUD" "$@"; }
+export PATH="$(dirname "$GCLOUD"):$PATH"
+
+PROJECT=${PROJECT:?Set PROJECT to your Google Cloud project ID}
+REGION=${REGION:?Set REGION to the GKE region}
+CLUSTER=${CLUSTER:?Set CLUSTER to the GKE cluster name}
+SKIP_INSTALL=${SKIP_INSTALL:-0}
+
+# Ray/UCCL run inside a Python venv on each pod. By default this creates a
+# minimal, generic environment (Ray + a CUDA build of PyTorch) that is all the
+# NCCL/UCCL validation needs. To install your own project into the venv instead
+# (e.g. a training framework), set RAY_ENV_SETUP_CMD to a shell command that
+# creates/populates the venv at $RAY_VENV.
+RAY_WORKDIR=${RAY_WORKDIR:-/workspace/rayenv}
+RAY_VENV=${RAY_VENV:-$RAY_WORKDIR/.venv}
+RAY_PYTHON_VERSION=${RAY_PYTHON_VERSION:-3.12}
+RAY_SPEC=${RAY_SPEC:-ray[default]}
+TORCH_SPEC=${TORCH_SPEC:-torch}
+TORCH_INDEX_URL=${TORCH_INDEX_URL:-https://download.pytorch.org/whl/cu128}
+RAY_ENV_SETUP_CMD=${RAY_ENV_SETUP_CMD:-}
+SKIP_READY_INSTALLS=${SKIP_READY_INSTALLS:-1}
+INSTALL_RETRIES=${INSTALL_RETRIES:-2}
+
+gcloud container clusters get-credentials "$CLUSTER" --location="$REGION" --project="$PROJECT"
+
+install_cmd=$(cat <<'EOS'
+set -euo pipefail
+mkdir -p "$RAY_WORKDIR"
+cd "$RAY_WORKDIR"
+curl -LsSf https://astral.sh/uv/install.sh | sh
+source "$HOME/.local/bin/env"
+export UV_LINK_MODE=${UV_LINK_MODE:-copy}
+if [ ! -d "$RAY_VENV" ]; then
+  uv venv --python "$RAY_PYTHON_VERSION" "$RAY_VENV"
+fi
+source "$RAY_VENV/bin/activate"
+if [ -n "$RAY_ENV_SETUP_CMD" ]; then
+  # Caller-provided environment setup (installs into the active venv).
+  bash -lc "$RAY_ENV_SETUP_CMD"
+else
+  uv pip install "$RAY_SPEC"
+  uv pip install "$TORCH_SPEC" --index-url "$TORCH_INDEX_URL"
+fi
+EOS
+)
+
+pod_env="RAY_WORKDIR=$RAY_WORKDIR RAY_VENV=$RAY_VENV RAY_PYTHON_VERSION=$RAY_PYTHON_VERSION RAY_SPEC=$RAY_SPEC TORCH_SPEC=$TORCH_SPEC TORCH_INDEX_URL=$TORCH_INDEX_URL RAY_ENV_SETUP_CMD=$RAY_ENV_SETUP_CMD"
+
+if [ "$SKIP_INSTALL" != "1" ]; then
+  for pod in ray-head ray-worker-0 ray-worker-1; do
+    if [ "$SKIP_READY_INSTALLS" = "1" ] && kubectl exec "$pod" -- env RAY_VENV="$RAY_VENV" bash -lc '
+      test -x "$RAY_VENV/bin/ray"
+      "$RAY_VENV/bin/python" - <<"PY"
+import ray
+print("ready", ray.__version__)
+PY
+    '; then
+      echo "Ray env already present in ${pod}; skipping install."
+      continue
+    fi
+
+    echo "Setting up Ray env in ${pod}"
+    installed=0
+    for attempt in $(seq 1 "$INSTALL_RETRIES"); do
+      if kubectl exec "$pod" -- env $pod_env bash -lc "$install_cmd"; then
+        installed=1
+        break
+      fi
+      echo "Setup attempt ${attempt}/${INSTALL_RETRIES} failed in ${pod}." >&2
+      sleep 10
+    done
+    if [ "$installed" != "1" ]; then
+      echo "Failed to set up Ray env in ${pod} after ${INSTALL_RETRIES} attempts." >&2
+      exit 1
+    fi
+  done
+fi
+
+echo "Starting Ray head"
+kubectl exec ray-head -- env RAY_WORKDIR="$RAY_WORKDIR" RAY_VENV="$RAY_VENV" bash -lc '
+  set -euo pipefail
+  cd "$RAY_WORKDIR"
+  source "$RAY_VENV/bin/activate"
+  ray stop --force >/tmp/ray-stop.log 2>&1 || true
+  export RAY_worker_register_timeout_seconds=1000
+  ray start --head \
+    --node-ip-address=$(hostname -i) \
+    --port=6379 \
+    --dashboard-host=0.0.0.0 \
+    --dashboard-port=8265 \
+    --num-gpus=0 \
+    --disable-usage-stats
+'
+
+for pod in ray-worker-0 ray-worker-1; do
+  echo "Starting Ray worker in ${pod}"
+  kubectl exec "$pod" -- env RAY_WORKDIR="$RAY_WORKDIR" RAY_VENV="$RAY_VENV" bash -lc '
+    set -euo pipefail
+    cd "$RAY_WORKDIR"
+    source "$RAY_VENV/bin/activate"
+    source /usr/local/gib/scripts/set_nccl_env.sh
+    ray stop --force >/tmp/ray-stop.log 2>&1 || true
+    export RAY_worker_register_timeout_seconds=1000
+    setsid nohup ray start --address=ray-head:6379 --num-gpus=8 --block \
+      > /workspace/ray-worker.log 2>&1 < /dev/null &
+  '
+done
+
+sleep 10
+kubectl exec ray-head -- env RAY_WORKDIR="$RAY_WORKDIR" RAY_VENV="$RAY_VENV" bash -lc 'cd "$RAY_WORKDIR" && source "$RAY_VENV/bin/activate" && ray status'

--- a/examples/gcp/gke-a4-b200-rdma/scripts/validate-cluster.sh
+++ b/examples/gcp/gke-a4-b200-rdma/scripts/validate-cluster.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GCLOUD=${GCLOUD:-}
+if [ -z "$GCLOUD" ]; then
+  if command -v gcloud >/dev/null 2>&1; then
+    GCLOUD=$(command -v gcloud)
+  else
+    echo "gcloud not found; set GCLOUD=/path/to/gcloud" >&2
+    exit 127
+  fi
+fi
+gcloud() { "$GCLOUD" "$@"; }
+export PATH="$(dirname "$GCLOUD"):$PATH"
+
+PROJECT=${PROJECT:?Set PROJECT to your Google Cloud project ID}
+REGION=${REGION:?Set REGION to the GKE region}
+CLUSTER=${CLUSTER:?Set CLUSTER to the GKE cluster name}
+
+gcloud container clusters get-credentials "$CLUSTER" --location="$REGION" --project="$PROJECT"
+
+echo "== Nodes =="
+kubectl get nodes \
+  -L cloud.google.com/gke-nodepool,cloud.google.com/gke-spot,cloud.google.com/gke-accelerator \
+  -o custom-columns=NAME:.metadata.name,POOL:.metadata.labels.cloud\\.google\\.com/gke-nodepool,SPOT:.metadata.labels.cloud\\.google\\.com/gke-spot,ACCEL:.metadata.labels.cloud\\.google\\.com/gke-accelerator,GPUS:.status.allocatable.nvidia\\.com/gpu
+
+echo
+echo "== Pods =="
+kubectl get pods -o wide
+
+for pod in ray-worker-0 ray-worker-1; do
+  echo
+  echo "== ${pod} device check =="
+  kubectl exec "$pod" -- bash -lc '
+    set -euo pipefail
+    echo "hostname=$(hostname)"
+    echo "gpu_count=$(nvidia-smi --query-gpu=index --format=csv,noheader | wc -l | tr -d " ")"
+    for iface in eth2 eth3 eth4 eth5 eth6 eth7 eth8 eth9; do
+      test -d "/sys/class/net/${iface}"
+      printf "%s mtu=%s state=%s\n" \
+        "$iface" \
+        "$(cat "/sys/class/net/${iface}/mtu")" \
+        "$(cat "/sys/class/net/${iface}/operstate")"
+    done
+    test -x /usr/local/gib/scripts/set_nccl_env.sh
+    source /usr/local/gib/scripts/set_nccl_env.sh
+    env | grep -E "^(NCCL_|LD_LIBRARY_PATH)" | sort
+    grep -q "^gdrdrv " /proc/modules
+    grep -q "[[:space:]]gdrdrv$" /proc/devices
+    test -c /dev/gdrdrv
+    ls -l /dev/gdrdrv
+    ls /sys/class/infiniband | sort
+  '
+done
+
+echo
+echo "Cluster readiness validation passed."

--- a/examples/gcp/gke-a4-b200-rdma/terraform/examples/a4-b200-rdma/main.tf
+++ b/examples/gcp/gke-a4-b200-rdma/terraform/examples/a4-b200-rdma/main.tf
@@ -1,0 +1,21 @@
+module "b200_rdma_gke" {
+  source = "../.."
+
+  project_id      = var.project_id
+  region          = var.region
+  zone            = var.zone
+  cluster_name    = var.cluster_name
+  host_network    = var.host_network
+  host_subnetwork = var.host_subnetwork
+
+  gvnic_network_name          = var.gvnic_network_name
+  gvnic_subnetwork_name       = var.gvnic_subnetwork_name
+  gvnic_subnetwork_cidr       = var.gvnic_subnetwork_cidr
+  rdma_network_name           = var.rdma_network_name
+  rdma_subnetwork_name_prefix = var.rdma_subnetwork_name_prefix
+  rdma_subnetwork_cidr_prefix = var.rdma_subnetwork_cidr_prefix
+
+  worker_node_count = var.worker_node_count
+  workload_name     = var.workload_name
+  resource_labels   = var.resource_labels
+}

--- a/examples/gcp/gke-a4-b200-rdma/terraform/examples/a4-b200-rdma/outputs.tf
+++ b/examples/gcp/gke-a4-b200-rdma/terraform/examples/a4-b200-rdma/outputs.tf
@@ -1,0 +1,14 @@
+output "get_credentials_command" {
+  description = "gcloud command for fetching kubeconfig credentials for this cluster."
+  value       = module.b200_rdma_gke.get_credentials_command
+}
+
+output "worker_pool_name" {
+  description = "Name of the A4/B200 worker node pool."
+  value       = module.b200_rdma_gke.worker_pool_name
+}
+
+output "rdma_subnetwork_names" {
+  description = "Names of the RDMA subnetworks attached to the A4/B200 worker pool."
+  value       = module.b200_rdma_gke.rdma_subnetwork_names
+}

--- a/examples/gcp/gke-a4-b200-rdma/terraform/examples/a4-b200-rdma/terraform.tfvars.example
+++ b/examples/gcp/gke-a4-b200-rdma/terraform/examples/a4-b200-rdma/terraform.tfvars.example
@@ -1,0 +1,21 @@
+project_id = "YOUR_GCP_PROJECT_ID"
+region     = "us-central1"
+zone       = "us-central1-b"
+
+cluster_name    = "b200-rdma-gke"
+host_network    = "existing-host-vpc"
+host_subnetwork = "existing-host-subnet"
+
+gvnic_network_name          = "b200-gvnic"
+gvnic_subnetwork_name       = "b200-gvnic-subnet"
+gvnic_subnetwork_cidr       = "YOUR_GVNIC_SUBNET_CIDR"
+rdma_network_name           = "b200-rdma"
+rdma_subnetwork_name_prefix = "b200-rdma-subnet"
+rdma_subnetwork_cidr_prefix = "YOUR_RDMA_CIDR_PREFIX"
+
+worker_node_count = 2
+workload_name     = "b200-rdma"
+
+resource_labels = {
+  purpose = "gpu-rdma-validation"
+}

--- a/examples/gcp/gke-a4-b200-rdma/terraform/examples/a4-b200-rdma/variables.tf
+++ b/examples/gcp/gke-a4-b200-rdma/terraform/examples/a4-b200-rdma/variables.tf
@@ -1,0 +1,75 @@
+variable "project_id" {
+  description = "Google Cloud project ID."
+  type        = string
+}
+
+variable "region" {
+  description = "Regional GKE control-plane location."
+  type        = string
+}
+
+variable "zone" {
+  description = "Single A4/B200 worker zone."
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "Name of the GKE cluster to create."
+  type        = string
+}
+
+variable "host_network" {
+  description = "Existing host/control-plane VPC name or self link for the GKE cluster."
+  type        = string
+}
+
+variable "host_subnetwork" {
+  description = "Existing host/control-plane subnetwork name or self link for the GKE cluster."
+  type        = string
+}
+
+variable "gvnic_network_name" {
+  description = "Dedicated VPC name for the extra Titanium gVNIC."
+  type        = string
+}
+
+variable "gvnic_subnetwork_name" {
+  description = "Subnetwork name for the extra Titanium gVNIC."
+  type        = string
+}
+
+variable "gvnic_subnetwork_cidr" {
+  description = "CIDR for the extra gVNIC subnetwork."
+  type        = string
+}
+
+variable "rdma_network_name" {
+  description = "Dedicated RoCE RDMA VPC name."
+  type        = string
+}
+
+variable "rdma_subnetwork_name_prefix" {
+  description = "Prefix for RDMA subnet names."
+  type        = string
+}
+
+variable "rdma_subnetwork_cidr_prefix" {
+  description = "First two octets for RDMA subnets."
+  type        = string
+}
+
+variable "worker_node_count" {
+  description = "A4/B200 worker node count."
+  type        = number
+}
+
+variable "workload_name" {
+  description = "Workload name used in default Kubernetes labels."
+  type        = string
+}
+
+variable "resource_labels" {
+  description = "Google Cloud resource labels applied to resources that support labels."
+  type        = map(string)
+  default     = {}
+}

--- a/examples/gcp/gke-a4-b200-rdma/terraform/examples/a4-b200-rdma/versions.tf
+++ b/examples/gcp/gke-a4-b200-rdma/terraform/examples/a4-b200-rdma/versions.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0, < 7.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}

--- a/examples/gcp/gke-a4-b200-rdma/terraform/main.tf
+++ b/examples/gcp/gke-a4-b200-rdma/terraform/main.tf
@@ -1,0 +1,293 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GCP GKE A4/B200 GPUDirect RDMA Cluster
+#
+# This module creates the infrastructure layer required before Kubernetes can expose GCP RDMA devices to Pods:
+# dedicated gVNIC and RoCE VPCs, a multi-networking GKE cluster, a CPU head node pool, and an A4/B200 Spot node pool
+# with one gVNIC and eight RDMA additional node networks.
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "google_container_engine_versions" "available" {
+  project  = var.project_id
+  location = var.region
+
+  depends_on = [google_project_service.required]
+}
+
+locals {
+  project_services = [
+    "compute.googleapis.com",
+    "container.googleapis.com",
+  ]
+
+  selected_gke_version = var.cluster_version != null && var.cluster_version != "" ? var.cluster_version : lookup(
+    data.google_container_engine_versions.available.release_channel_default_version,
+    var.release_channel,
+    data.google_container_engine_versions.available.default_cluster_version
+  )
+
+  rdma_network_profile = coalesce(
+    var.rdma_network_profile,
+    "projects/${var.project_id}/global/networkProfiles/${var.zone}-vpc-roce"
+  )
+
+  rdma_subnet_names = [
+    for index in range(var.rdma_interface_count) : "${var.rdma_subnetwork_name_prefix}-${index}"
+  ]
+
+  rdma_subnet_cidrs = [
+    for index in range(var.rdma_interface_count) : "${var.rdma_subnetwork_cidr_prefix}.${index}.0/24"
+  ]
+
+  additional_node_networks = concat(
+    [
+      {
+        network    = google_compute_network.gvnic.name
+        subnetwork = google_compute_subnetwork.gvnic.name
+      }
+    ],
+    [
+      for subnet in google_compute_subnetwork.rdma : {
+        network    = google_compute_network.rdma.name
+        subnetwork = subnet.name
+      }
+    ]
+  )
+
+  module_resource_labels = {
+    tf_sub_module = "gcp-gke-b200-rdma"
+  }
+
+  resource_labels = merge(local.module_resource_labels, var.resource_labels)
+
+  default_cpu_labels = {
+    workload = "${var.workload_name}-head"
+  }
+
+  cpu_labels = merge(local.default_cpu_labels, var.cpu_labels)
+
+  default_worker_labels = {
+    (var.workload_label_key)             = var.workload_name
+    "accelerator"                        = "b200"
+    "rdma"                               = "true"
+    "nvidia.com/gpu.present"             = "true"
+    "nvidia.com/gpu.product"             = "NVIDIA-B200"
+    "nvidia.com/gpu.count"               = tostring(var.gpu_count)
+    "node.anyscale.com/accelerator-type" = "GPU"
+    "node.anyscale.com/gpu-accelerator"  = "B200"
+    "node.anyscale.com/gpudirect-rdma"   = "true"
+  }
+
+  worker_labels = merge(local.default_worker_labels, var.worker_labels)
+}
+
+resource "google_project_service" "required" {
+  for_each = var.enable_project_services ? toset(local.project_services) : []
+
+  project = var.project_id
+  service = each.value
+
+  disable_on_destroy = var.disable_services_on_destroy
+}
+
+resource "google_compute_network" "gvnic" {
+  project = var.project_id
+
+  name                    = var.gvnic_network_name
+  auto_create_subnetworks = false
+  mtu                     = var.network_mtu
+}
+
+resource "google_compute_subnetwork" "gvnic" {
+  project = var.project_id
+
+  name          = var.gvnic_subnetwork_name
+  region        = var.region
+  network       = google_compute_network.gvnic.id
+  ip_cidr_range = var.gvnic_subnetwork_cidr
+}
+
+resource "google_compute_firewall" "gvnic_internal" {
+  project = var.project_id
+
+  name    = "${var.gvnic_network_name}-allow-internal"
+  network = google_compute_network.gvnic.name
+
+  direction     = "INGRESS"
+  source_ranges = [var.gvnic_subnetwork_cidr]
+
+  allow {
+    protocol = "tcp"
+  }
+
+  allow {
+    protocol = "udp"
+  }
+
+  allow {
+    protocol = "icmp"
+  }
+}
+
+resource "google_compute_network" "rdma" {
+  project = var.project_id
+
+  name                    = var.rdma_network_name
+  auto_create_subnetworks = false
+  mtu                     = var.network_mtu
+  network_profile         = local.rdma_network_profile
+}
+
+resource "google_compute_subnetwork" "rdma" {
+  for_each = {
+    for index, name in local.rdma_subnet_names : name => local.rdma_subnet_cidrs[index]
+  }
+
+  project = var.project_id
+
+  name          = each.key
+  region        = var.region
+  network       = google_compute_network.rdma.id
+  ip_cidr_range = each.value
+}
+
+resource "google_compute_firewall" "rdma_internal" {
+  project = var.project_id
+
+  name    = "${var.rdma_network_name}-allow-internal"
+  network = google_compute_network.rdma.name
+
+  direction     = "INGRESS"
+  source_ranges = ["${var.rdma_subnetwork_cidr_prefix}.0.0/16"]
+
+  allow {
+    protocol = "tcp"
+  }
+
+  allow {
+    protocol = "udp"
+  }
+
+  allow {
+    protocol = "icmp"
+  }
+}
+
+resource "google_container_cluster" "this" {
+  project = var.project_id
+
+  name               = var.cluster_name
+  location           = var.region
+  node_locations     = [var.zone]
+  min_master_version = local.selected_gke_version
+
+  network    = var.host_network
+  subnetwork = var.host_subnetwork
+
+  datapath_provider        = "ADVANCED_DATAPATH"
+  enable_multi_networking  = true
+  networking_mode          = "VPC_NATIVE"
+  initial_node_count       = 1
+  remove_default_node_pool = true
+  deletion_protection      = var.deletion_protection
+  resource_labels          = local.resource_labels
+
+  release_channel {
+    channel = var.release_channel
+  }
+
+  ip_allocation_policy {}
+
+  depends_on = [google_project_service.required]
+}
+
+resource "google_container_node_pool" "cpu_head" {
+  count = var.create_cpu_head_pool ? 1 : 0
+
+  project = var.project_id
+
+  name           = var.cpu_head_pool_name
+  cluster        = google_container_cluster.this.name
+  location       = var.region
+  node_locations = [var.zone]
+  node_count     = var.cpu_node_count
+  version        = local.selected_gke_version
+
+  management {
+    auto_repair  = var.enable_node_auto_repair
+    auto_upgrade = var.enable_node_auto_upgrade
+  }
+
+  node_config {
+    machine_type    = var.cpu_machine_type
+    disk_size_gb    = var.cpu_disk_size_gb
+    disk_type       = var.cpu_disk_type
+    image_type      = var.node_image_type
+    labels          = local.cpu_labels
+    oauth_scopes    = var.node_oauth_scopes
+    resource_labels = local.resource_labels
+    service_account = var.node_service_account_email
+  }
+}
+
+resource "google_container_node_pool" "a4_b200" {
+  project = var.project_id
+
+  name           = var.worker_pool_name
+  cluster        = google_container_cluster.this.name
+  location       = var.region
+  node_locations = [var.zone]
+  node_count     = var.worker_node_count
+  version        = local.selected_gke_version
+
+  management {
+    auto_repair  = var.enable_node_auto_repair
+    auto_upgrade = var.enable_node_auto_upgrade
+  }
+
+  node_config {
+    machine_type    = var.worker_machine_type
+    disk_size_gb    = var.worker_disk_size_gb
+    disk_type       = var.worker_disk_type
+    image_type      = var.node_image_type
+    labels          = local.worker_labels
+    oauth_scopes    = var.node_oauth_scopes
+    resource_labels = local.resource_labels
+    service_account = var.node_service_account_email
+    spot            = var.worker_spot
+
+    guest_accelerator {
+      type  = var.gpu_type
+      count = var.gpu_count
+
+      gpu_driver_installation_config {
+        gpu_driver_version = var.gpu_driver_version
+      }
+    }
+
+    dynamic "taint" {
+      for_each = var.worker_taints
+
+      content {
+        key    = taint.value.key
+        value  = taint.value.value
+        effect = taint.value.effect
+      }
+    }
+  }
+
+  network_config {
+    dynamic "additional_node_network_configs" {
+      for_each = local.additional_node_networks
+
+      content {
+        network    = additional_node_network_configs.value.network
+        subnetwork = additional_node_network_configs.value.subnetwork
+      }
+    }
+  }
+
+  depends_on = [
+    google_compute_subnetwork.gvnic,
+    google_compute_subnetwork.rdma,
+  ]
+}

--- a/examples/gcp/gke-a4-b200-rdma/terraform/outputs.tf
+++ b/examples/gcp/gke-a4-b200-rdma/terraform/outputs.tf
@@ -1,0 +1,75 @@
+output "cluster_name" {
+  description = "Name of the GKE cluster."
+  value       = google_container_cluster.this.name
+}
+
+output "cluster_id" {
+  description = "ID of the GKE cluster."
+  value       = google_container_cluster.this.id
+}
+
+output "cluster_location" {
+  description = "Regional location of the GKE control plane."
+  value       = google_container_cluster.this.location
+}
+
+output "cluster_endpoint" {
+  description = "Endpoint of the GKE cluster."
+  value       = google_container_cluster.this.endpoint
+  sensitive   = true
+}
+
+output "selected_gke_version" {
+  description = "GKE version selected for the cluster and node pools."
+  value       = local.selected_gke_version
+}
+
+output "cpu_head_pool_name" {
+  description = "Name of the CPU head node pool."
+  value       = var.create_cpu_head_pool ? google_container_node_pool.cpu_head[0].name : null
+}
+
+output "worker_pool_name" {
+  description = "Name of the A4/B200 worker node pool."
+  value       = google_container_node_pool.a4_b200.name
+}
+
+output "worker_pool_instance_group_urls" {
+  description = "Managed instance group URLs backing the A4/B200 worker node pool."
+  value       = google_container_node_pool.a4_b200.managed_instance_group_urls
+}
+
+output "gvnic_network_name" {
+  description = "Name of the dedicated gVNIC VPC."
+  value       = google_compute_network.gvnic.name
+}
+
+output "gvnic_subnetwork_name" {
+  description = "Name of the dedicated gVNIC subnetwork."
+  value       = google_compute_subnetwork.gvnic.name
+}
+
+output "rdma_network_name" {
+  description = "Name of the dedicated RDMA VPC."
+  value       = google_compute_network.rdma.name
+}
+
+output "rdma_network_profile" {
+  description = "Network profile used by the dedicated RDMA VPC."
+  value       = local.rdma_network_profile
+}
+
+output "rdma_subnetwork_names" {
+  description = "Names of the RDMA subnetworks attached to the A4/B200 worker pool."
+  value       = [for subnet in google_compute_subnetwork.rdma : subnet.name]
+}
+
+output "additional_node_networks" {
+  description = "Additional node network layout rendered into the A4/B200 node pool."
+  value       = local.additional_node_networks
+}
+
+output "get_credentials_command" {
+  description = "gcloud command for fetching kubeconfig credentials for this cluster."
+  value       = "gcloud container clusters get-credentials ${google_container_cluster.this.name} --location=${google_container_cluster.this.location} --project=${var.project_id}"
+}

--- a/examples/gcp/gke-a4-b200-rdma/terraform/variables.tf
+++ b/examples/gcp/gke-a4-b200-rdma/terraform/variables.tf
@@ -1,0 +1,316 @@
+# ------------------------------------------------------------------------------
+# REQUIRED PARAMETERS
+# ------------------------------------------------------------------------------
+
+variable "project_id" {
+  description = "(Required) Google Cloud project ID."
+  type        = string
+}
+
+variable "region" {
+  description = "(Required) Regional GKE control-plane location."
+  type        = string
+}
+
+variable "zone" {
+  description = "(Required) Single A4/B200 worker zone. The zone must have a matching vpc-roce network profile."
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "(Required) Name of the GKE cluster to create."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{0,38}[a-z0-9]$", var.cluster_name))
+    error_message = "cluster_name must be a valid GKE-style name: start with a lowercase letter, contain lowercase letters, numbers, and hyphens, and end with a letter or number."
+  }
+}
+
+variable "host_network" {
+  description = "(Required) Existing host/control-plane VPC name or self link for the GKE cluster."
+  type        = string
+}
+
+variable "host_subnetwork" {
+  description = "(Required) Existing host/control-plane subnetwork name or self link for the GKE cluster."
+  type        = string
+}
+
+# ------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+# ------------------------------------------------------------------------------
+
+variable "workload_name" {
+  description = "(Optional) Workload name used in default Kubernetes labels."
+  type        = string
+  default     = "b200-rdma"
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]*[a-z0-9]$", var.workload_name))
+    error_message = "workload_name must be lowercase DNS-style text: letters, numbers, hyphens, no leading/trailing hyphen."
+  }
+}
+
+variable "workload_label_key" {
+  description = "(Optional) Kubernetes label key used to identify the B200/RDMA worker pool."
+  type        = string
+  default     = "workload"
+}
+
+variable "resource_labels" {
+  description = "(Optional) Google Cloud resource labels applied to resources that support labels."
+  type        = map(string)
+  default     = {}
+}
+
+variable "enable_project_services" {
+  description = "(Optional) Whether to enable Compute Engine and GKE APIs for the project."
+  type        = bool
+  default     = true
+}
+
+variable "disable_services_on_destroy" {
+  description = "(Optional) Whether Terraform should disable project services on destroy."
+  type        = bool
+  default     = false
+}
+
+variable "release_channel" {
+  description = "(Optional) GKE release channel."
+  type        = string
+  default     = "REGULAR"
+
+  validation {
+    condition     = contains(["RAPID", "REGULAR", "STABLE", "EXTENDED", "UNSPECIFIED"], var.release_channel)
+    error_message = "release_channel must be one of RAPID, REGULAR, STABLE, EXTENDED, or UNSPECIFIED."
+  }
+}
+
+variable "cluster_version" {
+  description = "(Optional) Pinned GKE version. When null, the module uses the selected release channel default for the region."
+  type        = string
+  default     = null
+}
+
+variable "deletion_protection" {
+  description = "(Optional) Whether to enable GKE cluster deletion protection."
+  type        = bool
+  default     = false
+}
+
+variable "network_mtu" {
+  description = "(Optional) MTU for the dedicated gVNIC and RDMA VPCs."
+  type        = number
+  default     = 8896
+}
+
+variable "gvnic_network_name" {
+  description = "(Optional) Dedicated VPC name for the extra Titanium gVNIC."
+  type        = string
+  default     = "b200-gvnic"
+}
+
+variable "gvnic_subnetwork_name" {
+  description = "(Optional) Subnetwork name for the extra Titanium gVNIC."
+  type        = string
+  default     = "b200-gvnic-subnet"
+}
+
+variable "gvnic_subnetwork_cidr" {
+  description = "(Required) CIDR for the extra gVNIC subnetwork."
+  type        = string
+}
+
+variable "rdma_network_name" {
+  description = "(Optional) Dedicated RoCE RDMA VPC name."
+  type        = string
+  default     = "b200-rdma"
+}
+
+variable "rdma_network_profile" {
+  description = "(Optional) Full or partial Google network profile URL for the RDMA VPC. Defaults to projects/PROJECT/global/networkProfiles/ZONE-vpc-roce."
+  type        = string
+  default     = null
+}
+
+variable "rdma_subnetwork_name_prefix" {
+  description = "(Optional) Prefix for RDMA subnet names. The module creates PREFIX-0 through PREFIX-N."
+  type        = string
+  default     = "b200-rdma-subnet"
+}
+
+variable "rdma_subnetwork_cidr_prefix" {
+  description = "(Required) First two octets for RDMA subnets. Subnets become PREFIX.0.0/24 through PREFIX.N.0/24."
+  type        = string
+}
+
+variable "rdma_interface_count" {
+  description = "(Optional) Number of RDMA additional node networks to attach to each A4/B200 worker."
+  type        = number
+  default     = 8
+
+  validation {
+    condition     = var.rdma_interface_count >= 1 && var.rdma_interface_count <= 8
+    error_message = "rdma_interface_count must be between 1 and 8 for GKE A4/B200 workers."
+  }
+}
+
+variable "create_cpu_head_pool" {
+  description = "(Optional) Whether to create a CPU node pool for the Ray head or other control-plane workloads."
+  type        = bool
+  default     = true
+}
+
+variable "cpu_head_pool_name" {
+  description = "(Optional) CPU head node pool name."
+  type        = string
+  default     = "cpu-head"
+}
+
+variable "cpu_node_count" {
+  description = "(Optional) CPU head node count."
+  type        = number
+  default     = 1
+}
+
+variable "cpu_machine_type" {
+  description = "(Optional) Machine type for CPU head nodes."
+  type        = string
+  default     = "e2-standard-16"
+}
+
+variable "cpu_disk_size_gb" {
+  description = "(Optional) Boot disk size in GB for CPU head nodes."
+  type        = number
+  default     = 500
+}
+
+variable "cpu_disk_type" {
+  description = "(Optional) Boot disk type for CPU head nodes."
+  type        = string
+  default     = "pd-balanced"
+}
+
+variable "cpu_labels" {
+  description = "(Optional) Additional or overriding Kubernetes labels for the CPU head node pool."
+  type        = map(string)
+  default     = {}
+}
+
+variable "worker_pool_name" {
+  description = "(Optional) A4/B200 worker node pool name."
+  type        = string
+  default     = "a4-spot"
+}
+
+variable "worker_node_count" {
+  description = "(Optional) A4/B200 worker node count. Each node has 8 B200 GPUs."
+  type        = number
+  default     = 2
+
+  validation {
+    condition     = var.worker_node_count >= 1
+    error_message = "worker_node_count must be at least 1."
+  }
+}
+
+variable "worker_machine_type" {
+  description = "(Optional) A4/B200 worker machine type."
+  type        = string
+  default     = "a4-highgpu-8g"
+}
+
+variable "worker_spot" {
+  description = "(Optional) Whether to create worker nodes as Spot VMs."
+  type        = bool
+  default     = true
+}
+
+variable "worker_disk_size_gb" {
+  description = "(Optional) Boot disk size in GB for A4/B200 workers."
+  type        = number
+  default     = 500
+}
+
+variable "worker_disk_type" {
+  description = "(Optional) Boot disk type for A4/B200 workers."
+  type        = string
+  default     = "hyperdisk-balanced"
+}
+
+variable "worker_labels" {
+  description = "(Optional) Additional or overriding Kubernetes labels for the A4/B200 worker node pool."
+  type        = map(string)
+  default     = {}
+}
+
+variable "worker_taints" {
+  description = <<-EOT
+    (Optional) Kubernetes taints for the A4/B200 worker node pool.
+
+    Effects must use GKE API values: NO_SCHEDULE, NO_EXECUTE, or PREFER_NO_SCHEDULE.
+  EOT
+  type = list(object({
+    key    = string
+    value  = string
+    effect = string
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for taint in var.worker_taints :
+      contains(["NO_SCHEDULE", "NO_EXECUTE", "PREFER_NO_SCHEDULE"], taint.effect)
+    ])
+    error_message = "worker_taints effects must be one of NO_SCHEDULE, NO_EXECUTE, or PREFER_NO_SCHEDULE."
+  }
+}
+
+variable "gpu_type" {
+  description = "(Optional) GKE accelerator type for A4/B200 workers."
+  type        = string
+  default     = "nvidia-b200"
+}
+
+variable "gpu_count" {
+  description = "(Optional) GPU count per A4/B200 worker."
+  type        = number
+  default     = 8
+}
+
+variable "gpu_driver_version" {
+  description = "(Optional) GKE GPU driver version mode."
+  type        = string
+  default     = "LATEST"
+}
+
+variable "node_image_type" {
+  description = "(Optional) GKE node image type."
+  type        = string
+  default     = "COS_CONTAINERD"
+}
+
+variable "node_service_account_email" {
+  description = "(Optional) Google service account email to use for node VMs."
+  type        = string
+  default     = null
+}
+
+variable "node_oauth_scopes" {
+  description = "(Optional) OAuth scopes for node VMs."
+  type        = set(string)
+  default     = ["https://www.googleapis.com/auth/cloud-platform"]
+}
+
+variable "enable_node_auto_repair" {
+  description = "(Optional) Whether GKE should auto-repair nodes."
+  type        = bool
+  default     = false
+}
+
+variable "enable_node_auto_upgrade" {
+  description = "(Optional) Whether GKE should auto-upgrade nodes."
+  type        = bool
+  default     = false
+}

--- a/examples/gcp/gke-a4-b200-rdma/terraform/versions.tf
+++ b/examples/gcp/gke-a4-b200-rdma/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0, < 7.0"
+    }
+  }
+}

--- a/modules/aws-efa-nodegroup/README.md
+++ b/modules/aws-efa-nodegroup/README.md
@@ -1,0 +1,202 @@
+# AWS EFA EKS Managed Node Group Module
+
+This module creates the AWS infrastructure required before Kubernetes can expose
+EFA devices to Pods running on `p5.48xlarge` H100 workers.
+
+It is intentionally scoped to the GPU worker node group. It expects an existing
+EKS cluster, VPC, subnet, and worker-node IAM role from an Anyscale/EKS
+foundation module.
+
+## What It Creates
+
+```text
+aws_placement_group strategy=cluster
+EFA security group with self-referencing all ingress/egress
+aws_launch_template with EFA-only network interfaces
+aws_eks_node_group pinned to one subnet/AZ
+```
+
+The default network interface layout is for `p5.48xlarge`:
+
+```text
+network card 0, device 0: interface  (primary ENA/IP)
+network card 0, device 1: efa-only   (RDMA)
+network cards 1-31, device 0: efa-only
+```
+
+That gives one IP-consuming ENA interface for Kubernetes/TCP bootstrap traffic
+and 32 EFA-only interfaces for RDMA payload traffic.
+
+The module intentionally defaults to `p5.48xlarge` and H100 node metadata. The
+caller still controls the workload identity through `workload_name`, which is
+used in generated resource names, Kubernetes labels, default taints, and
+Cluster Autoscaler node-template tags. Override `labels`, `taints`, or
+`enable_cluster_autoscaler_tags` when integrating with a different scheduler
+policy.
+
+## Example
+
+```hcl
+module "h100_efa_nodegroup" {
+  source = "./modules/aws-efa-nodegroup"
+
+  cluster_name  = "my-eks-cluster"
+  vpc_id        = "vpc-0123456789abcdef0"
+  subnet_id     = "subnet-0123456789abcdef0"
+  node_role_arn = "arn:aws:iam::123456789012:role/eks-node-role"
+
+  availability_zone = "us-west-2a"
+  workload_name     = "training"
+  desired_size      = 4
+  min_size          = 0
+  max_size          = 4
+
+  cluster_security_group_ids    = ["sg-eks-control-plane"]
+  additional_security_group_ids = ["sg-existing-anyscale-or-node-sg"]
+
+  tags = {
+    project = "h100-efa"
+  }
+}
+```
+
+For Capacity Blocks:
+
+```hcl
+capacity_type           = "CAPACITY_BLOCK"
+capacity_reservation_id = "cr-0123456789abcdef0"
+subnet_id               = "subnet-in-the-reservation-az"
+```
+
+## Follow-On Kubernetes Layer
+
+After this module is applied, install either the EFA device plugin or EFA DRA
+driver. With the device plugin path, a `p5.48xlarge` node should advertise:
+
+```text
+nvidia.com/gpu: 8
+vpc.amazonaws.com/efa: 32
+```
+
+Pods for this node group should request all node-local devices:
+
+```yaml
+resources:
+  limits:
+    nvidia.com/gpu: 8
+    vpc.amazonaws.com/efa: 32
+```
+
+## Validation
+
+Run in a Terraform-capable environment:
+
+```bash
+terraform fmt -recursive
+terraform init
+terraform validate
+terraform plan
+```
+
+After apply:
+
+```bash
+kubectl get nodes -l efa=true -o wide
+kubectl describe node <node-name> | egrep 'nvidia.com/gpu|vpc.amazonaws.com/efa'
+```
+
+Then run workload-image checks that exercise EFA device discovery, NCCL, and
+any collective communication libraries used by the workload.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0, < 7.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0, < 7.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_autoscaling_group_tag.efa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group_tag) | resource |
+| [aws_eks_node_group.efa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group) | resource |
+| [aws_launch_template.efa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
+| [aws_placement_group.efa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/placement_group) | resource |
+| [aws_security_group.efa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.cluster_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.efa_all_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.efa_self_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.efa_self_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_subnet.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | (Required) Name of the existing EKS cluster. | `string` | n/a | yes |
+| <a name="input_node_role_arn"></a> [node\_role\_arn](#input\_node\_role\_arn) | (Required) IAM role ARN for the EKS managed node group workers. | `string` | n/a | yes |
+| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | (Required) Single subnet ID for the EFA managed node group. Use a private subnet in one Availability Zone. | `string` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | (Required) VPC ID where the EKS worker nodes and EFA security group are created. | `string` | n/a | yes |
+| <a name="input_additional_security_group_ids"></a> [additional\_security\_group\_ids](#input\_additional\_security\_group\_ids) | (Optional) Additional security group IDs attached to every launch-template network interface, such as an existing Anyscale/EKS node security group. | `list(string)` | `[]` | no |
+| <a name="input_allow_all_egress"></a> [allow\_all\_egress](#input\_allow\_all\_egress) | (Optional) Whether to allow outbound IPv4 traffic from the EFA security group. | `bool` | `true` | no |
+| <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | (Optional) Custom AMI ID for the launch template. If set, provide bootstrap-compatible user data outside this module if needed. | `string` | `null` | no |
+| <a name="input_ami_type"></a> [ami\_type](#input\_ami\_type) | (Optional) EKS managed node group AMI type. Ignored when ami\_id is set in the launch template. | `string` | `"AL2023_x86_64_NVIDIA"` | no |
+| <a name="input_availability_zone"></a> [availability\_zone](#input\_availability\_zone) | (Optional) Expected Availability Zone for subnet\_id. When set, the module verifies the subnet is in this AZ. | `string` | `null` | no |
+| <a name="input_capacity_reservation_id"></a> [capacity\_reservation\_id](#input\_capacity\_reservation\_id) | (Optional) Targeted EC2 Capacity Reservation ID. Required when capacity\_type is CAPACITY\_BLOCK; also usable with ON\_DEMAND targeted reservations. | `string` | `null` | no |
+| <a name="input_capacity_type"></a> [capacity\_type](#input\_capacity\_type) | (Optional) EKS managed node group capacity type. | `string` | `"ON_DEMAND"` | no |
+| <a name="input_cluster_security_group_ids"></a> [cluster\_security\_group\_ids](#input\_cluster\_security\_group\_ids) | (Optional) EKS control-plane or cluster security group IDs allowed to initiate traffic to EFA nodes. | `list(string)` | `[]` | no |
+| <a name="input_create_efa_security_group"></a> [create\_efa\_security\_group](#input\_create\_efa\_security\_group) | (Optional) Whether to create the EFA security group. | `bool` | `true` | no |
+| <a name="input_desired_size"></a> [desired\_size](#input\_desired\_size) | (Optional) Desired number of EFA worker nodes. | `number` | `4` | no |
+| <a name="input_efa_interface_count"></a> [efa\_interface\_count](#input\_efa\_interface\_count) | (Optional) Number of EFA-only interfaces to generate when network\_interfaces is not supplied. p5.48xlarge supports 32. | `number` | `32` | no |
+| <a name="input_efa_security_group_id"></a> [efa\_security\_group\_id](#input\_efa\_security\_group\_id) | (Optional) Existing EFA security group ID to use when create\_efa\_security\_group is false. | `string` | `null` | no |
+| <a name="input_efa_security_group_name"></a> [efa\_security\_group\_name](#input\_efa\_security\_group\_name) | (Optional) Name for the EFA security group. | `string` | `null` | no |
+| <a name="input_efa_security_group_name_prefix"></a> [efa\_security\_group\_name\_prefix](#input\_efa\_security\_group\_name\_prefix) | (Optional) Name prefix for the EFA security group. | `string` | `null` | no |
+| <a name="input_enable_cluster_autoscaler_tags"></a> [enable\_cluster\_autoscaler\_tags](#input\_enable\_cluster\_autoscaler\_tags) | (Optional) Whether to add Cluster Autoscaler node-template tags for the P5/H100/EFA labels, taints, and resources. | `bool` | `true` | no |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | (Optional) EFA-capable GPU instance type for the node group. | `string` | `"p5.48xlarge"` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | (Optional) Additional or overriding Kubernetes labels for the managed node group. The module supplies P5/H100/EFA defaults. | `map(string)` | `{}` | no |
+| <a name="input_launch_template_name_prefix"></a> [launch\_template\_name\_prefix](#input\_launch\_template\_name\_prefix) | (Optional) Explicit launch template name prefix. | `string` | `null` | no |
+| <a name="input_max_size"></a> [max\_size](#input\_max\_size) | (Optional) Maximum number of EFA worker nodes. | `number` | `4` | no |
+| <a name="input_min_size"></a> [min\_size](#input\_min\_size) | (Optional) Minimum number of EFA worker nodes. | `number` | `0` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | (Optional) Prefix used for generated resource names. | `string` | `null` | no |
+| <a name="input_network_interfaces"></a> [network\_interfaces](#input\_network\_interfaces) | (Optional) Override launch-template network interface layout.<br/><br/>Leave null for the p5.48xlarge one-IP layout:<br/>card 0 device 0 interface, card 0 device 1 efa-only, cards 1..31 device 0 efa-only. | <pre>list(object({<br/>    network_card_index = number<br/>    device_index       = number<br/>    interface_type     = string<br/>  }))</pre> | `null` | no |
+| <a name="input_node_group_name"></a> [node\_group\_name](#input\_node\_group\_name) | (Optional) Explicit EKS managed node group name. | `string` | `null` | no |
+| <a name="input_placement_group_name"></a> [placement\_group\_name](#input\_placement\_group\_name) | (Optional) Explicit placement group name. Defaults to a name derived from name\_prefix. | `string` | `null` | no |
+| <a name="input_revoke_security_group_rules_on_delete"></a> [revoke\_security\_group\_rules\_on\_delete](#input\_revoke\_security\_group\_rules\_on\_delete) | (Optional) Whether Terraform revokes security group rules before deleting the EFA security group. | `bool` | `false` | no |
+| <a name="input_root_block_device_name"></a> [root\_block\_device\_name](#input\_root\_block\_device\_name) | (Optional) Root block device name for the EKS optimized AMI. | `string` | `"/dev/xvda"` | no |
+| <a name="input_root_volume_encrypted"></a> [root\_volume\_encrypted](#input\_root\_volume\_encrypted) | (Optional) Whether to encrypt the root EBS volume. | `bool` | `true` | no |
+| <a name="input_root_volume_size_gb"></a> [root\_volume\_size\_gb](#input\_root\_volume\_size\_gb) | (Optional) Root EBS volume size in GiB. | `number` | `300` | no |
+| <a name="input_root_volume_type"></a> [root\_volume\_type](#input\_root\_volume\_type) | (Optional) Root EBS volume type. | `string` | `"gp3"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) Tags applied to resources that support tags. | `map(string)` | `{}` | no |
+| <a name="input_taints"></a> [taints](#input\_taints) | (Optional) Kubernetes taints for the managed node group.<br/><br/>Effects must use AWS EKS API values: NO\_SCHEDULE, NO\_EXECUTE, or PREFER\_NO\_SCHEDULE. | <pre>list(object({<br/>    key    = string<br/>    value  = string<br/>    effect = string<br/>  }))</pre> | `null` | no |
+| <a name="input_update_max_unavailable"></a> [update\_max\_unavailable](#input\_update\_max\_unavailable) | (Optional) Maximum unavailable nodes during managed node group updates. | `number` | `1` | no |
+| <a name="input_workload_label_key"></a> [workload\_label\_key](#input\_workload\_label\_key) | (Optional) Kubernetes label and taint key used to isolate this P5/H100 EFA node group. | `string` | `"workload"` | no |
+| <a name="input_workload_name"></a> [workload\_name](#input\_workload\_name) | (Optional) Workload name used in default resource names, Kubernetes labels, taints, and Cluster Autoscaler template tags. | `string` | `"h100-efa"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_efa_security_group_id"></a> [efa\_security\_group\_id](#output\_efa\_security\_group\_id) | Security group ID used by EFA network interfaces. |
+| <a name="output_launch_template_default_version"></a> [launch\_template\_default\_version](#output\_launch\_template\_default\_version) | Default version of the EFA launch template. |
+| <a name="output_launch_template_id"></a> [launch\_template\_id](#output\_launch\_template\_id) | ID of the EFA launch template. |
+| <a name="output_launch_template_latest_version"></a> [launch\_template\_latest\_version](#output\_launch\_template\_latest\_version) | Latest version of the EFA launch template. |
+| <a name="output_network_interfaces"></a> [network\_interfaces](#output\_network\_interfaces) | Network interface layout rendered into the launch template. |
+| <a name="output_node_group_arn"></a> [node\_group\_arn](#output\_node\_group\_arn) | ARN of the EKS managed node group. |
+| <a name="output_node_group_name"></a> [node\_group\_name](#output\_node\_group\_name) | Name of the EKS managed node group. |
+| <a name="output_node_group_status"></a> [node\_group\_status](#output\_node\_group\_status) | Status of the EKS managed node group. |
+| <a name="output_placement_group_name"></a> [placement\_group\_name](#output\_placement\_group\_name) | Name of the cluster placement group. |
+| <a name="output_security_group_ids"></a> [security\_group\_ids](#output\_security\_group\_ids) | Full set of security group IDs attached to launch-template network interfaces. |
+| <a name="output_subnet_availability_zone"></a> [subnet\_availability\_zone](#output\_subnet\_availability\_zone) | Availability Zone of subnet\_id. |
+<!-- END_TF_DOCS -->

--- a/modules/aws-efa-nodegroup/examples/basic/main.tf
+++ b/modules/aws-efa-nodegroup/examples/basic/main.tf
@@ -1,0 +1,37 @@
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 7.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+module "h100_efa_nodegroup" {
+  source = "../.."
+
+  cluster_name  = var.cluster_name
+  vpc_id        = var.vpc_id
+  subnet_id     = var.subnet_id
+  node_role_arn = var.node_role_arn
+
+  availability_zone = var.availability_zone
+
+  desired_size = var.desired_size
+  min_size     = var.min_size
+  max_size     = var.max_size
+
+  cluster_security_group_ids    = var.cluster_security_group_ids
+  additional_security_group_ids = var.additional_security_group_ids
+
+  capacity_type           = var.capacity_type
+  capacity_reservation_id = var.capacity_reservation_id
+
+  tags = var.tags
+}

--- a/modules/aws-efa-nodegroup/examples/basic/outputs.tf
+++ b/modules/aws-efa-nodegroup/examples/basic/outputs.tf
@@ -1,0 +1,19 @@
+output "node_group_name" {
+  description = "EKS managed node group name."
+  value       = module.h100_efa_nodegroup.node_group_name
+}
+
+output "launch_template_id" {
+  description = "EFA launch template ID."
+  value       = module.h100_efa_nodegroup.launch_template_id
+}
+
+output "placement_group_name" {
+  description = "Cluster placement group name."
+  value       = module.h100_efa_nodegroup.placement_group_name
+}
+
+output "efa_security_group_id" {
+  description = "EFA security group ID."
+  value       = module.h100_efa_nodegroup.efa_security_group_id
+}

--- a/modules/aws-efa-nodegroup/examples/basic/variables.tf
+++ b/modules/aws-efa-nodegroup/examples/basic/variables.tf
@@ -1,0 +1,78 @@
+variable "region" {
+  description = "AWS region."
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "Existing EKS cluster name."
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID for the EFA node group."
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "Single private subnet ID in the target Availability Zone."
+  type        = string
+}
+
+variable "availability_zone" {
+  description = "Availability Zone expected for subnet_id."
+  type        = string
+  default     = null
+}
+
+variable "node_role_arn" {
+  description = "IAM role ARN for EKS worker nodes."
+  type        = string
+}
+
+variable "desired_size" {
+  description = "Desired node count."
+  type        = number
+  default     = 4
+}
+
+variable "min_size" {
+  description = "Minimum node count."
+  type        = number
+  default     = 0
+}
+
+variable "max_size" {
+  description = "Maximum node count."
+  type        = number
+  default     = 4
+}
+
+variable "cluster_security_group_ids" {
+  description = "EKS control-plane or cluster security group IDs allowed to reach EFA nodes."
+  type        = list(string)
+  default     = []
+}
+
+variable "additional_security_group_ids" {
+  description = "Additional security groups attached to launch-template network interfaces."
+  type        = list(string)
+  default     = []
+}
+
+variable "capacity_type" {
+  description = "EKS capacity type."
+  type        = string
+  default     = "ON_DEMAND"
+}
+
+variable "capacity_reservation_id" {
+  description = "Capacity Block reservation ID when capacity_type is CAPACITY_BLOCK."
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "Tags applied to resources."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/aws-efa-nodegroup/main.tf
+++ b/modules/aws-efa-nodegroup/main.tf
@@ -1,0 +1,365 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# AWS EKS EFA Managed Node Group
+#
+# This module creates the infrastructure layer required before Kubernetes can expose EFA devices to Pods:
+# a cluster placement group, an EFA-friendly security group, a launch template with EFA-only network interfaces,
+# and an EKS managed node group pinned to one subnet/AZ.
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_subnet" "selected" {
+  id = var.subnet_id
+}
+
+locals {
+  name_prefix = coalesce(var.name_prefix, "${var.cluster_name}-${var.workload_name}-")
+
+  module_tags = {
+    tf_sub_module = "aws-efa-nodegroup"
+  }
+
+  efa_security_group_id = var.create_efa_security_group ? aws_security_group.efa[0].id : var.efa_security_group_id
+
+  security_group_ids = distinct(compact(concat(
+    [local.efa_security_group_id],
+    var.additional_security_group_ids
+  )))
+
+  default_network_interfaces = concat(
+    [
+      {
+        network_card_index = 0
+        device_index       = 0
+        interface_type     = "interface"
+      }
+    ],
+    var.efa_interface_count > 0 ? [
+      {
+        network_card_index = 0
+        device_index       = 1
+        interface_type     = "efa-only"
+      }
+    ] : [],
+    [
+      for index in range(1, var.efa_interface_count) : {
+        network_card_index = index
+        device_index       = 0
+        interface_type     = "efa-only"
+      }
+    ]
+  )
+
+  network_interfaces = var.network_interfaces == null ? local.default_network_interfaces : var.network_interfaces
+
+  h100_node_labels = {
+    (var.workload_label_key)             = var.workload_name
+    "accelerator"                        = "h100"
+    "efa"                                = "true"
+    "nvidia.com/gpu.present"             = "true"
+    "nvidia.com/gpu.product"             = "NVIDIA-H100-80GB-HBM3"
+    "nvidia.com/gpu.count"               = "8"
+    "vpc.amazonaws.com/efa.present"      = "true"
+    "vpc.amazonaws.com/efa.count"        = tostring(var.efa_interface_count)
+    "node.anyscale.com/accelerator-type" = "GPU"
+    "node.anyscale.com/gpu-accelerator"  = "H100"
+    "node.anyscale.com/efa-enabled"      = "true"
+  }
+
+  node_labels = merge(local.h100_node_labels, var.labels)
+
+  default_taints = [
+    {
+      key    = "nvidia.com/gpu"
+      value  = "present"
+      effect = "NO_SCHEDULE"
+    },
+    {
+      key    = "node.anyscale.com/accelerator-type"
+      value  = "GPU"
+      effect = "NO_SCHEDULE"
+    },
+    {
+      key    = var.workload_label_key
+      value  = var.workload_name
+      effect = "NO_SCHEDULE"
+    },
+  ]
+
+  node_taints = var.taints == null ? local.default_taints : var.taints
+
+  cluster_autoscaler_taint_effects = {
+    NO_SCHEDULE        = "NoSchedule"
+    NO_EXECUTE         = "NoExecute"
+    PREFER_NO_SCHEDULE = "PreferNoSchedule"
+  }
+
+  capacity_block_enabled = var.capacity_type == "CAPACITY_BLOCK"
+
+  launch_template_name_prefix = coalesce(var.launch_template_name_prefix, "${local.name_prefix}lt-")
+  node_group_name             = coalesce(var.node_group_name, "${local.name_prefix}nodegroup")
+  placement_group_name        = coalesce(var.placement_group_name, "${local.name_prefix}pg")
+
+  cluster_autoscaler_tags = var.enable_cluster_autoscaler_tags ? merge(
+    {
+      "k8s.io/cluster-autoscaler/enabled"                                            = "true"
+      "k8s.io/cluster-autoscaler/${var.cluster_name}"                                = "owned"
+      "k8s.io/cluster-autoscaler/node-template/label/eks.amazonaws.com/capacityType" = var.capacity_type
+      "k8s.io/cluster-autoscaler/node-template/resources/cpu"                        = "192"
+      "k8s.io/cluster-autoscaler/node-template/resources/memory"                     = "1800Gi"
+      "k8s.io/cluster-autoscaler/node-template/resources/nvidia.com/gpu"             = "8"
+      "k8s.io/cluster-autoscaler/node-template/resources/vpc.amazonaws.com/efa"      = tostring(var.efa_interface_count)
+    },
+    {
+      for key, value in local.node_labels :
+      "k8s.io/cluster-autoscaler/node-template/label/${key}" => value
+    },
+    {
+      for taint in local.node_taints :
+      "k8s.io/cluster-autoscaler/node-template/taint/${taint.key}" => "${taint.value}:${local.cluster_autoscaler_taint_effects[taint.effect]}"
+    }
+  ) : {}
+
+  tags = merge(local.module_tags, local.cluster_autoscaler_tags, var.tags)
+}
+
+resource "aws_placement_group" "efa" {
+  name     = local.placement_group_name
+  strategy = "cluster"
+
+  tags = merge(
+    {
+      Name = local.placement_group_name
+    },
+    local.tags
+  )
+}
+
+resource "aws_security_group" "efa" {
+  count = var.create_efa_security_group ? 1 : 0
+
+  name        = var.efa_security_group_name
+  name_prefix = var.efa_security_group_name == null ? coalesce(var.efa_security_group_name_prefix, "${local.name_prefix}efa-sg-") : null
+  description = "Security group for EKS EFA worker nodes"
+  vpc_id      = var.vpc_id
+
+  revoke_rules_on_delete = var.revoke_security_group_rules_on_delete
+
+  tags = merge(
+    {
+      Name = coalesce(var.efa_security_group_name, "${local.name_prefix}efa-sg")
+    },
+    local.tags
+  )
+}
+
+resource "aws_security_group_rule" "efa_self_ingress" {
+  count = var.create_efa_security_group ? 1 : 0
+
+  security_group_id = aws_security_group.efa[0].id
+  type              = "ingress"
+  self              = true
+  description       = "Allow all node-to-node EFA traffic inside the EFA node group"
+  from_port         = -1
+  to_port           = -1
+  protocol          = "-1"
+}
+
+resource "aws_security_group_rule" "efa_self_egress" {
+  count = var.create_efa_security_group ? 1 : 0
+
+  security_group_id = aws_security_group.efa[0].id
+  type              = "egress"
+  self              = true
+  description       = "Allow all node-to-node EFA traffic inside the EFA node group"
+  from_port         = -1
+  to_port           = -1
+  protocol          = "-1"
+}
+
+resource "aws_security_group_rule" "efa_all_egress" {
+  count = var.create_efa_security_group && var.allow_all_egress ? 1 : 0
+
+  security_group_id = aws_security_group.efa[0].id
+  type              = "egress"
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "Allow outbound control-plane, registry, and package traffic"
+  from_port         = -1
+  to_port           = -1
+  protocol          = "-1"
+}
+
+resource "aws_security_group_rule" "cluster_ingress" {
+  for_each = var.create_efa_security_group ? {
+    for index, security_group_id in var.cluster_security_group_ids : index => security_group_id
+  } : {}
+
+  security_group_id        = aws_security_group.efa[0].id
+  type                     = "ingress"
+  source_security_group_id = each.value
+  description              = "Allow EKS control-plane security group traffic to EFA nodes"
+  from_port                = -1
+  to_port                  = -1
+  protocol                 = "-1"
+}
+
+resource "aws_launch_template" "efa" {
+  name_prefix   = local.launch_template_name_prefix
+  instance_type = var.instance_type
+  image_id      = var.ami_id
+
+  update_default_version = true
+
+  dynamic "instance_market_options" {
+    for_each = local.capacity_block_enabled ? [1] : []
+
+    content {
+      market_type = "capacity-block"
+    }
+  }
+
+  dynamic "capacity_reservation_specification" {
+    for_each = var.capacity_reservation_id != null ? [1] : []
+
+    content {
+      capacity_reservation_target {
+        capacity_reservation_id = var.capacity_reservation_id
+      }
+    }
+  }
+
+  placement {
+    group_name = aws_placement_group.efa.name
+  }
+
+  block_device_mappings {
+    device_name = var.root_block_device_name
+
+    ebs {
+      delete_on_termination = true
+      encrypted             = var.root_volume_encrypted
+      volume_size           = var.root_volume_size_gb
+      volume_type           = var.root_volume_type
+    }
+  }
+
+  dynamic "network_interfaces" {
+    for_each = local.network_interfaces
+
+    content {
+      associate_public_ip_address = false
+      delete_on_termination       = true
+      device_index                = network_interfaces.value.device_index
+      interface_type              = network_interfaces.value.interface_type
+      network_card_index          = network_interfaces.value.network_card_index
+      security_groups             = local.security_group_ids
+    }
+  }
+
+  tag_specifications {
+    resource_type = "instance"
+
+    tags = merge(
+      {
+        Name = local.node_group_name
+      },
+      local.tags
+    )
+  }
+
+  tag_specifications {
+    resource_type = "volume"
+
+    tags = merge(
+      {
+        Name = local.node_group_name
+      },
+      local.tags
+    )
+  }
+
+  tag_specifications {
+    resource_type = "network-interface"
+
+    tags = merge(
+      {
+        Name = local.node_group_name
+      },
+      local.tags
+    )
+  }
+
+  tags = local.tags
+
+  lifecycle {
+    precondition {
+      condition     = var.create_efa_security_group || var.efa_security_group_id != null
+      error_message = "efa_security_group_id is required when create_efa_security_group is false."
+    }
+
+    precondition {
+      condition     = !local.capacity_block_enabled || var.capacity_reservation_id != null
+      error_message = "capacity_reservation_id is required when capacity_type is CAPACITY_BLOCK."
+    }
+  }
+}
+
+resource "aws_eks_node_group" "efa" {
+  cluster_name    = var.cluster_name
+  node_group_name = local.node_group_name
+  node_role_arn   = var.node_role_arn
+  subnet_ids      = [var.subnet_id]
+
+  ami_type      = var.ami_id == null ? var.ami_type : null
+  capacity_type = var.capacity_type
+  labels        = local.node_labels
+
+  launch_template {
+    id      = aws_launch_template.efa.id
+    version = aws_launch_template.efa.default_version
+  }
+
+  scaling_config {
+    desired_size = var.desired_size
+    max_size     = var.max_size
+    min_size     = var.min_size
+  }
+
+  update_config {
+    max_unavailable = var.update_max_unavailable
+  }
+
+  dynamic "taint" {
+    for_each = local.node_taints
+
+    content {
+      key    = taint.value.key
+      value  = taint.value.value
+      effect = taint.value.effect
+    }
+  }
+
+  tags = local.tags
+
+  lifecycle {
+    precondition {
+      condition     = var.availability_zone == null || data.aws_subnet.selected.availability_zone == var.availability_zone
+      error_message = "subnet_id must be in availability_zone when availability_zone is set."
+    }
+
+    precondition {
+      condition     = var.min_size <= var.desired_size && var.desired_size <= var.max_size
+      error_message = "desired_size must be between min_size and max_size."
+    }
+  }
+}
+
+resource "aws_autoscaling_group_tag" "efa" {
+  for_each = local.tags
+
+  autoscaling_group_name = aws_eks_node_group.efa.resources[0].autoscaling_groups[0].name
+
+  tag {
+    key                 = each.key
+    value               = each.value
+    propagate_at_launch = true
+  }
+}

--- a/modules/aws-efa-nodegroup/outputs.tf
+++ b/modules/aws-efa-nodegroup/outputs.tf
@@ -1,0 +1,54 @@
+output "node_group_arn" {
+  description = "ARN of the EKS managed node group."
+  value       = aws_eks_node_group.efa.arn
+}
+
+output "node_group_name" {
+  description = "Name of the EKS managed node group."
+  value       = aws_eks_node_group.efa.node_group_name
+}
+
+output "node_group_status" {
+  description = "Status of the EKS managed node group."
+  value       = aws_eks_node_group.efa.status
+}
+
+output "launch_template_id" {
+  description = "ID of the EFA launch template."
+  value       = aws_launch_template.efa.id
+}
+
+output "launch_template_latest_version" {
+  description = "Latest version of the EFA launch template."
+  value       = aws_launch_template.efa.latest_version
+}
+
+output "launch_template_default_version" {
+  description = "Default version of the EFA launch template."
+  value       = aws_launch_template.efa.default_version
+}
+
+output "placement_group_name" {
+  description = "Name of the cluster placement group."
+  value       = aws_placement_group.efa.name
+}
+
+output "efa_security_group_id" {
+  description = "Security group ID used by EFA network interfaces."
+  value       = local.efa_security_group_id
+}
+
+output "security_group_ids" {
+  description = "Full set of security group IDs attached to launch-template network interfaces."
+  value       = local.security_group_ids
+}
+
+output "subnet_availability_zone" {
+  description = "Availability Zone of subnet_id."
+  value       = data.aws_subnet.selected.availability_zone
+}
+
+output "network_interfaces" {
+  description = "Network interface layout rendered into the launch template."
+  value       = local.network_interfaces
+}

--- a/modules/aws-efa-nodegroup/variables.tf
+++ b/modules/aws-efa-nodegroup/variables.tf
@@ -1,0 +1,275 @@
+# ------------------------------------------------------------------------------
+# REQUIRED PARAMETERS
+# ------------------------------------------------------------------------------
+
+variable "cluster_name" {
+  description = "(Required) Name of the existing EKS cluster."
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "(Required) VPC ID where the EKS worker nodes and EFA security group are created."
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "(Required) Single subnet ID for the EFA managed node group. Use a private subnet in one Availability Zone."
+  type        = string
+}
+
+variable "node_role_arn" {
+  description = "(Required) IAM role ARN for the EKS managed node group workers."
+  type        = string
+}
+
+# ------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+# ------------------------------------------------------------------------------
+
+variable "name_prefix" {
+  description = "(Optional) Prefix used for generated resource names."
+  type        = string
+  default     = null
+}
+
+variable "workload_name" {
+  description = "(Optional) Workload name used in default resource names, Kubernetes labels, taints, and Cluster Autoscaler template tags."
+  type        = string
+  default     = "h100-efa"
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]*[a-z0-9]$", var.workload_name))
+    error_message = "workload_name must be lowercase DNS-style text: letters, numbers, hyphens, no leading/trailing hyphen."
+  }
+}
+
+variable "workload_label_key" {
+  description = "(Optional) Kubernetes label and taint key used to isolate this P5/H100 EFA node group."
+  type        = string
+  default     = "workload"
+}
+
+variable "tags" {
+  description = "(Optional) Tags applied to resources that support tags."
+  type        = map(string)
+  default     = {}
+}
+
+variable "availability_zone" {
+  description = "(Optional) Expected Availability Zone for subnet_id. When set, the module verifies the subnet is in this AZ."
+  type        = string
+  default     = null
+}
+
+variable "instance_type" {
+  description = "(Optional) EFA-capable GPU instance type for the node group."
+  type        = string
+  default     = "p5.48xlarge"
+}
+
+variable "desired_size" {
+  description = "(Optional) Desired number of EFA worker nodes."
+  type        = number
+  default     = 4
+}
+
+variable "min_size" {
+  description = "(Optional) Minimum number of EFA worker nodes."
+  type        = number
+  default     = 0
+}
+
+variable "max_size" {
+  description = "(Optional) Maximum number of EFA worker nodes."
+  type        = number
+  default     = 4
+}
+
+variable "ami_type" {
+  description = "(Optional) EKS managed node group AMI type. Ignored when ami_id is set in the launch template."
+  type        = string
+  default     = "AL2023_x86_64_NVIDIA"
+}
+
+variable "ami_id" {
+  description = "(Optional) Custom AMI ID for the launch template. If set, provide bootstrap-compatible user data outside this module if needed."
+  type        = string
+  default     = null
+}
+
+variable "capacity_type" {
+  description = "(Optional) EKS managed node group capacity type."
+  type        = string
+  default     = "ON_DEMAND"
+
+  validation {
+    condition     = contains(["ON_DEMAND", "SPOT", "CAPACITY_BLOCK"], var.capacity_type)
+    error_message = "capacity_type must be one of ON_DEMAND, SPOT, or CAPACITY_BLOCK."
+  }
+}
+
+variable "capacity_reservation_id" {
+  description = "(Optional) Targeted EC2 Capacity Reservation ID. Required when capacity_type is CAPACITY_BLOCK; also usable with ON_DEMAND targeted reservations."
+  type        = string
+  default     = null
+}
+
+variable "root_volume_size_gb" {
+  description = "(Optional) Root EBS volume size in GiB."
+  type        = number
+  default     = 300
+}
+
+variable "root_volume_type" {
+  description = "(Optional) Root EBS volume type."
+  type        = string
+  default     = "gp3"
+}
+
+variable "root_volume_encrypted" {
+  description = "(Optional) Whether to encrypt the root EBS volume."
+  type        = bool
+  default     = true
+}
+
+variable "root_block_device_name" {
+  description = "(Optional) Root block device name for the EKS optimized AMI."
+  type        = string
+  default     = "/dev/xvda"
+}
+
+variable "labels" {
+  description = "(Optional) Additional or overriding Kubernetes labels for the managed node group. The module supplies P5/H100/EFA defaults."
+  type        = map(string)
+  default     = {}
+}
+
+variable "taints" {
+  description = <<-EOT
+    (Optional) Kubernetes taints for the managed node group.
+
+    Effects must use AWS EKS API values: NO_SCHEDULE, NO_EXECUTE, or PREFER_NO_SCHEDULE.
+  EOT
+  type = list(object({
+    key    = string
+    value  = string
+    effect = string
+  }))
+  default  = null
+  nullable = true
+
+  validation {
+    condition = (
+      var.taints == null ||
+      alltrue([
+        for taint in var.taints :
+        contains(["NO_SCHEDULE", "NO_EXECUTE", "PREFER_NO_SCHEDULE"], taint.effect)
+      ])
+    )
+    error_message = "taints effects must be one of NO_SCHEDULE, NO_EXECUTE, or PREFER_NO_SCHEDULE."
+  }
+}
+
+variable "enable_cluster_autoscaler_tags" {
+  description = "(Optional) Whether to add Cluster Autoscaler node-template tags for the P5/H100/EFA labels, taints, and resources."
+  type        = bool
+  default     = true
+}
+
+variable "update_max_unavailable" {
+  description = "(Optional) Maximum unavailable nodes during managed node group updates."
+  type        = number
+  default     = 1
+}
+
+variable "placement_group_name" {
+  description = "(Optional) Explicit placement group name. Defaults to a name derived from name_prefix."
+  type        = string
+  default     = null
+}
+
+variable "launch_template_name_prefix" {
+  description = "(Optional) Explicit launch template name prefix."
+  type        = string
+  default     = null
+}
+
+variable "node_group_name" {
+  description = "(Optional) Explicit EKS managed node group name."
+  type        = string
+  default     = null
+}
+
+variable "create_efa_security_group" {
+  description = "(Optional) Whether to create the EFA security group."
+  type        = bool
+  default     = true
+}
+
+variable "efa_security_group_id" {
+  description = "(Optional) Existing EFA security group ID to use when create_efa_security_group is false."
+  type        = string
+  default     = null
+}
+
+variable "efa_security_group_name" {
+  description = "(Optional) Name for the EFA security group."
+  type        = string
+  default     = null
+}
+
+variable "efa_security_group_name_prefix" {
+  description = "(Optional) Name prefix for the EFA security group."
+  type        = string
+  default     = null
+}
+
+variable "revoke_security_group_rules_on_delete" {
+  description = "(Optional) Whether Terraform revokes security group rules before deleting the EFA security group."
+  type        = bool
+  default     = false
+}
+
+variable "allow_all_egress" {
+  description = "(Optional) Whether to allow outbound IPv4 traffic from the EFA security group."
+  type        = bool
+  default     = true
+}
+
+variable "cluster_security_group_ids" {
+  description = "(Optional) EKS control-plane or cluster security group IDs allowed to initiate traffic to EFA nodes."
+  type        = list(string)
+  default     = []
+}
+
+variable "additional_security_group_ids" {
+  description = "(Optional) Additional security group IDs attached to every launch-template network interface, such as an existing Anyscale/EKS node security group."
+  type        = list(string)
+  default     = []
+}
+
+variable "efa_interface_count" {
+  description = "(Optional) Number of EFA-only interfaces to generate when network_interfaces is not supplied. p5.48xlarge supports 32."
+  type        = number
+  default     = 32
+
+  validation {
+    condition     = var.efa_interface_count >= 1
+    error_message = "efa_interface_count must be at least 1."
+  }
+}
+
+variable "network_interfaces" {
+  description = <<-EOT
+    (Optional) Override launch-template network interface layout.
+
+    Leave null for the p5.48xlarge one-IP layout:
+    card 0 device 0 interface, card 0 device 1 efa-only, cards 1..31 device 0 efa-only.
+  EOT
+  type = list(object({
+    network_card_index = number
+    device_index       = number
+    interface_type     = string
+  }))
+  default = null
+}

--- a/modules/aws-efa-nodegroup/versions.tf
+++ b/modules/aws-efa-nodegroup/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 7.0"
+    }
+  }
+}


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] pre-commit has been run
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All tests passing
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull Request Type

- [ ] Bugfix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [x] Documentation change
- [ ] Other (please describe):

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

## Summary

This PR adds a reusable AWS EFA EKS managed node group module for P5/H100 workers, plus a public AWS EKS example that wires the module into an Anyscale Kubernetes foundation deployment.

The new `modules/aws-efa-nodegroup` module creates:
- a cluster placement group
- an EFA security group with self-referencing EFA traffic rules
- an EKS launch template with the `p5.48xlarge` EFA network interface layout
- an EKS managed node group scoped to a single subnet/AZ
- optional targeted Capacity Reservation support
- labels, taints, and Cluster Autoscaler node-template tags for GPU/EFA scheduling

The new `examples/aws/eks-public-efa` example extends the existing public EKS path with:
- an EFA private subnet in the requested AZ/AZ ID
- capacity reservation inputs for P5 workers
- the H100/EFA managed node group
- sample Helm values for NVIDIA and EFA device plugin scheduling
- README guidance for Terraform apply, device plugin setup, Anyscale cloud registration, and runtime validation

## Validation

Performed:
- end-to-end development validation created fresh AWS/EKS/Anyscale clouds with the EFA node group, installed the required Kubernetes add-ons/operator, launched a P5 validation workspace, and completed the runtime checks: `quick`, `nccl`, `uccl-ll`, and `uccl-ht`

## Privacy / Public Release Check

The branch was checked for private/local values before push. No real local paths, personal workspace paths, AWS account IDs, Anyscale cloud IDs, capacity reservation IDs, security group IDs, run directories, tfstate files, logs, keys, or secret values are included.

The remaining ID-like values are generic documentation placeholders such as `123456789012`, `cr-0123456789abcdef0`, and `sg-existing-*`.
