### PR TITLE
Add GCP GKE B200 RDMA module

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The examples folder has a couple common use cases that have been tested. These i
   * [eks-private](https://github.com/anyscale/terraform-kubernetes-anyscale-foundation-modules/tree/main/examples/aws/eks-private) - Build everything - use a common name for all resources, private networking
 * Anyscale - GCP & GKE
   * [gke-existing_cluster](https://github.com/anyscale/terraform-kubernetes-anyscale-foundation-modules/tree/main/examples/gcp/gke-existing_cluster) - Use an existing GKE cluster, build additional resources such as object storage, service accounts, filestore.
+  * [gke-b200-rdma](https://github.com/anyscale/terraform-kubernetes-anyscale-foundation-modules/tree/main/examples/gcp/gke-b200-rdma) - Build a GKE A4/B200 cluster with GPUDirect RDMA networking for GPU collectives.
 
 Additional examples can be requested via an [issues] ticket.
 

--- a/examples/gcp/gke-b200-rdma/README.md
+++ b/examples/gcp/gke-b200-rdma/README.md
@@ -38,6 +38,27 @@ terraform output get_credentials_command
 kubectl get nodes -l rdma=true -o wide
 ```
 
+## Build the RDMA/UCCL Runtime Image
+
+The self-contained `docker/` build context installs UCCL/UCCL-EP and the
+runtime validation tools for the GKE RDMA environment. Build locally and push
+to an Artifact Registry repository accessible to the worker nodes:
+
+```bash
+cd docker
+
+export IMAGE_URI=<region>-docker.pkg.dev/<project>/<repository>/gcp-b200-rdma-uccl:1
+docker build \
+  -f Dockerfile.nvcr-pytorch-25.04-gcp-rdma-uccl \
+  -t "$IMAGE_URI" \
+  .
+docker push "$IMAGE_URI"
+```
+
+Alternatively, `scripts/cloud_build_image.sh` builds and publishes the same
+context with Cloud Build. See [`docker/README.md`](docker/README.md) for the
+required GKE host integration, Cloud Build parameters, and validation commands.
+
 The Terraform layer creates the GKE cluster, gVNIC/RDMA networks, and node
 pools. You still need to install the Kubernetes RDMA/multi-network add-ons and
 run workload-level validation before relying on the cluster for production

--- a/examples/gcp/gke-b200-rdma/README.md
+++ b/examples/gcp/gke-b200-rdma/README.md
@@ -1,0 +1,44 @@
+# GKE A4/B200 GPUDirect RDMA Example
+
+This example instantiates the `modules/gcp-gke-b200-rdma` module with a
+two-node A4/B200 worker pool and the default eight RDMA rails per worker.
+
+The values in `terraform.tfvars.example` are placeholders. Copy them into a
+real `terraform.tfvars` file or pass equivalent values through your CI system
+before applying.
+
+If your B200 capacity is reserved, set `worker_reservation_affinity` in
+`terraform.tfvars`. If you want GKE to scale the worker pool dynamically, set
+`worker_autoscaling` and keep `worker_node_count` as the fixed-size fallback.
+
+## Prerequisites
+
+```text
+Google Cloud project with quota for A4/B200 workers in the target zone
+Existing host/control-plane VPC and subnetwork for the GKE cluster
+Terraform credentials with Compute Engine and GKE permissions
+GKE zone with a matching ZONE-vpc-roce network profile
+```
+
+## Usage
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars for your project, region, zone, and host VPC.
+
+terraform init
+terraform plan -out=tfplan
+terraform apply tfplan
+```
+
+After apply:
+
+```bash
+terraform output get_credentials_command
+kubectl get nodes -l rdma=true -o wide
+```
+
+The Terraform layer creates the GKE cluster, gVNIC/RDMA networks, and node
+pools. You still need to install the Kubernetes RDMA/multi-network add-ons and
+run workload-level validation before relying on the cluster for production
+collectives.

--- a/examples/gcp/gke-b200-rdma/docker/.dockerignore
+++ b/examples/gcp/gke-b200-rdma/docker/.dockerignore
@@ -1,0 +1,5 @@
+.DS_Store
+.git
+.gitignore
+README.md
+cloudbuild.yaml

--- a/examples/gcp/gke-b200-rdma/docker/.gitignore
+++ b/examples/gcp/gke-b200-rdma/docker/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+*.log
+*.tmp
+__pycache__/
+.pytest_cache/
+.venv/
+venv/

--- a/examples/gcp/gke-b200-rdma/docker/Dockerfile.gcp-rdma-uccl.fragment
+++ b/examples/gcp/gke-b200-rdma/docker/Dockerfile.gcp-rdma-uccl.fragment
@@ -1,0 +1,80 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+SHELL ["/bin/bash", "-lc"]
+
+ARG UCCL_URL=https://github.com/uccl-project/uccl.git
+ARG UCCL_REF=v0.1.1
+ARG UCCL_FORCE_DMABUF=1
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV CUDA_HOME=/usr/local/cuda
+ENV TORCH_CUDA_ARCH_LIST=10.0
+ENV EFA_HOME=/opt/gcp-no-efa
+ENV PER_EXPERT_BATCHING=1
+ENV USE_DMABUF=1
+ENV UCCL_FORCE_DMABUF=${UCCL_FORCE_DMABUF}
+ENV MAX_JOBS=16
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    autoconf \
+    automake \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    ibverbs-providers \
+    iproute2 \
+    libhwloc-dev \
+    libibverbs-dev \
+    libnl-3-dev \
+    libnl-route-3-dev \
+    libnuma-dev \
+    librdmacm-dev \
+    libtool \
+    perl \
+    pciutils \
+    pkg-config \
+    rdma-core \
+    wget \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN python -m pip install --no-cache-dir --upgrade pip setuptools wheel \
+  && python -m pip install --no-cache-dir nanobind intervaltree sortedcontainers
+
+RUN git clone "${UCCL_URL}" /opt/uccl \
+  && cd /opt/uccl \
+  && git checkout "${UCCL_REF}" \
+  && if [ "${UCCL_FORCE_DMABUF}" = "1" ] && ! grep -q "GCP_FORCE_DMABUF" ep/include/common.hpp; then \
+       perl -0pi -e 's{// Intel RDMA NIC support}{#ifndef USE_DMABUF\n#define USE_DMABUF  // GCP_FORCE_DMABUF: force DMA-BUF for GKE A4 RoCE\n#endif\n\n// Intel RDMA NIC support}' ep/include/common.hpp; \
+     fi
+
+RUN python -m pip install --no-cache-dir /opt/uccl \
+  && rm -rf /tmp/uccl_ep_build \
+  && cp -a /opt/uccl /tmp/uccl_ep_build \
+  && cd /tmp/uccl_ep_build/ep \
+  && python setup.py install \
+  && cd /tmp/uccl_ep_build/ep/deep_ep_wrapper \
+  && for name in buffer.py test_internode.py utils.py; do \
+       rm -f "deep_ep/${name}"; \
+       cp "../bench/${name}" "deep_ep/${name}"; \
+     done \
+  && python -m pip install --no-cache-dir . \
+  && rm -rf /tmp/uccl_ep_build
+
+COPY env/ /opt/gcp-middle/env/
+COPY scripts/ /opt/gcp-middle/scripts/
+
+RUN chmod +x /opt/gcp-middle/env/*.sh /opt/gcp-middle/scripts/*.sh
+
+ENV PATH=/opt/gcp-middle/scripts:/usr/local/cuda/bin:${PATH}
+ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib64:/usr/local/gib/lib64:${LD_LIBRARY_PATH}
+ENV CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+ENV OMP_NUM_THREADS=8
+ENV PYTHONUNBUFFERED=1
+ENV NCCL_DEBUG=WARN
+ENV NCCL_DEBUG_SUBSYS=INIT,NET
+ENV GLOO_SOCKET_IFNAME=eth0
+ENV UCCL_SOCKET_IFNAME=eth0
+
+WORKDIR /workspace

--- a/examples/gcp/gke-b200-rdma/docker/Dockerfile.nvcr-pytorch-25.04-gcp-rdma-uccl
+++ b/examples/gcp/gke-b200-rdma/docker/Dockerfile.nvcr-pytorch-25.04-gcp-rdma-uccl
@@ -1,0 +1,80 @@
+ARG BASE_IMAGE=nvcr.io/nvidia/pytorch:25.04-py3
+FROM ${BASE_IMAGE}
+
+SHELL ["/bin/bash", "-lc"]
+
+ARG UCCL_URL=https://github.com/uccl-project/uccl.git
+ARG UCCL_REF=v0.1.1
+ARG UCCL_FORCE_DMABUF=1
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV CUDA_HOME=/usr/local/cuda
+ENV TORCH_CUDA_ARCH_LIST=10.0
+ENV EFA_HOME=/opt/gcp-no-efa
+ENV PER_EXPERT_BATCHING=1
+ENV USE_DMABUF=1
+ENV UCCL_FORCE_DMABUF=${UCCL_FORCE_DMABUF}
+ENV MAX_JOBS=16
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    autoconf \
+    automake \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    ibverbs-providers \
+    iproute2 \
+    libhwloc-dev \
+    libibverbs-dev \
+    libnl-3-dev \
+    libnl-route-3-dev \
+    libnuma-dev \
+    librdmacm-dev \
+    libtool \
+    perl \
+    pciutils \
+    pkg-config \
+    rdma-core \
+    wget \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN python -m pip install --no-cache-dir --upgrade pip setuptools wheel \
+  && python -m pip install --no-cache-dir nanobind intervaltree sortedcontainers
+
+RUN git clone "${UCCL_URL}" /opt/uccl \
+  && cd /opt/uccl \
+  && git checkout "${UCCL_REF}" \
+  && if [ "${UCCL_FORCE_DMABUF}" = "1" ] && ! grep -q "GCP_FORCE_DMABUF" ep/include/common.hpp; then \
+       perl -0pi -e 's{// Intel RDMA NIC support}{#ifndef USE_DMABUF\n#define USE_DMABUF  // GCP_FORCE_DMABUF: force DMA-BUF for GKE A4 RoCE\n#endif\n\n// Intel RDMA NIC support}' ep/include/common.hpp; \
+     fi
+
+RUN python -m pip install --no-cache-dir /opt/uccl \
+  && rm -rf /tmp/uccl_ep_build \
+  && cp -a /opt/uccl /tmp/uccl_ep_build \
+  && cd /tmp/uccl_ep_build/ep \
+  && python setup.py install \
+  && cd /tmp/uccl_ep_build/ep/deep_ep_wrapper \
+  && for name in buffer.py test_internode.py utils.py; do \
+       rm -f "deep_ep/${name}"; \
+       cp "../bench/${name}" "deep_ep/${name}"; \
+     done \
+  && python -m pip install --no-cache-dir . \
+  && rm -rf /tmp/uccl_ep_build
+
+COPY env/ /opt/gcp-middle/env/
+COPY scripts/ /opt/gcp-middle/scripts/
+
+RUN chmod +x /opt/gcp-middle/env/*.sh /opt/gcp-middle/scripts/*.sh
+
+ENV PATH=/opt/gcp-middle/scripts:/usr/local/cuda/bin:${PATH}
+ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib64:/usr/local/gib/lib64:${LD_LIBRARY_PATH}
+ENV CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+ENV OMP_NUM_THREADS=8
+ENV PYTHONUNBUFFERED=1
+ENV NCCL_DEBUG=WARN
+ENV NCCL_DEBUG_SUBSYS=INIT,NET
+ENV GLOO_SOCKET_IFNAME=eth0
+ENV UCCL_SOCKET_IFNAME=eth0
+
+WORKDIR /workspace

--- a/examples/gcp/gke-b200-rdma/docker/README.md
+++ b/examples/gcp/gke-b200-rdma/docker/README.md
@@ -1,0 +1,128 @@
+# GCP RDMA UCCL-EP Docker Middle Layer
+
+This directory builds a CUDA container layer for GKE A4/B200 workloads that
+need NCCL, UCCL, UCCL-EP, and runtime validation tools for GCP RDMA.
+
+It is a self-contained Docker build context shipped with the
+`examples/gcp/gke-b200-rdma` Terraform example. From the repository root,
+change into this directory before running the build commands below:
+
+```bash
+cd examples/gcp/gke-b200-rdma/docker
+```
+
+The host and Kubernetes layer must already provide:
+
+```text
+NVIDIA GPUs exposed to the container
+RDMA NICs exposed through GKE multi-networking
+/usr/local/gib mounted from /home/kubernetes/bin/gib
+/usr/local/nvidia mounted from /home/kubernetes/bin/nvidia
+/dev/gdrdrv mounted from the host after the loader DaemonSet runs
+```
+
+The image does not create RDMA devices, load kernel modules, or install the
+Google gIB host plugin. It only provides userspace libraries, environment
+defaults, and validation entrypoints.
+
+## Build
+
+Build with a configurable base image:
+
+```bash
+BASE_IMAGE=nvcr.io/nvidia/pytorch:25.04-py3 \
+IMAGE=gcp-b200-rdma-uccl:dev \
+bash scripts/build_image.sh
+```
+
+Or build the concrete image directly:
+
+```bash
+docker build \
+  -f Dockerfile.nvcr-pytorch-25.04-gcp-rdma-uccl \
+  -t gcp-b200-rdma-uccl:dev \
+  .
+```
+
+The build context must be this directory because the Dockerfiles copy `env/`
+and `scripts/` into the image.
+
+Default build arguments:
+
+```text
+BASE_IMAGE=nvcr.io/nvidia/pytorch:25.04-py3
+UCCL_REF=v0.1.1
+UCCL_FORCE_DMABUF=1
+TORCH_CUDA_ARCH_LIST=10.0
+```
+
+The Dockerfiles default `UCCL_FORCE_DMABUF=1`. During the UCCL checkout step,
+they patch `ep/include/common.hpp` with a guarded `#define USE_DMABUF` before
+building UCCL-EP. This is required on GCP A4 RoCE because UCCL v0.1.1 does not
+make runtime `USE_DMABUF=1` a compile-time define by itself.
+
+## Cloud Build
+
+The Cloud Build wrapper builds the same image into Artifact Registry:
+
+```bash
+PROJECT=YOUR_GCP_PROJECT_ID \
+REGION=us-central1 \
+REPOSITORY=gcp-rdma-images \
+IMAGE_NAME=gcp-rdma-uccl \
+TAG=dev \
+bash scripts/cloud_build_image.sh
+```
+
+It enables `cloudbuild.googleapis.com` and `artifactregistry.googleapis.com`,
+creates the Artifact Registry Docker repository when needed, and submits this
+directory as the build context.
+
+## Runtime Environment
+
+The main environment file is:
+
+```bash
+source /opt/gcp-middle/env/gcp_rdma_uccl_env.sh
+```
+
+It sets CUDA, gIB, NCCL, and UCCL defaults used by the validation scripts:
+
+```text
+GIB_HOME=/usr/local/gib
+NVIDIA_HOST_HOME=/usr/local/nvidia
+GLOO_SOCKET_IFNAME=eth0
+UCCL_SOCKET_IFNAME=eth0
+USE_DMABUF=1
+UCCL_FORCE_DMABUF=1
+PER_EXPERT_BATCHING=1
+```
+
+## Validation
+
+Inside a GKE A4/B200 worker pod:
+
+```bash
+/opt/gcp-middle/scripts/validate_gcp_rdma_devices.sh
+PYTHON=python /opt/gcp-middle/scripts/validate_uccl_imports.sh
+```
+
+For UCCL-EP, run matching commands on each worker pod. Example for two nodes:
+
+```bash
+PYTHON=python \
+NNODES=2 NPROC_PER_NODE=8 NODE_RANK=0 MASTER_ADDR=<worker-0-pod-ip> \
+  /opt/gcp-middle/scripts/validate_uccl_ep.sh ll
+
+PYTHON=python \
+NNODES=2 NPROC_PER_NODE=8 NODE_RANK=0 MASTER_ADDR=<worker-0-pod-ip> \
+  /opt/gcp-middle/scripts/validate_uccl_ep.sh ht
+```
+
+Run the same commands on the second worker with `NODE_RANK=1`.
+
+## Notes
+
+This image was designed for GKE A4/B200 RDMA environments where GCP gIB,
+GPUDirect RDMA, and multi-networking are configured at the cluster layer. The
+container intentionally keeps those host responsibilities outside the image.

--- a/examples/gcp/gke-b200-rdma/docker/cloudbuild.yaml
+++ b/examples/gcp/gke-b200-rdma/docker/cloudbuild.yaml
@@ -1,0 +1,18 @@
+substitutions:
+  _BASE_IMAGE: nvcr.io/nvidia/pytorch:25.04-py3
+  _IMAGE: us-central1-docker.pkg.dev/$PROJECT_ID/gcp-rdma-images/gcp-rdma-uccl:dev
+
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - -f
+      - Dockerfile.gcp-rdma-uccl.fragment
+      - --build-arg
+      - BASE_IMAGE=${_BASE_IMAGE}
+      - -t
+      - ${_IMAGE}
+      - .
+
+images:
+  - ${_IMAGE}

--- a/examples/gcp/gke-b200-rdma/docker/env/gcp_rdma_uccl_env.sh
+++ b/examples/gcp/gke-b200-rdma/docker/env/gcp_rdma_uccl_env.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+if [ -z "${BASH_VERSION:-}" ]; then
+  exec bash "$0" "$@"
+fi
+
+export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
+export GIB_HOME="${GIB_HOME:-/usr/local/gib}"
+export NVIDIA_HOST_HOME="${NVIDIA_HOST_HOME:-/usr/local/nvidia}"
+
+if [ -x "${GIB_HOME}/scripts/set_nccl_env.sh" ]; then
+  # shellcheck disable=SC1091
+  source "${GIB_HOME}/scripts/set_nccl_env.sh"
+fi
+
+export PATH="${CUDA_HOME}/bin:${PATH}"
+export LD_LIBRARY_PATH="${NVIDIA_HOST_HOME}/lib64:${GIB_HOME}/lib64:${LD_LIBRARY_PATH:-}"
+
+export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0,1,2,3,4,5,6,7}"
+export OMP_NUM_THREADS="${OMP_NUM_THREADS:-8}"
+export PYTHONUNBUFFERED="${PYTHONUNBUFFERED:-1}"
+
+export GLOO_SOCKET_IFNAME="${GLOO_SOCKET_IFNAME:-eth0}"
+export UCCL_SOCKET_IFNAME="${UCCL_SOCKET_IFNAME:-eth0}"
+export NCCL_DEBUG="${NCCL_DEBUG:-WARN}"
+export NCCL_DEBUG_SUBSYS="${NCCL_DEBUG_SUBSYS:-INIT,NET}"
+
+export USE_DMABUF="${USE_DMABUF:-1}"
+export UCCL_FORCE_DMABUF="${UCCL_FORCE_DMABUF:-1}"
+export PER_EXPERT_BATCHING="${PER_EXPERT_BATCHING:-1}"

--- a/examples/gcp/gke-b200-rdma/docker/scripts/build_image.sh
+++ b/examples/gcp/gke-b200-rdma/docker/scripts/build_image.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOCKER=${DOCKER:-docker}
+BASE_IMAGE=${BASE_IMAGE:-nvcr.io/nvidia/pytorch:25.04-py3}
+IMAGE=${IMAGE:-gcp-b200-rdma-uccl:dev}
+
+cd "$(dirname "$0")/.."
+
+"$DOCKER" build \
+  -f Dockerfile.gcp-rdma-uccl.fragment \
+  --build-arg BASE_IMAGE="$BASE_IMAGE" \
+  -t "$IMAGE" \
+  .

--- a/examples/gcp/gke-b200-rdma/docker/scripts/cloud_build_image.sh
+++ b/examples/gcp/gke-b200-rdma/docker/scripts/cloud_build_image.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GCLOUD=${GCLOUD:-}
+if [ -z "$GCLOUD" ]; then
+  if command -v gcloud >/dev/null 2>&1; then
+    GCLOUD=$(command -v gcloud)
+  else
+    echo "gcloud not found; set GCLOUD=/path/to/gcloud" >&2
+    exit 127
+  fi
+fi
+gcloud() { "$GCLOUD" "$@"; }
+
+PROJECT=${PROJECT:?Set PROJECT to your Google Cloud project ID}
+REGION=${REGION:-us-central1}
+REPOSITORY=${REPOSITORY:-gcp-rdma-images}
+IMAGE_NAME=${IMAGE_NAME:-gcp-rdma-uccl}
+TAG=${TAG:-dev}
+BASE_IMAGE=${BASE_IMAGE:-nvcr.io/nvidia/pytorch:25.04-py3}
+IMAGE=${IMAGE:-${REGION}-docker.pkg.dev/${PROJECT}/${REPOSITORY}/${IMAGE_NAME}:${TAG}}
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+
+gcloud services enable cloudbuild.googleapis.com artifactregistry.googleapis.com \
+  --project="$PROJECT"
+
+if ! gcloud artifacts repositories describe "$REPOSITORY" \
+  --project="$PROJECT" \
+  --location="$REGION" >/dev/null 2>&1; then
+  gcloud artifacts repositories create "$REPOSITORY" \
+    --project="$PROJECT" \
+    --location="$REGION" \
+    --repository-format=docker \
+    --description="GKE GPU RDMA/UCCL images"
+fi
+
+gcloud builds submit "$ROOT" \
+  --project="$PROJECT" \
+  --config="$ROOT/cloudbuild.yaml" \
+  --machine-type=e2-highcpu-32 \
+  --disk-size=300 \
+  --substitutions="_BASE_IMAGE=${BASE_IMAGE},_IMAGE=${IMAGE}"
+
+echo "$IMAGE"

--- a/examples/gcp/gke-b200-rdma/docker/scripts/validate_gcp_rdma_devices.sh
+++ b/examples/gcp/gke-b200-rdma/docker/scripts/validate_gcp_rdma_devices.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+source "${SCRIPT_DIR}/../env/gcp_rdma_uccl_env.sh"
+
+EXPECTED_GPUS=${EXPECTED_GPUS:-8}
+EXPECTED_RDMA_DEVICES=${EXPECTED_RDMA_DEVICES:-8}
+EXPECT_GDRDRV=${EXPECT_GDRDRV:-1}
+
+section() {
+  printf '\n== %s ==\n' "$1"
+}
+
+section "Host"
+hostname
+
+section "GPU Devices"
+nvidia-smi --query-gpu=index,name,pci.bus_id --format=csv,noheader |
+  awk -F', *' '{printf "GPU%-2s  %-24s  pci=%s\n", $1, $2, tolower($3)}'
+gpu_count=$(nvidia-smi --query-gpu=index --format=csv,noheader | wc -l | tr -d ' ')
+echo "GPU count: ${gpu_count}"
+if [ "$gpu_count" -lt "$EXPECTED_GPUS" ]; then
+  echo "Expected at least ${EXPECTED_GPUS} GPUs, found ${gpu_count}" >&2
+  exit 1
+fi
+
+section "RDMA Interfaces"
+for iface in eth2 eth3 eth4 eth5 eth6 eth7 eth8 eth9; do
+  ip -br addr show "$iface"
+done
+
+section "Infiniband Devices"
+if [ ! -d /sys/class/infiniband ]; then
+  echo "/sys/class/infiniband not found" >&2
+  exit 1
+fi
+for dev in /sys/class/infiniband/*; do
+  [ -e "$dev" ] || continue
+  basename "$dev"
+done | sort
+rdma_count=$(find /sys/class/infiniband -mindepth 1 -maxdepth 1 | wc -l | tr -d ' ')
+echo "RDMA device count: ${rdma_count}"
+if [ "$rdma_count" -lt "$EXPECTED_RDMA_DEVICES" ]; then
+  echo "Expected at least ${EXPECTED_RDMA_DEVICES} RDMA devices, found ${rdma_count}" >&2
+  exit 1
+fi
+
+section "gIB"
+test -x /usr/local/gib/scripts/set_nccl_env.sh
+env | grep -E '^(LD_LIBRARY_PATH|NCCL_|GLOO_SOCKET_IFNAME|UCCL_SOCKET_IFNAME|CUDA_VISIBLE_DEVICES|USE_DMABUF|PER_EXPERT_BATCHING)=' | sort
+
+section "gdrdrv"
+if [ "$EXPECT_GDRDRV" = "1" ]; then
+  grep -q '^gdrdrv ' /proc/modules
+  grep -q '[[:space:]]gdrdrv$' /proc/devices
+  test -c /dev/gdrdrv
+  ls -l /dev/gdrdrv
+else
+  ls -l /dev/gdrdrv 2>/dev/null || true
+fi
+
+section "ibv_devices"
+if command -v ibv_devices >/dev/null 2>&1; then
+  ibv_devices | sed -n '1,80p'
+else
+  echo "ibv_devices not found" >&2
+  exit 1
+fi
+
+echo
+echo "GCP RDMA device validation passed"

--- a/examples/gcp/gke-b200-rdma/docker/scripts/validate_uccl_ep.sh
+++ b/examples/gcp/gke-b200-rdma/docker/scripts/validate_uccl_ep.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE=${1:-}
+if [ "$MODE" != "ll" ] && [ "$MODE" != "ht" ]; then
+  echo "Usage: $0 ll|ht" >&2
+  exit 2
+fi
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+source "${SCRIPT_DIR}/../env/gcp_rdma_uccl_env.sh"
+
+PYTHON=${PYTHON:-python}
+NNODES=${NNODES:-1}
+NPROC_PER_NODE=${NPROC_PER_NODE:-8}
+NODE_RANK=${NODE_RANK:-0}
+MASTER_ADDR=${MASTER_ADDR:-127.0.0.1}
+
+LL_PORT=${LL_PORT:-6123}
+HT_PORT=${HT_PORT:-6124}
+LL_TOKENS=${LL_TOKENS:-128}
+HT_TOKENS=${HT_TOKENS:-4096}
+HIDDEN=${HIDDEN:-7168}
+TOPK=${TOPK:-8}
+EXPERTS=${EXPERTS:-288}
+
+UCCL_BENCH_DIR=${UCCL_BENCH_DIR:-/opt/uccl/ep/bench}
+if [ ! -d "$UCCL_BENCH_DIR" ]; then
+  echo "Cannot find UCCL bench dir. Set UCCL_BENCH_DIR=/path/to/uccl/ep/bench" >&2
+  exit 1
+fi
+
+if [ "$MODE" = "ll" ]; then
+  MASTER_PORT=${MASTER_PORT:-$LL_PORT}
+  BENCH_SCRIPT=test_low_latency.py
+  BENCH_ARGS=(--num-tokens="$LL_TOKENS" --hidden="$HIDDEN" --num-topk="$TOPK" --num-experts="$EXPERTS")
+else
+  MASTER_PORT=${MASTER_PORT:-$HT_PORT}
+  BENCH_SCRIPT=test_internode.py
+  BENCH_ARGS=(--num-tokens="$HT_TOKENS" --hidden="$HIDDEN" --num-topk="$TOPK" --num-experts="$EXPERTS" --test-ll-compatibility)
+fi
+
+echo "Running UCCL-EP ${MODE} validation"
+echo "NNODES=$NNODES NPROC_PER_NODE=$NPROC_PER_NODE NODE_RANK=$NODE_RANK MASTER=$MASTER_ADDR:$MASTER_PORT"
+echo "UCCL_BENCH_DIR=$UCCL_BENCH_DIR"
+
+cd "$UCCL_BENCH_DIR"
+"$PYTHON" -u -m torch.distributed.run \
+  --nnodes="$NNODES" \
+  --nproc_per_node="$NPROC_PER_NODE" \
+  --node_rank="$NODE_RANK" \
+  --master_addr="$MASTER_ADDR" \
+  --master_port="$MASTER_PORT" \
+  "$BENCH_SCRIPT" \
+  "${BENCH_ARGS[@]}"

--- a/examples/gcp/gke-b200-rdma/docker/scripts/validate_uccl_imports.sh
+++ b/examples/gcp/gke-b200-rdma/docker/scripts/validate_uccl_imports.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+source "${SCRIPT_DIR}/../env/gcp_rdma_uccl_env.sh"
+
+PYTHON=${PYTHON:-python}
+
+"$PYTHON" - <<'PY'
+import importlib
+import torch
+
+print("torch", torch.__version__)
+print("cuda available", torch.cuda.is_available())
+print("cuda devices", torch.cuda.device_count())
+
+for name in ("uccl", "uccl.ep", "deep_ep"):
+    mod = importlib.import_module(name)
+    print(name, getattr(mod, "__file__", "builtin"))
+PY
+
+echo "UCCL import validation passed"

--- a/examples/gcp/gke-b200-rdma/main.tf
+++ b/examples/gcp/gke-b200-rdma/main.tf
@@ -1,0 +1,23 @@
+module "b200_rdma_gke" {
+  source = "../../../modules/gcp-gke-b200-rdma"
+
+  project_id      = var.project_id
+  region          = var.region
+  zone            = var.zone
+  cluster_name    = var.cluster_name
+  host_network    = var.host_network
+  host_subnetwork = var.host_subnetwork
+
+  gvnic_network_name          = var.gvnic_network_name
+  gvnic_subnetwork_name       = var.gvnic_subnetwork_name
+  gvnic_subnetwork_cidr       = var.gvnic_subnetwork_cidr
+  rdma_network_name           = var.rdma_network_name
+  rdma_subnetwork_name_prefix = var.rdma_subnetwork_name_prefix
+  rdma_subnetwork_cidr_prefix = var.rdma_subnetwork_cidr_prefix
+
+  worker_node_count           = var.worker_node_count
+  worker_autoscaling          = var.worker_autoscaling
+  worker_reservation_affinity = var.worker_reservation_affinity
+  workload_name               = var.workload_name
+  resource_labels             = var.resource_labels
+}

--- a/examples/gcp/gke-b200-rdma/outputs.tf
+++ b/examples/gcp/gke-b200-rdma/outputs.tf
@@ -1,0 +1,14 @@
+output "get_credentials_command" {
+  description = "gcloud command for fetching kubeconfig credentials for this cluster."
+  value       = module.b200_rdma_gke.get_credentials_command
+}
+
+output "worker_pool_name" {
+  description = "Name of the A4/B200 worker node pool."
+  value       = module.b200_rdma_gke.worker_pool_name
+}
+
+output "rdma_subnetwork_names" {
+  description = "Names of the RDMA subnetworks attached to the A4/B200 worker pool."
+  value       = module.b200_rdma_gke.rdma_subnetwork_names
+}

--- a/examples/gcp/gke-b200-rdma/terraform.tfvars.example
+++ b/examples/gcp/gke-b200-rdma/terraform.tfvars.example
@@ -1,0 +1,37 @@
+project_id = "my-gcp-project"
+region     = "us-central1"
+zone       = "us-central1-b"
+
+cluster_name    = "b200-rdma-gke-us-central1"
+host_network    = "gke-host-vpc"
+host_subnetwork = "gke-host-subnet"
+
+gvnic_network_name          = "b200-rdma-gvnic-us-central1"
+gvnic_subnetwork_name       = "b200-rdma-gvnic-us-central1-subnet"
+gvnic_subnetwork_cidr       = "10.1.0.0/16"
+rdma_network_name           = "b200-rdma-us-central1-b"
+rdma_subnetwork_name_prefix = "b200-rdma-us-central1-b-subnet"
+rdma_subnetwork_cidr_prefix = "172.31"
+
+worker_node_count = 2
+workload_name     = "b200-rdma"
+
+# Optional: consume a specific zonal Compute Engine reservation.
+# worker_reservation_affinity = {
+#   type   = "SPECIFIC_RESERVATION"
+#   key    = "compute.googleapis.com/reservation-name"
+#   values = ["my-b200-reservation"]
+# }
+
+# Optional: use autoscaling instead of the fixed worker_node_count.
+# worker_autoscaling = {
+#   enabled         = true
+#   min_node_count  = 0
+#   max_node_count  = 2
+#   location_policy = "ANY"
+# }
+
+resource_labels = {
+  environment = "dev"
+  workload    = "b200-rdma"
+}

--- a/examples/gcp/gke-b200-rdma/variables.tf
+++ b/examples/gcp/gke-b200-rdma/variables.tf
@@ -1,0 +1,100 @@
+variable "project_id" {
+  description = "Google Cloud project ID."
+  type        = string
+}
+
+variable "region" {
+  description = "Regional GKE control-plane location."
+  type        = string
+}
+
+variable "zone" {
+  description = "Single A4/B200 worker zone."
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "Name of the GKE cluster to create."
+  type        = string
+}
+
+variable "host_network" {
+  description = "Existing host/control-plane VPC name or self link for the GKE cluster."
+  type        = string
+}
+
+variable "host_subnetwork" {
+  description = "Existing host/control-plane subnetwork name or self link for the GKE cluster."
+  type        = string
+}
+
+variable "gvnic_network_name" {
+  description = "Dedicated VPC name for the extra Titanium gVNIC."
+  type        = string
+}
+
+variable "gvnic_subnetwork_name" {
+  description = "Subnetwork name for the extra Titanium gVNIC."
+  type        = string
+}
+
+variable "gvnic_subnetwork_cidr" {
+  description = "CIDR for the extra gVNIC subnetwork."
+  type        = string
+}
+
+variable "rdma_network_name" {
+  description = "Dedicated RoCE RDMA VPC name."
+  type        = string
+}
+
+variable "rdma_subnetwork_name_prefix" {
+  description = "Prefix for RDMA subnet names."
+  type        = string
+}
+
+variable "rdma_subnetwork_cidr_prefix" {
+  description = "First two octets for RDMA subnets."
+  type        = string
+}
+
+variable "worker_node_count" {
+  description = "A4/B200 worker node count."
+  type        = number
+}
+
+variable "worker_autoscaling" {
+  description = "Autoscaling configuration for the A4/B200 worker node pool."
+  type = object({
+    enabled              = bool
+    min_node_count       = optional(number)
+    max_node_count       = optional(number)
+    total_min_node_count = optional(number)
+    total_max_node_count = optional(number)
+    location_policy      = optional(string)
+  })
+  default = {
+    enabled = false
+  }
+}
+
+variable "worker_reservation_affinity" {
+  description = "Reservation affinity for A4/B200 workers."
+  type = object({
+    type   = string
+    key    = optional(string)
+    values = optional(set(string))
+  })
+  default = null
+}
+
+variable "workload_name" {
+  description = "Workload name used in default Kubernetes labels."
+  type        = string
+}
+
+variable "resource_labels" {
+  description = "Google Cloud resource labels applied to resources that support labels."
+  type        = map(string)
+  default     = {}
+}

--- a/examples/gcp/gke-b200-rdma/versions.tf
+++ b/examples/gcp/gke-b200-rdma/versions.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0, < 7.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}

--- a/modules/gcp-gke-b200-rdma/README.md
+++ b/modules/gcp-gke-b200-rdma/README.md
@@ -1,0 +1,138 @@
+# GCP GKE A4/B200 GPUDirect RDMA Module
+
+This module creates the GCP infrastructure required before Kubernetes can
+expose GPUDirect RDMA devices to Pods running on GKE A4/B200 workers.
+
+It is intentionally scoped to the GKE and node infrastructure layer. It expects
+an existing host/control-plane VPC and subnetwork, then creates the extra
+gVNIC/RDMA networks, the GKE cluster, an optional CPU head pool, and one
+A4/B200 worker pool.
+
+## What It Creates
+
+```text
+google_compute_network for the extra Titanium gVNIC
+google_compute_subnetwork for the extra Titanium gVNIC
+google_compute_network with a ZONE-vpc-roce network profile for RDMA
+RDMA subnetworks for the requested RDMA rails
+google_container_cluster with multi-networking and Dataplane V2
+optional CPU head google_container_node_pool
+A4/B200 google_container_node_pool with one gVNIC and RDMA additional node networks
+```
+
+The default worker layout is for `a4-highgpu-8g`:
+
+```text
+eth0: default GKE host network
+eth1: extra Titanium gVNIC network
+eth2..eth9: RDMA device networks backed by mlx5_0..mlx5_7
+8 NVIDIA B200 GPUs
+```
+
+The module defaults to a fixed-size Spot worker pool, `COS_CONTAINERD`,
+automatic GPU driver installation, disabled node auto-repair/auto-upgrade, and
+`disable-legacy-endpoints` node metadata. These defaults match
+high-performance RDMA validation flows, but all major sizing, label, service
+account, reservation, autoscaling, and node-management choices are configurable.
+
+## Example
+
+```hcl
+module "b200_rdma_gke" {
+  source = "./modules/gcp-gke-b200-rdma"
+
+  project_id      = "my-gcp-project"
+  region          = "us-central1"
+  zone            = "us-central1-b"
+  cluster_name    = "b200-rdma-gke-us-central1"
+  host_network    = "gke-host-vpc"
+  host_subnetwork = "gke-host-subnet"
+
+  gvnic_network_name          = "b200-rdma-gvnic-us-central1"
+  gvnic_subnetwork_name       = "b200-rdma-gvnic-us-central1-subnet"
+  rdma_network_name           = "b200-rdma-us-central1-b"
+  rdma_subnetwork_name_prefix = "b200-rdma-us-central1-b-subnet"
+
+  worker_node_count = 2
+  workload_name     = "b200-rdma"
+
+  resource_labels = {
+    environment = "dev"
+    workload    = "b200-rdma"
+  }
+}
+```
+
+When the RDMA network profile does not follow the default
+`projects/PROJECT/global/networkProfiles/ZONE-vpc-roce` naming, set
+`rdma_network_profile` explicitly.
+
+To consume a specific zonal Compute Engine reservation for the A4/B200 workers:
+
+```hcl
+worker_reservation_affinity = {
+  type   = "SPECIFIC_RESERVATION"
+  key    = "compute.googleapis.com/reservation-name"
+  values = ["my-b200-reservation"]
+}
+```
+
+To use GKE autoscaling instead of a fixed worker node count:
+
+```hcl
+worker_autoscaling = {
+  enabled         = true
+  min_node_count  = 0
+  max_node_count  = 2
+  location_policy = "ANY"
+}
+```
+
+## Follow-On Kubernetes Layer
+
+After this module is applied, install the Kubernetes layer required by your GKE
+RDMA stack. At minimum this usually includes:
+
+```text
+Google GPUDirect RDMA or gIB host installer components
+GKE multi-network objects that map the gVNIC and RDMA subnetworks into Pods
+Any workload-specific GPU/RDMA validation Jobs or Ray/Anyscale workloads
+```
+
+With the add-ons installed, A4/B200 worker pods should see:
+
+```text
+nvidia.com/gpu: 8
+eth2..eth9 RDMA interfaces
+mlx5_0..mlx5_7 verbs devices
+/usr/local/gib from the GKE gIB installer
+/dev/gdrdrv after the loader DaemonSet runs
+```
+
+## Validation
+
+Run in a Terraform-capable environment:
+
+```bash
+terraform fmt -recursive
+terraform init
+terraform validate
+terraform plan
+```
+
+After apply:
+
+```bash
+terraform output get_credentials_command
+kubectl get nodes -l rdma=true -o wide
+kubectl describe node <node-name> | egrep 'nvidia.com/gpu|cloud.google.com/gke-accelerator'
+```
+
+Then validate the runtime image or workload layer with your chosen NCCL, UCCL,
+or Ray-based collectives tests.
+
+## Boundary
+
+This module validates the GCP RDMA infrastructure path used by NCCL/gIB and
+UCCL/DeepEP with DMA-BUF. It does not build container images, configure
+Anyscale resources, or claim native GPU-initiated IBGDA/GDAKI support.

--- a/modules/gcp-gke-b200-rdma/main.tf
+++ b/modules/gcp-gke-b200-rdma/main.tf
@@ -1,0 +1,321 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GCP GKE A4/B200 GPUDirect RDMA Cluster
+#
+# This module creates the infrastructure layer required before Kubernetes can expose GCP RDMA devices to Pods:
+# dedicated gVNIC and RoCE VPCs, a multi-networking GKE cluster, a CPU head node pool, and an A4/B200 Spot node pool
+# with one gVNIC and eight RDMA additional node networks.
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "google_container_engine_versions" "available" {
+  project  = var.project_id
+  location = var.region
+
+  depends_on = [google_project_service.required]
+}
+
+locals {
+  project_services = [
+    "compute.googleapis.com",
+    "container.googleapis.com",
+  ]
+
+  selected_gke_version = var.cluster_version != null && var.cluster_version != "" ? var.cluster_version : lookup(
+    data.google_container_engine_versions.available.release_channel_default_version,
+    var.release_channel,
+    data.google_container_engine_versions.available.default_cluster_version
+  )
+
+  rdma_network_profile = coalesce(
+    var.rdma_network_profile,
+    "projects/${var.project_id}/global/networkProfiles/${var.zone}-vpc-roce"
+  )
+
+  rdma_subnet_names = [
+    for index in range(var.rdma_interface_count) : "${var.rdma_subnetwork_name_prefix}-${index}"
+  ]
+
+  rdma_subnet_cidrs = [
+    for index in range(var.rdma_interface_count) : "${var.rdma_subnetwork_cidr_prefix}.${index}.0/24"
+  ]
+
+  additional_node_networks = concat(
+    [
+      {
+        network    = google_compute_network.gvnic.name
+        subnetwork = google_compute_subnetwork.gvnic.name
+      }
+    ],
+    [
+      for subnet in google_compute_subnetwork.rdma : {
+        network    = google_compute_network.rdma.name
+        subnetwork = subnet.name
+      }
+    ]
+  )
+
+  module_resource_labels = {
+    tf_sub_module = "gcp-gke-b200-rdma"
+  }
+
+  resource_labels = merge(local.module_resource_labels, var.resource_labels)
+
+  default_cpu_labels = {
+    workload = "${var.workload_name}-head"
+  }
+
+  cpu_labels = merge(local.default_cpu_labels, var.cpu_labels)
+
+  default_worker_labels = {
+    (var.workload_label_key)             = var.workload_name
+    "accelerator"                        = "b200"
+    "rdma"                               = "true"
+    "nvidia.com/gpu.present"             = "true"
+    "nvidia.com/gpu.product"             = "NVIDIA-B200"
+    "nvidia.com/gpu.count"               = tostring(var.gpu_count)
+    "node.anyscale.com/accelerator-type" = "GPU"
+    "node.anyscale.com/gpu-accelerator"  = "B200"
+    "node.anyscale.com/gpudirect-rdma"   = "true"
+  }
+
+  worker_labels = merge(local.default_worker_labels, var.worker_labels)
+}
+
+resource "google_project_service" "required" {
+  for_each = var.enable_project_services ? toset(local.project_services) : []
+
+  project = var.project_id
+  service = each.value
+
+  disable_on_destroy = var.disable_services_on_destroy
+}
+
+resource "google_compute_network" "gvnic" {
+  project = var.project_id
+
+  name                    = var.gvnic_network_name
+  auto_create_subnetworks = false
+  mtu                     = var.network_mtu
+
+  depends_on = [google_project_service.required]
+}
+
+resource "google_compute_subnetwork" "gvnic" {
+  project = var.project_id
+
+  name          = var.gvnic_subnetwork_name
+  region        = var.region
+  network       = google_compute_network.gvnic.id
+  ip_cidr_range = var.gvnic_subnetwork_cidr
+}
+
+resource "google_compute_firewall" "gvnic_internal" {
+  project = var.project_id
+
+  name    = "${var.gvnic_network_name}-allow-internal"
+  network = google_compute_network.gvnic.name
+
+  direction     = "INGRESS"
+  source_ranges = [var.gvnic_subnetwork_cidr]
+
+  allow {
+    protocol = "tcp"
+  }
+
+  allow {
+    protocol = "udp"
+  }
+
+  allow {
+    protocol = "icmp"
+  }
+}
+
+resource "google_compute_network" "rdma" {
+  project = var.project_id
+
+  name                    = var.rdma_network_name
+  auto_create_subnetworks = false
+  mtu                     = var.network_mtu
+  network_profile         = local.rdma_network_profile
+
+  depends_on = [google_project_service.required]
+}
+
+resource "google_compute_subnetwork" "rdma" {
+  for_each = {
+    for index, name in local.rdma_subnet_names : name => local.rdma_subnet_cidrs[index]
+  }
+
+  project = var.project_id
+
+  name          = each.key
+  region        = var.region
+  network       = google_compute_network.rdma.id
+  ip_cidr_range = each.value
+}
+
+resource "google_compute_firewall" "rdma_internal" {
+  project = var.project_id
+
+  name    = "${var.rdma_network_name}-allow-internal"
+  network = google_compute_network.rdma.name
+
+  direction     = "INGRESS"
+  source_ranges = ["${var.rdma_subnetwork_cidr_prefix}.0.0/16"]
+
+  allow {
+    protocol = "tcp"
+  }
+
+  allow {
+    protocol = "udp"
+  }
+
+  allow {
+    protocol = "icmp"
+  }
+}
+
+resource "google_container_cluster" "this" {
+  project = var.project_id
+
+  name               = var.cluster_name
+  location           = var.region
+  node_locations     = [var.zone]
+  min_master_version = local.selected_gke_version
+
+  network    = var.host_network
+  subnetwork = var.host_subnetwork
+
+  datapath_provider        = "ADVANCED_DATAPATH"
+  enable_multi_networking  = true
+  networking_mode          = "VPC_NATIVE"
+  initial_node_count       = 1
+  remove_default_node_pool = true
+  deletion_protection      = var.deletion_protection
+  resource_labels          = local.resource_labels
+
+  release_channel {
+    channel = var.release_channel
+  }
+
+  ip_allocation_policy {}
+
+  depends_on = [google_project_service.required]
+}
+
+resource "google_container_node_pool" "cpu_head" {
+  count = var.create_cpu_head_pool ? 1 : 0
+
+  project = var.project_id
+
+  name           = var.cpu_head_pool_name
+  cluster        = google_container_cluster.this.name
+  location       = var.region
+  node_locations = [var.zone]
+  node_count     = var.cpu_node_count
+  version        = local.selected_gke_version
+
+  management {
+    auto_repair  = var.enable_node_auto_repair
+    auto_upgrade = var.enable_node_auto_upgrade
+  }
+
+  node_config {
+    machine_type    = var.cpu_machine_type
+    disk_size_gb    = var.cpu_disk_size_gb
+    disk_type       = var.cpu_disk_type
+    image_type      = var.node_image_type
+    labels          = local.cpu_labels
+    metadata        = var.node_metadata
+    oauth_scopes    = var.node_oauth_scopes
+    resource_labels = local.resource_labels
+    service_account = var.node_service_account_email
+  }
+}
+
+resource "google_container_node_pool" "a4_b200" {
+  project = var.project_id
+
+  name           = var.worker_pool_name
+  cluster        = google_container_cluster.this.name
+  location       = var.region
+  node_locations = [var.zone]
+  node_count     = var.worker_autoscaling.enabled ? null : var.worker_node_count
+  version        = local.selected_gke_version
+
+  dynamic "autoscaling" {
+    for_each = var.worker_autoscaling.enabled ? [var.worker_autoscaling] : []
+
+    content {
+      location_policy      = autoscaling.value.location_policy
+      min_node_count       = autoscaling.value.total_min_node_count == null ? autoscaling.value.min_node_count : null
+      max_node_count       = autoscaling.value.total_max_node_count == null ? autoscaling.value.max_node_count : null
+      total_min_node_count = autoscaling.value.min_node_count == null ? autoscaling.value.total_min_node_count : null
+      total_max_node_count = autoscaling.value.max_node_count == null ? autoscaling.value.total_max_node_count : null
+    }
+  }
+
+  management {
+    auto_repair  = var.enable_node_auto_repair
+    auto_upgrade = var.enable_node_auto_upgrade
+  }
+
+  node_config {
+    machine_type    = var.worker_machine_type
+    disk_size_gb    = var.worker_disk_size_gb
+    disk_type       = var.worker_disk_type
+    image_type      = var.node_image_type
+    labels          = local.worker_labels
+    metadata        = var.node_metadata
+    oauth_scopes    = var.node_oauth_scopes
+    resource_labels = local.resource_labels
+    service_account = var.node_service_account_email
+    spot            = var.worker_spot
+
+    dynamic "reservation_affinity" {
+      for_each = var.worker_reservation_affinity == null ? [] : [var.worker_reservation_affinity]
+
+      content {
+        consume_reservation_type = reservation_affinity.value.type
+        key                      = reservation_affinity.value.key
+        values                   = reservation_affinity.value.values
+      }
+    }
+
+    guest_accelerator {
+      type  = var.gpu_type
+      count = var.gpu_count
+
+      gpu_driver_installation_config {
+        gpu_driver_version = var.gpu_driver_version
+      }
+    }
+
+    dynamic "taint" {
+      for_each = var.worker_taints
+
+      content {
+        key    = taint.value.key
+        value  = taint.value.value
+        effect = taint.value.effect
+      }
+    }
+  }
+
+  network_config {
+    dynamic "additional_node_network_configs" {
+      for_each = local.additional_node_networks
+
+      content {
+        network    = additional_node_network_configs.value.network
+        subnetwork = additional_node_network_configs.value.subnetwork
+      }
+    }
+  }
+
+  depends_on = [
+    google_compute_subnetwork.gvnic,
+    google_compute_subnetwork.rdma,
+  ]
+}

--- a/modules/gcp-gke-b200-rdma/outputs.tf
+++ b/modules/gcp-gke-b200-rdma/outputs.tf
@@ -1,0 +1,75 @@
+output "cluster_name" {
+  description = "Name of the GKE cluster."
+  value       = google_container_cluster.this.name
+}
+
+output "cluster_id" {
+  description = "ID of the GKE cluster."
+  value       = google_container_cluster.this.id
+}
+
+output "cluster_location" {
+  description = "Regional location of the GKE control plane."
+  value       = google_container_cluster.this.location
+}
+
+output "cluster_endpoint" {
+  description = "Endpoint of the GKE cluster."
+  value       = google_container_cluster.this.endpoint
+  sensitive   = true
+}
+
+output "selected_gke_version" {
+  description = "GKE version selected for the cluster and node pools."
+  value       = local.selected_gke_version
+}
+
+output "cpu_head_pool_name" {
+  description = "Name of the CPU head node pool."
+  value       = var.create_cpu_head_pool ? google_container_node_pool.cpu_head[0].name : null
+}
+
+output "worker_pool_name" {
+  description = "Name of the A4/B200 worker node pool."
+  value       = google_container_node_pool.a4_b200.name
+}
+
+output "worker_pool_instance_group_urls" {
+  description = "Managed instance group URLs backing the A4/B200 worker node pool."
+  value       = google_container_node_pool.a4_b200.managed_instance_group_urls
+}
+
+output "gvnic_network_name" {
+  description = "Name of the dedicated gVNIC VPC."
+  value       = google_compute_network.gvnic.name
+}
+
+output "gvnic_subnetwork_name" {
+  description = "Name of the dedicated gVNIC subnetwork."
+  value       = google_compute_subnetwork.gvnic.name
+}
+
+output "rdma_network_name" {
+  description = "Name of the dedicated RDMA VPC."
+  value       = google_compute_network.rdma.name
+}
+
+output "rdma_network_profile" {
+  description = "Network profile used by the dedicated RDMA VPC."
+  value       = local.rdma_network_profile
+}
+
+output "rdma_subnetwork_names" {
+  description = "Names of the RDMA subnetworks attached to the A4/B200 worker pool."
+  value       = [for subnet in google_compute_subnetwork.rdma : subnet.name]
+}
+
+output "additional_node_networks" {
+  description = "Additional node network layout rendered into the A4/B200 node pool."
+  value       = local.additional_node_networks
+}
+
+output "get_credentials_command" {
+  description = "gcloud command for fetching kubeconfig credentials for this cluster."
+  value       = "gcloud container clusters get-credentials ${google_container_cluster.this.name} --location=${google_container_cluster.this.location} --project=${var.project_id}"
+}

--- a/modules/gcp-gke-b200-rdma/variables.tf
+++ b/modules/gcp-gke-b200-rdma/variables.tf
@@ -1,0 +1,530 @@
+# ------------------------------------------------------------------------------
+# REQUIRED PARAMETERS
+# ------------------------------------------------------------------------------
+
+variable "project_id" {
+  description = "(Required) Google Cloud project ID."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{4,28}[a-z0-9]$", var.project_id))
+    error_message = "project_id must look like a Google Cloud project ID: 6-30 lowercase letters, numbers, and hyphens, starting with a letter and ending with a letter or number."
+  }
+}
+
+variable "region" {
+  description = "(Required) Regional GKE control-plane location."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z]+-[a-z]+[0-9]+$", var.region))
+    error_message = "region must look like a Google Cloud region, for example us-central1."
+  }
+}
+
+variable "zone" {
+  description = "(Required) Single A4/B200 worker zone. The zone must have a matching vpc-roce network profile."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z]+-[a-z]+[0-9]+-[a-z]$", var.zone))
+    error_message = "zone must look like a Google Cloud zone, for example us-central1-b."
+  }
+}
+
+variable "cluster_name" {
+  description = "(Required) Name of the GKE cluster to create."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{0,38}[a-z0-9]$", var.cluster_name))
+    error_message = "cluster_name must be a valid GKE-style name: start with a lowercase letter, contain lowercase letters, numbers, and hyphens, and end with a letter or number."
+  }
+}
+
+variable "host_network" {
+  description = "(Required) Existing host/control-plane VPC name or self link for the GKE cluster."
+  type        = string
+
+  validation {
+    condition     = length(var.host_network) > 0
+    error_message = "host_network must not be empty."
+  }
+}
+
+variable "host_subnetwork" {
+  description = "(Required) Existing host/control-plane subnetwork name or self link for the GKE cluster."
+  type        = string
+
+  validation {
+    condition     = length(var.host_subnetwork) > 0
+    error_message = "host_subnetwork must not be empty."
+  }
+}
+
+# ------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+# ------------------------------------------------------------------------------
+
+variable "workload_name" {
+  description = "(Optional) Workload name used in default Kubernetes labels."
+  type        = string
+  default     = "b200-rdma"
+
+  validation {
+    condition     = can(regex("^[a-z0-9]([a-z0-9-]*[a-z0-9])?$", var.workload_name))
+    error_message = "workload_name must be lowercase DNS-style text: letters, numbers, hyphens, no leading/trailing hyphen."
+  }
+}
+
+variable "workload_label_key" {
+  description = "(Optional) Kubernetes label key used to identify the B200/RDMA worker pool."
+  type        = string
+  default     = "workload"
+}
+
+variable "resource_labels" {
+  description = "(Optional) Google Cloud resource labels applied to resources that support labels."
+  type        = map(string)
+  default     = {}
+
+  validation {
+    condition = alltrue([
+      for key, value in var.resource_labels :
+      can(regex("^[a-z]([a-z0-9_-]{0,61}[a-z0-9])?$", key)) &&
+      (value == "" || can(regex("^[a-z0-9]([a-z0-9_-]{0,61}[a-z0-9])?$", value)))
+    ])
+    error_message = "resource_labels must use Google Cloud label syntax: lowercase keys beginning with a letter, and lowercase values containing letters, numbers, underscores, or hyphens."
+  }
+}
+
+variable "enable_project_services" {
+  description = "(Optional) Whether to enable Compute Engine and GKE APIs for the project."
+  type        = bool
+  default     = true
+}
+
+variable "disable_services_on_destroy" {
+  description = "(Optional) Whether Terraform should disable project services on destroy."
+  type        = bool
+  default     = false
+}
+
+variable "release_channel" {
+  description = "(Optional) GKE release channel."
+  type        = string
+  default     = "REGULAR"
+
+  validation {
+    condition     = contains(["RAPID", "REGULAR", "STABLE", "EXTENDED", "UNSPECIFIED"], var.release_channel)
+    error_message = "release_channel must be one of RAPID, REGULAR, STABLE, EXTENDED, or UNSPECIFIED."
+  }
+}
+
+variable "cluster_version" {
+  description = "(Optional) Pinned GKE version. When null, the module uses the selected release channel default for the region."
+  type        = string
+  default     = null
+}
+
+variable "deletion_protection" {
+  description = "(Optional) Whether to enable GKE cluster deletion protection."
+  type        = bool
+  default     = false
+}
+
+variable "network_mtu" {
+  description = "(Optional) MTU for the dedicated gVNIC and RDMA VPCs."
+  type        = number
+  default     = 8896
+
+  validation {
+    condition     = var.network_mtu >= 1460 && var.network_mtu <= 8896
+    error_message = "network_mtu must be between 1460 and 8896."
+  }
+}
+
+variable "gvnic_network_name" {
+  description = "(Optional) Dedicated VPC name for the extra Titanium gVNIC."
+  type        = string
+  default     = "b200-gvnic"
+
+  validation {
+    condition     = can(regex("^[a-z]([-a-z0-9]*[a-z0-9])?$", var.gvnic_network_name))
+    error_message = "gvnic_network_name must be a valid Google Compute network name."
+  }
+}
+
+variable "gvnic_subnetwork_name" {
+  description = "(Optional) Subnetwork name for the extra Titanium gVNIC."
+  type        = string
+  default     = "b200-gvnic-subnet"
+
+  validation {
+    condition     = can(regex("^[a-z]([-a-z0-9]*[a-z0-9])?$", var.gvnic_subnetwork_name))
+    error_message = "gvnic_subnetwork_name must be a valid Google Compute subnetwork name."
+  }
+}
+
+variable "gvnic_subnetwork_cidr" {
+  description = "(Optional) CIDR for the extra gVNIC subnetwork."
+  type        = string
+  default     = "10.1.0.0/16"
+
+  validation {
+    condition     = can(cidrnetmask(var.gvnic_subnetwork_cidr))
+    error_message = "gvnic_subnetwork_cidr must be a valid IPv4 CIDR range."
+  }
+}
+
+variable "rdma_network_name" {
+  description = "(Optional) Dedicated RoCE RDMA VPC name."
+  type        = string
+  default     = "b200-rdma"
+
+  validation {
+    condition     = can(regex("^[a-z]([-a-z0-9]*[a-z0-9])?$", var.rdma_network_name))
+    error_message = "rdma_network_name must be a valid Google Compute network name."
+  }
+}
+
+variable "rdma_network_profile" {
+  description = "(Optional) Full or partial Google network profile URL for the RDMA VPC. Defaults to projects/PROJECT/global/networkProfiles/ZONE-vpc-roce."
+  type        = string
+  default     = null
+}
+
+variable "rdma_subnetwork_name_prefix" {
+  description = "(Optional) Prefix for RDMA subnet names. The module creates PREFIX-0 through PREFIX-N."
+  type        = string
+  default     = "b200-rdma-subnet"
+
+  validation {
+    condition     = can(regex("^[a-z]([-a-z0-9]*[a-z0-9])?$", var.rdma_subnetwork_name_prefix))
+    error_message = "rdma_subnetwork_name_prefix must be a valid Google Compute subnetwork name prefix."
+  }
+}
+
+variable "rdma_subnetwork_cidr_prefix" {
+  description = "(Optional) First two octets for RDMA subnets. Subnets become PREFIX.0.0/24 through PREFIX.N.0/24."
+  type        = string
+  default     = "172.31"
+
+  validation {
+    condition     = can(cidrnetmask("${var.rdma_subnetwork_cidr_prefix}.0.0/16"))
+    error_message = "rdma_subnetwork_cidr_prefix must be two IPv4 octets, for example 172.31."
+  }
+}
+
+variable "rdma_interface_count" {
+  description = "(Optional) Number of RDMA additional node networks to attach to each A4/B200 worker."
+  type        = number
+  default     = 8
+
+  validation {
+    condition     = var.rdma_interface_count >= 1 && var.rdma_interface_count <= 8
+    error_message = "rdma_interface_count must be between 1 and 8 for GKE A4/B200 workers."
+  }
+}
+
+variable "create_cpu_head_pool" {
+  description = "(Optional) Whether to create a CPU node pool for the Ray head or other control-plane workloads."
+  type        = bool
+  default     = true
+}
+
+variable "cpu_head_pool_name" {
+  description = "(Optional) CPU head node pool name."
+  type        = string
+  default     = "cpu-head"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{0,38}[a-z0-9]$", var.cpu_head_pool_name))
+    error_message = "cpu_head_pool_name must be a valid GKE node pool name."
+  }
+}
+
+variable "cpu_node_count" {
+  description = "(Optional) CPU head node count."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.cpu_node_count >= 1
+    error_message = "cpu_node_count must be at least 1. Set create_cpu_head_pool to false to skip the CPU head pool."
+  }
+}
+
+variable "cpu_machine_type" {
+  description = "(Optional) Machine type for CPU head nodes."
+  type        = string
+  default     = "e2-standard-16"
+}
+
+variable "cpu_disk_size_gb" {
+  description = "(Optional) Boot disk size in GB for CPU head nodes."
+  type        = number
+  default     = 500
+
+  validation {
+    condition     = var.cpu_disk_size_gb >= 100
+    error_message = "cpu_disk_size_gb must be at least 100."
+  }
+}
+
+variable "cpu_disk_type" {
+  description = "(Optional) Boot disk type for CPU head nodes."
+  type        = string
+  default     = "pd-balanced"
+}
+
+variable "cpu_labels" {
+  description = "(Optional) Additional or overriding Kubernetes labels for the CPU head node pool."
+  type        = map(string)
+  default     = {}
+}
+
+variable "worker_pool_name" {
+  description = "(Optional) A4/B200 worker node pool name."
+  type        = string
+  default     = "a4-spot"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{0,38}[a-z0-9]$", var.worker_pool_name))
+    error_message = "worker_pool_name must be a valid GKE node pool name."
+  }
+}
+
+variable "worker_node_count" {
+  description = "(Optional) Fixed A4/B200 worker node count when worker_autoscaling.enabled is false. Each node has 8 B200 GPUs."
+  type        = number
+  default     = 2
+
+  validation {
+    condition     = var.worker_node_count >= 1
+    error_message = "worker_node_count must be at least 1."
+  }
+}
+
+variable "worker_autoscaling" {
+  description = <<-EOT
+    (Optional) Autoscaling configuration for the A4/B200 worker node pool.
+
+    Leave enabled=false for a fixed-size pool controlled by worker_node_count.
+    When enabled=true, set either min_node_count/max_node_count or
+    total_min_node_count/total_max_node_count. Do not mix per-zone and total
+    limits.
+  EOT
+  type = object({
+    enabled              = bool
+    min_node_count       = optional(number)
+    max_node_count       = optional(number)
+    total_min_node_count = optional(number)
+    total_max_node_count = optional(number)
+    location_policy      = optional(string)
+  })
+  default = {
+    enabled = false
+  }
+
+  validation {
+    condition = !var.worker_autoscaling.enabled || (
+      (
+        var.worker_autoscaling.min_node_count != null &&
+        var.worker_autoscaling.max_node_count != null &&
+        var.worker_autoscaling.total_min_node_count == null &&
+        var.worker_autoscaling.total_max_node_count == null &&
+        var.worker_autoscaling.min_node_count >= 0 &&
+        var.worker_autoscaling.max_node_count >= var.worker_autoscaling.min_node_count
+      ) ||
+      (
+        var.worker_autoscaling.total_min_node_count != null &&
+        var.worker_autoscaling.total_max_node_count != null &&
+        var.worker_autoscaling.min_node_count == null &&
+        var.worker_autoscaling.max_node_count == null &&
+        var.worker_autoscaling.total_min_node_count >= 0 &&
+        var.worker_autoscaling.total_max_node_count >= var.worker_autoscaling.total_min_node_count
+      )
+    )
+    error_message = "When worker_autoscaling.enabled is true, set either valid per-zone min/max values or valid total min/max values, but not both."
+  }
+
+  validation {
+    condition = (
+      var.worker_autoscaling.location_policy == null ||
+      contains(["BALANCED", "ANY"], var.worker_autoscaling.location_policy)
+    )
+    error_message = "worker_autoscaling.location_policy must be BALANCED or ANY when set."
+  }
+}
+
+variable "worker_machine_type" {
+  description = "(Optional) A4/B200 worker machine type."
+  type        = string
+  default     = "a4-highgpu-8g"
+}
+
+variable "worker_spot" {
+  description = "(Optional) Whether to create worker nodes as Spot VMs."
+  type        = bool
+  default     = true
+}
+
+variable "worker_disk_size_gb" {
+  description = "(Optional) Boot disk size in GB for A4/B200 workers."
+  type        = number
+  default     = 500
+
+  validation {
+    condition     = var.worker_disk_size_gb >= 100
+    error_message = "worker_disk_size_gb must be at least 100."
+  }
+}
+
+variable "worker_disk_type" {
+  description = "(Optional) Boot disk type for A4/B200 workers."
+  type        = string
+  default     = "hyperdisk-balanced"
+}
+
+variable "worker_labels" {
+  description = "(Optional) Additional or overriding Kubernetes labels for the A4/B200 worker node pool."
+  type        = map(string)
+  default     = {}
+}
+
+variable "worker_reservation_affinity" {
+  description = <<-EOT
+    (Optional) Reservation affinity for A4/B200 workers. Use this when the
+    worker pool should consume a specific Compute Engine GPU reservation.
+
+    Example:
+      {
+        type   = "SPECIFIC_RESERVATION"
+        key    = "compute.googleapis.com/reservation-name"
+        values = ["my-b200-reservation"]
+      }
+
+    Set type to ANY_RESERVATION or NO_RESERVATION to use those GKE modes.
+  EOT
+  type = object({
+    type   = string
+    key    = optional(string)
+    values = optional(set(string))
+  })
+  default = null
+
+  validation {
+    condition = (
+      var.worker_reservation_affinity == null ||
+      contains(["ANY_RESERVATION", "NO_RESERVATION", "SPECIFIC_RESERVATION"], var.worker_reservation_affinity.type)
+    )
+    error_message = "worker_reservation_affinity.type must be ANY_RESERVATION, NO_RESERVATION, or SPECIFIC_RESERVATION."
+  }
+
+  validation {
+    condition = (
+      var.worker_reservation_affinity == null ||
+      var.worker_reservation_affinity.type != "SPECIFIC_RESERVATION" ||
+      (
+        var.worker_reservation_affinity.key != null &&
+        var.worker_reservation_affinity.values != null &&
+        length(var.worker_reservation_affinity.values) > 0
+      )
+    )
+    error_message = "SPECIFIC_RESERVATION requires worker_reservation_affinity.key and at least one value."
+  }
+}
+
+variable "worker_taints" {
+  description = <<-EOT
+    (Optional) Kubernetes taints for the A4/B200 worker node pool.
+
+    Effects must use GKE API values: NO_SCHEDULE, NO_EXECUTE, or PREFER_NO_SCHEDULE.
+  EOT
+  type = list(object({
+    key    = string
+    value  = string
+    effect = string
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for taint in var.worker_taints :
+      contains(["NO_SCHEDULE", "NO_EXECUTE", "PREFER_NO_SCHEDULE"], taint.effect)
+    ])
+    error_message = "worker_taints effects must be one of NO_SCHEDULE, NO_EXECUTE, or PREFER_NO_SCHEDULE."
+  }
+}
+
+variable "gpu_type" {
+  description = "(Optional) GKE accelerator type for A4/B200 workers."
+  type        = string
+  default     = "nvidia-b200"
+}
+
+variable "gpu_count" {
+  description = "(Optional) GPU count per A4/B200 worker."
+  type        = number
+  default     = 8
+
+  validation {
+    condition     = var.gpu_count >= 1 && var.gpu_count <= 8
+    error_message = "gpu_count must be between 1 and 8."
+  }
+}
+
+variable "gpu_driver_version" {
+  description = "(Optional) GKE GPU driver version mode."
+  type        = string
+  default     = "LATEST"
+
+  validation {
+    condition     = contains(["DEFAULT", "LATEST", "INSTALLATION_DISABLED"], var.gpu_driver_version)
+    error_message = "gpu_driver_version must be DEFAULT, LATEST, or INSTALLATION_DISABLED."
+  }
+}
+
+variable "node_image_type" {
+  description = "(Optional) GKE node image type."
+  type        = string
+  default     = "COS_CONTAINERD"
+
+  validation {
+    condition     = contains(["COS_CONTAINERD", "UBUNTU_CONTAINERD"], var.node_image_type)
+    error_message = "node_image_type must be COS_CONTAINERD or UBUNTU_CONTAINERD."
+  }
+}
+
+variable "node_service_account_email" {
+  description = "(Optional) Google service account email to use for node VMs."
+  type        = string
+  default     = null
+}
+
+variable "node_oauth_scopes" {
+  description = "(Optional) OAuth scopes for node VMs."
+  type        = set(string)
+  default     = ["https://www.googleapis.com/auth/cloud-platform"]
+}
+
+variable "node_metadata" {
+  description = "(Optional) Metadata applied to GKE node VMs."
+  type        = map(string)
+  default = {
+    disable-legacy-endpoints = "true"
+  }
+}
+
+variable "enable_node_auto_repair" {
+  description = "(Optional) Whether GKE should auto-repair nodes."
+  type        = bool
+  default     = false
+}
+
+variable "enable_node_auto_upgrade" {
+  description = "(Optional) Whether GKE should auto-upgrade nodes."
+  type        = bool
+  default     = false
+}

--- a/modules/gcp-gke-b200-rdma/versions.tf
+++ b/modules/gcp-gke-b200-rdma/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0, < 7.0"
+    }
+  }
+}


### PR DESCRIPTION
Summary:
- Add `modules/gcp-gke-b200-rdma` for GKE A4/B200 GPUDirect RDMA infrastructure.
- Add `examples/gcp/gke-b200-rdma` with generic placeholder values and optional reservation/autoscaling snippets.
- Document the Terraform/Kubernetes boundary and keep runtime image/add-on installation as follow-on validation work.

Testing:
- `terraform fmt -recursive modules/gcp-gke-b200-rdma examples/gcp/gke-b200-rdma`
- `terraform init -backend=false && terraform validate` in `modules/gcp-gke-b200-rdma`
- `terraform init -backend=false && terraform validate` in `examples/gcp/gke-b200-rdma`
- Scanned for stale local names, account IDs, workspace IDs, credentials, and private paths.