### PR TITLE
Add optional shared PVC (blobfuse2 RWX) to Azure new-AKS example

### DIFF
--- a/examples/azure/anyscale-on-azure-new-aks/README.md
+++ b/examples/azure/anyscale-on-azure-new-aks/README.md
@@ -39,7 +39,32 @@ That hostname is baked directly into the operator extension's `networking.gatewa
 | `enable_node_auto_provisioning` | `false` | NAP / managed Karpenter via azapi patch + GPU NodePool (**preview**; needs `NodeAutoProvisioningPreview`) |
 | `internal_gateway` | `false` | Internal Standard LB — VNet-only data plane; falls back to LB polling |
 | `enable_nfs` | `false` | Premium NFS FileStorage account locked to the node subnet |
+| `enable_shared_pvc` | `false` | Shared file storage for Ray pods: blobfuse2 StorageClass + RWX PVC (requires `enable_blob_driver`) |
 | `enable_acr` | `true` | Customer-owned ACR + pull/push/tasks role assignments |
+
+### Shared file storage (`enable_shared_pvc`)
+
+On AWS and GCP, Anyscale gets shared POSIX storage from EFS/Filestore, mounted by ID.
+Azure has no mount-by-ID equivalent — the supported path is a `ReadWriteMany`
+PersistentVolumeClaim backed by the Azure Blob CSI driver (blobfuse2).
+
+Setting `enable_shared_pvc = true` (alongside `enable_blob_driver = true`) provisions,
+in `shared_pvc.tf`:
+
+- a dedicated blob container on the deployment's storage account,
+- a `blobfuse-csi` StorageClass authenticating via Entra workload identity
+  (`mountWithWorkloadIdentityToken`) — no account keys reach pods,
+- an RWX PVC named `anyscale-shared-fuse` in the operator namespace,
+- `Storage Blob Data Contributor` + `Storage Account Key Operator Service Role` for the
+  CSI driver's principals (the cluster and kubelet identities), which are distinct from
+  the operator identity already granted in `identity.tf`.
+
+**One manual step remains.** Terraform creates the volume but does not register it with
+the Anyscale cloud, because that is only settable through a complete cloud resource YAML
+(`anyscale cloud update --resources-file`) and a partial file risks clearing other
+fields. After apply, `terraform output shared_pvc_registration_instructions` prints the
+`file_storage.persistent_volume_claim` snippet and the command. Per-workload mounts via
+`advanced_instance_config` need no registration at all.
 
 ## Prerequisites
 

--- a/examples/azure/anyscale-on-azure-new-aks/outputs.tf
+++ b/examples/azure/anyscale-on-azure-new-aks/outputs.tf
@@ -21,6 +21,37 @@ output "azure_nfs_storage_account_name" {
   description = "Name of the optional Azure NFS Storage Account."
 }
 
+output "shared_pvc_name" {
+  value       = var.enable_shared_pvc ? kubernetes_persistent_volume_claim_v1.shared_pvc[0].metadata[0].name : null
+  description = "Name of the shared ReadWriteMany PVC for Ray pods. Null when enable_shared_pvc=false."
+}
+
+locals {
+  shared_pvc_registration_instructions = <<-EOT
+    The PVC "${var.shared_pvc_name}" exists in namespace "${var.anyscale_operator_namespace}",
+    but Anyscale does not yet attach it to workloads. There is no `anyscale cloud update` flag
+    for this — it is set through the cloud resource YAML. Add to your resources file:
+
+        file_storage:
+          persistent_volume_claim: ${var.shared_pvc_name}
+
+    then apply it:
+
+        anyscale cloud update --name ${local.anyscale_cloud_name} --resources-file <file>.yaml
+
+    The resources file must be a COMPLETE cloud resource spec — passing a fragment containing
+    only file_storage may clear other fields. Schema: https://docs.anyscale.com/reference/cloud#cloudresource
+
+    Alternatively, skip cloud-wide registration and mount the PVC per workload via
+    advanced_instance_config in a compute config.
+  EOT
+}
+
+output "shared_pvc_registration_instructions" {
+  value       = var.enable_shared_pvc ? local.shared_pvc_registration_instructions : null
+  description = "How to register the shared PVC with the Anyscale cloud after apply. Null when enable_shared_pvc=false."
+}
+
 output "azure_aks_cluster_name" {
   value       = azurerm_kubernetes_cluster.aks.name
   description = "Name of the AKS cluster."

--- a/examples/azure/anyscale-on-azure-new-aks/shared_pvc.tf
+++ b/examples/azure/anyscale-on-azure-new-aks/shared_pvc.tf
@@ -1,0 +1,221 @@
+###############################################################################
+# SHARED FILE STORAGE FOR RAY PODS (blobfuse2 CSI + ReadWriteMany PVC)
+#
+# Anyscale on AWS/GCP gets shared POSIX storage from EFS/Filestore, mounted by
+# ID. Azure has no equivalent "mount by ID" path — the supported mechanism is a
+# ReadWriteMany PersistentVolumeClaim backed by the Azure Blob CSI driver
+# (blobfuse2), which the Anyscale cloud then attaches to every workload.
+#
+# This file provisions the Kubernetes half of that setup plus the extra Azure
+# role assignments the CSI driver needs. Registering the PVC with the Anyscale
+# cloud is a separate step — see the note at the bottom of this file.
+#
+# Mount authentication uses Microsoft Entra workload identity
+# (`mountWithWorkloadIdentityToken`), reusing the operator's user-assigned
+# identity from identity.tf. No storage account keys are handed to pods.
+###############################################################################
+
+locals {
+  shared_pvc_container_name = coalesce(
+    var.shared_pvc_container_name,
+    "${var.aks_cluster_name}-shared",
+  )
+
+  # The blob CSI driver components do not all run under the same identity: the
+  # controller (provisioning, container access) uses the cluster's
+  # system-assigned identity, while the node plugin runs under the kubelet
+  # identity. AKS creates these as two distinct principals, so grant both
+  # rather than guessing which one services a given mount.
+  shared_pvc_csi_principal_ids = var.enable_shared_pvc ? toset([
+    azurerm_kubernetes_cluster.aks.identity[0].principal_id,
+    azurerm_kubernetes_cluster.aks.kubelet_identity[0].object_id,
+  ]) : toset([])
+}
+
+###############################################################################
+# Dedicated container backing the shared volume.
+#
+# Deliberately separate from the artifact/log container in main.tf: that one is
+# the Anyscale cloud's object store and is written through the control plane,
+# whereas this one is a POSIX-ish filesystem written directly by user code.
+# Naming it here (rather than letting the CSI driver dynamically provision one)
+# keeps the container's lifecycle in Terraform and gives it a stable name.
+###############################################################################
+resource "azurerm_storage_container" "shared_pvc" {
+  count = var.enable_shared_pvc ? 1 : 0
+
+  #checkov:skip=CKV2_AZURE_21: "Ensure Storage logging is enabled for Blob service for read requests"
+
+  name                  = local.shared_pvc_container_name
+  storage_account_id    = azurerm_storage_account.sa.id
+  container_access_type = "private"
+}
+
+###############################################################################
+# ROLE ASSIGNMENTS FOR THE CSI DRIVER
+#
+# identity.tf already grants "Storage Blob Data Contributor" to the *operator*
+# identity, which is what workload-identity mounts authenticate as. The CSI
+# driver itself is a separate principal and needs its own grants:
+#
+#   - Storage Blob Data Contributor      — read/write and container access
+#   - Storage Account Key Operator Service Role — read account keys, which the
+#     driver still requires for some mount and provisioning paths even when
+#     pods authenticate via workload identity
+###############################################################################
+resource "azurerm_role_assignment" "shared_pvc_csi_blob_contrib" {
+  for_each = local.shared_pvc_csi_principal_ids
+
+  scope                            = azurerm_storage_account.sa.id
+  role_definition_name             = "Storage Blob Data Contributor"
+  principal_id                     = each.value
+  skip_service_principal_aad_check = true
+}
+
+resource "azurerm_role_assignment" "shared_pvc_csi_key_operator" {
+  for_each = local.shared_pvc_csi_principal_ids
+
+  scope                            = azurerm_storage_account.sa.id
+  role_definition_name             = "Storage Account Key Operator Service Role"
+  principal_id                     = each.value
+  skip_service_principal_aad_check = true
+}
+
+###############################################################################
+# StorageClass
+#
+# `protocol: fuse2` selects blobfuse2. `mountWithWorkloadIdentityToken` makes
+# the mount exchange the pod's service-account token for an Entra token
+# instead of using an account key — this is why the federated identity
+# credential in identity.tf must be bound to the operator service account.
+#
+# reclaimPolicy Retain: the backing container is Terraform-managed, so a
+# deleted PVC must not take the data with it.
+###############################################################################
+resource "kubernetes_storage_class_v1" "shared_pvc" {
+  count = var.enable_shared_pvc ? 1 : 0
+
+  metadata {
+    name = var.shared_pvc_storage_class_name
+  }
+
+  storage_provisioner    = "blob.csi.azure.com"
+  reclaim_policy         = "Retain"
+  volume_binding_mode    = "Immediate"
+  allow_volume_expansion = true
+
+  parameters = {
+    protocol                       = "fuse2"
+    storageAccount                 = azurerm_storage_account.sa.name
+    resourceGroup                  = azurerm_resource_group.rg.name
+    containerName                  = azurerm_storage_container.shared_pvc[0].name
+    mountWithWorkloadIdentityToken = "true"
+
+    # REQUIRED, despite being absent from the Anyscale Azure PVC doc's example
+    # StorageClass. The CSI *node plugin* performs the mount, and it cannot see
+    # the pod service account's `azure.workload.identity/client-id` annotation
+    # (that annotation only drives the pod's own SDK calls). Without clientID
+    # the driver falls back to the kubelet identity and the mount fails with:
+    #
+    #   AADSTS70025: The client '<cluster>-agentpool' has no configured
+    #   federated identity credentials
+    #
+    # Verified against a live AKS cluster 2026-07-21.
+    clientID = azurerm_user_assigned_identity.anyscale_operator.client_id
+  }
+
+  # allow_other lets the ray container's non-root user read the mount.
+  #
+  # The block cache is what makes large sequential reads (datasets,
+  # checkpoints) perform acceptably over blob, but a bare `--block-cache`
+  # (as in the Anyscale doc) fails to mount:
+  #   "config error in block_cache [memory limit too low for configured prefetch]"
+  # because the defaults size the prefetch pool against node memory. The three
+  # explicit values below are a verified-working combination. Note that
+  # prefetch has a floor — values below ~11 fail with "invalid prefetch count".
+  mount_options = [
+    "-o allow_other",
+    "--block-cache",
+    "--block-cache-block-size=${var.shared_pvc_block_cache.block_size_mb}",
+    "--block-cache-pool-size=${var.shared_pvc_block_cache.pool_size_mb}",
+    "--block-cache-prefetch=${var.shared_pvc_block_cache.prefetch_blocks}",
+  ]
+
+  lifecycle {
+    precondition {
+      condition     = var.enable_blob_driver
+      error_message = "enable_shared_pvc requires enable_blob_driver = true so the AKS cluster runs the Azure Blob CSI driver."
+    }
+  }
+
+  depends_on = [
+    azurerm_role_assignment.shared_pvc_csi_blob_contrib,
+    azurerm_role_assignment.shared_pvc_csi_key_operator,
+  ]
+}
+
+###############################################################################
+# PersistentVolumeClaim
+#
+# Must live in the operator's namespace (that is where Ray pods are scheduled)
+# and must be ReadWriteMany so head and workers can hold it simultaneously.
+#
+# OPERATIONAL NOTE: the CSI driver mounts with `--cancel-list-on-mount-seconds=10`,
+# so for the first 10 seconds after a pod mounts this volume, directory listings
+# (`ls`, `find`, glob) return EMPTY while reads by explicit path work normally.
+# This is intentional upstream behaviour, not a misconfiguration — but workload
+# code that enumerates the mount at startup can see a spuriously empty directory.
+#
+# The namespace is created by the operator extension, hence the depends_on.
+# `storage` is a required field on a PVC but is not a hard quota here — blob
+# containers grow on demand — so it functions as a declared ceiling only.
+###############################################################################
+resource "kubernetes_persistent_volume_claim_v1" "shared_pvc" {
+  count = var.enable_shared_pvc ? 1 : 0
+
+  metadata {
+    name      = var.shared_pvc_name
+    namespace = var.anyscale_operator_namespace
+  }
+
+  spec {
+    access_modes       = ["ReadWriteMany"]
+    storage_class_name = kubernetes_storage_class_v1.shared_pvc[0].metadata[0].name
+
+    resources {
+      requests = {
+        storage = "${var.shared_pvc_size_gi}Gi"
+      }
+    }
+  }
+
+  # Immediate binding means the CSI driver provisions on create; block until it
+  # succeeds so a misconfigured mount surfaces during apply rather than as a
+  # pending pod later.
+  wait_until_bound = true
+
+  depends_on = [
+    azurerm_kubernetes_cluster_extension.anyscale_operator,
+  ]
+}
+
+###############################################################################
+# REGISTERING THE PVC WITH THE ANYSCALE CLOUD
+#
+# The resources above give the cluster a mountable RWX volume. For Anyscale to
+# attach it to every workload automatically, the cloud must also record:
+#
+#   file_storage:
+#     persistent_volume_claim: <var.shared_pvc_name>
+#
+# That property is NOT set here. The documented path is `anyscale cloud update
+# --resources-file`, which takes a complete cloud resource spec — there is no
+# single-field flag for it — and the equivalent property name on the
+# Anyscale.Platform/clouds/cloudResources ARM surface (anyscale.tf) is not
+# documented. Wiring either one blind risks clobbering the cloud's storage
+# config, so this last step is left manual; see the
+# `shared_pvc_registration_instructions` output.
+#
+# Per-workload mounts do not need this at all — a compute config can reference
+# the PVC directly via advanced_instance_config.
+###############################################################################

--- a/examples/azure/anyscale-on-azure-new-aks/terraform.tfvars.example
+++ b/examples/azure/anyscale-on-azure-new-aks/terraform.tfvars.example
@@ -32,6 +32,8 @@ cpu_vm_size    = "Standard_D8s_v5"   # CPU worker pools; scale to zero when idle
 # enable_node_auto_provisioning = false       # NAP / managed Karpenter (PREVIEW)
 # internal_gateway              = false       # true = VNet-only data plane (re-enables LB polling)
 # enable_nfs                    = false       # Premium NFS share, subnet-restricted
+# enable_blob_driver            = false       # Azure Blob CSI driver on the cluster
+# enable_shared_pvc             = false       # shared RWX PVC for Ray pods (needs enable_blob_driver)
 
 # ── registry ────────────────────────────────────────────────────────────────
 enable_acr = true

--- a/examples/azure/anyscale-on-azure-new-aks/variables.tf
+++ b/examples/azure/anyscale-on-azure-new-aks/variables.tf
@@ -278,6 +278,82 @@ variable "enable_blob_driver" {
   default     = false
 }
 
+variable "enable_shared_pvc" {
+  description = <<-EOT
+    (Optional) Provision shared file storage for Ray pods: a blobfuse2 StorageClass and a
+    ReadWriteMany PersistentVolumeClaim in the operator namespace, backed by a dedicated
+    container on the deployment's storage account. This is the Azure equivalent of EFS on
+    AWS / Filestore on GCP. Requires enable_blob_driver = true. See shared_pvc.tf.
+  EOT
+  type        = bool
+  nullable    = false
+  default     = false
+}
+
+variable "shared_pvc_name" {
+  description = "(Optional) Name of the shared PersistentVolumeClaim. This is the value passed to the Anyscale cloud as file_storage.persistent_volume_claim. Only used when enable_shared_pvc is true."
+  type        = string
+  nullable    = false
+  default     = "anyscale-shared-fuse"
+}
+
+variable "shared_pvc_storage_class_name" {
+  description = "(Optional) Name of the blobfuse2 StorageClass backing the shared PVC. Only used when enable_shared_pvc is true."
+  type        = string
+  nullable    = false
+  default     = "blobfuse-csi"
+}
+
+variable "shared_pvc_size_gi" {
+  description = "(Optional) Declared size of the shared PVC, in GiB. Blob containers grow on demand, so this acts as a ceiling rather than a preallocation. Only used when enable_shared_pvc is true."
+  type        = number
+  nullable    = false
+  default     = 100
+
+  validation {
+    condition     = var.shared_pvc_size_gi > 0
+    error_message = "shared_pvc_size_gi must be greater than 0."
+  }
+}
+
+variable "shared_pvc_block_cache" {
+  description = <<-EOT
+    (Optional) blobfuse2 block-cache sizing for the shared PVC mount. The defaults are a
+    verified-working combination; a bare `--block-cache` with library defaults fails to
+    mount with "memory limit too low for configured prefetch".
+    Note prefetch_blocks has a floor of ~11 — below that the mount fails with
+    "invalid prefetch count". Only used when enable_shared_pvc is true.
+  EOT
+  type = object({
+    block_size_mb   = number
+    pool_size_mb    = number
+    prefetch_blocks = number
+  })
+  nullable = false
+  default = {
+    block_size_mb   = 16
+    pool_size_mb    = 512
+    prefetch_blocks = 12
+  }
+
+  validation {
+    condition     = var.shared_pvc_block_cache.prefetch_blocks >= 11
+    error_message = "prefetch_blocks must be >= 11; blobfuse2 rejects lower values with 'invalid prefetch count'."
+  }
+
+  validation {
+    condition     = var.shared_pvc_block_cache.pool_size_mb >= var.shared_pvc_block_cache.block_size_mb * var.shared_pvc_block_cache.prefetch_blocks
+    error_message = "pool_size_mb must be at least block_size_mb * prefetch_blocks, or blobfuse2 fails with 'memory limit too low for configured prefetch'."
+  }
+}
+
+variable "shared_pvc_container_name" {
+  description = "(Optional) Name of the blob container backing the shared PVC. Defaults to \"<aks_cluster_name>-shared\". Only used when enable_shared_pvc is true."
+  type        = string
+  nullable    = true
+  default     = null
+}
+
 variable "enable_nfs" {
   description = <<-EOT
     (Optional) Enable provisioning of an Azure NFS (Network File System) storage account.


### PR DESCRIPTION
Adds an opt-in shared ReadWriteMany PVC to the `anyscale-on-azure-new-aks` example, backed by the Azure Blob CSI driver (blobfuse2). This is the Azure equivalent of the EFS/Filestore shared storage the AWS/GCP examples get. Ray pods can mount it for shared checkpoints, datasets, etc.

Everything is gated behind `enable_shared_pvc` (default `false`), so existing users are unaffected.

## What's included
- New `shared_pvc.tf`: blob container, CSI role assignments, StorageClass, and the RWX PVC
- `variables.tf`: `enable_shared_pvc` and a few knobs, including `shared_pvc_block_cache` tuning
- `outputs.tf`: PVC name + registration instructions
- README + tfvars example

## Notes for reviewers
Verified against a live AKS cluster. Two places this config differs from the published Anyscale [Azure PVC doc](https://docs.anyscale.com/clouds/azure/pvc), both deliberate:

- **`clientID` is set on the StorageClass.** The doc omits it. With the managed blob-CSI addon there's no default workload identity, so the mount falls back to the kubelet identity and fails with `AADSTS70025`. Setting `clientID` to the operator identity fixes it.
- **`--block-cache` uses explicit sizing** instead of the bare flag. Bare `--block-cache` sizes its prefetch pool against node memory and fails to mount on smaller nodes ("memory limit too low for configured prefetch"). Explicit values make it portable.

## Not included
Registering the PVC with the Anyscale cloud (`file_storage.persistent_volume_claim`) is a one-time `anyscale cloud update` step, not something that belongs in `terraform apply`. The `shared_pvc_registration_instructions` output explains it.