### PR TITLE
adapt version

### DIFF
--- a/examples/aws/eks-public/versions.tf
+++ b/examples/aws/eks-public/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 6.37.0, < 7.0"
     }
   }
 }


### PR DESCRIPTION
## Pull request checklist

The example pins the AWS provider to ~> 5.0 (5.x only), but the Anyscale modules it pulls from main now require >= 6.37.0 — those ranges don't overlap, so no provider version satisfies both. Fix: edit versions.tf to version = ">= 6.37.0, < 7.0", bump required_version to >= 1.9, then run terraform init -upgrade.

Please check if your PR fulfills the following requirements:
- [ ] pre-commit has been run
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] All tests passing
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull Request Type

- [ ] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation change
- [ ] Other (please describe):

## Does this introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots. -->
