### PR TITLE
Add anyscale-on-azure-aks-automatic example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ These modules are designed with best practices in mind, ensuring a secure, effic
 The examples folder has a couple common use cases that have been tested. These include:
 * Anyscale - Azure & AKS
   * [aks-new](https://github.com/anyscale/terraform-kubernetes-anyscale-foundation-modules/tree/main/examples/azure/aks-new_cluster) - Build everything - create a new AKS cluster and connect it to Anyscale
+  * [anyscale-on-azure-aks-automatic](https://github.com/anyscale/terraform-kubernetes-anyscale-foundation-modules/tree/main/examples/azure/anyscale-on-azure-aks-automatic) - Build everything on AKS Automatic - Karpenter node auto-provisioning, AKS-managed GPU drivers, built-in app-routing Istio gateway, Entra-only cluster auth
 * Anyscale - AWS & EKS
   * [eks-public](https://github.com/anyscale/terraform-kubernetes-anyscale-foundation-modules/tree/main/examples/aws/eks-public) - Build everything - use a common name for all resources, public networking
   * [eks-private](https://github.com/anyscale/terraform-kubernetes-anyscale-foundation-modules/tree/main/examples/aws/eks-private) - Build everything - use a common name for all resources, private networking

--- a/examples/azure/anyscale-on-azure-aks-automatic/.gitignore
+++ b/examples/azure/anyscale-on-azure-aks-automatic/.gitignore
@@ -1,0 +1,34 @@
+# Terraform
+# NOTE: .terraform.lock.hcl is ignored repo-wide by the root .gitignore, so no
+# example here commits one — provider versions are pinned by the constraints in
+# versions.tf instead. (HashiCorp's guidance for root modules is to commit the
+# lock file; changing that is a repo-wide decision, not this example's.)
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfplan
+tfplan
+crash.log
+
+# Apply/destroy transcripts. These embed subscription IDs, ARM resource paths,
+# and OIDC issuer URLs, so they must never be committed.
+*.log
+
+# Deployment-specific values and generated artifacts (embed subscription IDs)
+terraform.tfvars
+anyscale-aks-cloud.yaml
+
+# Manifests rendered by gateway.tf / gpu.tf and applied by the bootstrap.
+# Regenerated on every apply; the Gateway one embeds the cloud resource ID.
+anyscale-namespace.yaml
+anyscale-gateway.yaml
+nvidia-nodepool.yaml
+
+# Isolated kubeconfig written by the in-cluster bootstrap (never ~/.kube/config)
+.kubeconfig
+
+# Scheduling diagnostics written by diagnose-head-pod.sh
+diagnostics/
+
+# OS
+.DS_Store

--- a/examples/azure/anyscale-on-azure-aks-automatic/PLAN.md
+++ b/examples/azure/anyscale-on-azure-aks-automatic/PLAN.md
@@ -1,0 +1,246 @@
+# Plan — `anyscale-on-azure-aks-automatic`
+
+Status: **implemented and verified end to end** against a real subscription
+(westus2, 2026-07-26/27): `terraform apply` → operator Running → `terraform destroy` with
+no orphans. See "Verification results" below.
+
+Deviations from the plan as written, discovered while implementing:
+
+- **`default_nginx_controller = "None"` is not accepted by the typed resource** — its schema
+  only allows `AnnotationControlled` / `Internal` / `External`. Turning the nginx controller
+  off entirely needs a third azapi patch (`app_routing` in `aks.tf`), so the count is
+  three patches, not two.
+- **`azapi_update_resource` has no `schema_validation_enabled` argument** (that is
+  `azapi_resource` only), so the deployment-safeguards patch omits it.
+- **Terraform has no user-defined functions**, so `gpu.tf` flattens on-demand/spot into a
+  `gpu_nodepool_variants` list rather than calling a shared NodePool builder.
+- `select-gpu.sh`'s existing object schema (`name`/`vm_size`/`product_name`/`gpu_count`) was
+  already what the NodePool CRs need, so it is a `sed` rename plus wording, not a rewrite.
+  `gpu_nodepool_configs` adds `enable_spot`, `max_gpus`, `image_family`, `os_disk_size_gb`.
+- Added beyond the plan: `api_server_authorized_ip_ranges`,
+  `aks_cluster_admin_principal_ids`, `enable_default_nginx_ingress_controller`,
+  `deployment_safeguards_level`, `deployment_safeguards_api_version`,
+  `gateway.api_ready_timeout_seconds`.
+
+---
+
+## Verification results (westus2, 2026-07-26/27)
+
+Four bugs surfaced only under a real apply and a real workload. All four would have hit any
+first-time user.
+
+| # | Bug | Symptom | Fix |
+|---|---|---|---|
+| 1 | `deploymentSafeguards` addressed as a child of `managedClusters` | 404 on an otherwise correct PATCH | It is an **extension** resource: `<cluster-id>/providers/Microsoft.ContainerService/deploymentSafeguards/default`. Also moved to the GA `2025-07-01` API |
+| 2 | `ingressProfile.gatewayAPI.installation` never set | `no matches for kind "Gateway"` — **`web_app_routing_ingress { istio_enabled = true }` does NOT install the Gateway API CRDs**, it only configures the Istio implementation. `gatewayApi` stayed `null` through an 18m reconcile | Folded `gatewayAPI.installation = "Standard"` into the ingress patch; made the bootstrap `depends_on` it (it was racing) and wait for the CRDs + GatewayClass instead of blind-retrying |
+| 3 | `app_routing` and `monitoring` both PATCH the same managedCluster | `409 EtagMismatch` — ARM allows no concurrent cluster writes, and nothing in the graph ordered them | `depends_on` purely to serialize. **Any future cluster patch must join this chain** |
+| 4 | `--cloud` documented as `anyscale_cloud_name` | `API Exception (404) ... "Cloud with name anyscale-auto-t1-cloud does not exist."` The control plane registers the cloud under its **full lowercased ARM resource ID** | Added the `anyscale_cloud_cli_name` output (`lower(arm_id)`); fixed README and `job.yaml`. Also note `cldrsrc_…` (cloud resource ID) and `cld_…` (CLI cloud ID) are different identifiers — the original `anyscale cloud verify --id` line conflated them |
+
+Bug 2 is the instructive one: blind retries could not distinguish "still reconciling" from
+"this field was never set", so the failure read as a timing flake for two full applies. The
+bootstrap now waits on the specific object and prints the `ingressProfile.gatewayApi` check
+on timeout.
+
+Confirmed working on real infrastructure:
+
+- Typed `azurerm_kubernetes_automatic_cluster` with 3-subnet BYO VNet and UserAssigned identity.
+- Entra-only auth: `az aks get-credentials` + `kubelogin convert-kubeconfig -l azurecli`.
+- Deployment-safeguards exclusion — operator `3/3 Running` for 9h, no restarts. **This is the
+  single most likely thing to break on Automatic and it is invisible without the exclusion.**
+- **Deterministic hostname**, the riskiest port (annotation moved from `EnvoyProxy` to the
+  Gateway's `spec.infrastructure.annotations`):
+  `cldrsrc-2na19fk7le9dsnzct5lf5sppuw.westus2.cloudapp.azure.com` → `20.252.59.31`, the LB.
+- GPU `AKSNodeClass` + `NodePool` accepted by Karpenter, both `Ready`.
+- Monitoring patch: `omsagent`/`metrics`/`containerInsights` all true, `ama-logs` Running.
+- **Destroy**: pre-delete hook deleted the cloud in 11s with zero retries, then
+  `Destroy complete! Resources: 45 destroyed` — no 409 wedge, no orphaned RG or node RG.
+
+Timings varied across runs — the ingress-profile reconcile ranged **16–25 min**. See the
+cold-path table below for the authoritative numbers. A cold apply is roughly an hour, not
+the 20–35 min the first draft of the README implied.
+
+### Cold-path run (the authoritative one)
+
+The fixes above were each verified as they were added, but on a partly-built cluster.
+A final run from zero — empty Azure, empty state, all fixes in place from the start —
+produced `Apply complete! Resources: 45 added, 0 changed, 0 destroyed` with **zero errors**
+and zero `409`s. That is the run these numbers come from:
+
+| Resource | Cold-path duration |
+|---|---|
+| `azurerm_kubernetes_automatic_cluster.aks` | 8m30s |
+| `azapi_update_resource.app_routing` | 24m52s |
+| `azapi_update_resource.monitoring` | 5m9s (serialized behind app_routing — bug 3's fix under real contention) |
+| `terraform_data.cluster_bootstrap` | 13s (CRDs already present — bug 2's fix working) |
+| `azurerm_kubernetes_cluster_extension.anyscale_operator` | 17m3s |
+
+Ray workload: `anyscale job submit -f sample-workload/job.yaml` reached **SUCCEEDED in 2m40s**,
+and Karpenter provisioned `aks-default-6w8g9` (`Standard_D4as_v6`) from the built-in `default`
+NodePool to host it — so on-demand provisioning is proven, not just the NodePool manifests.
+
+### Still not verified
+
+- **GPU drivers.** The `gput4` NodePool and AKSNodeClass go `Ready`, and Karpenter provisions
+  CPU nodes on demand, but no GPU node was ever provisioned: the smoke test's GPU branch needs
+  a CUDA-capable image (`RUN_GPU_CHECK=1` plus an `image_uri`), which this run did not build.
+  The `EnableManagedGPUExperience` tag path is therefore still unproven end to end.
+- `internal_gateway = true`, `enable_nfs`, `enable_otlp_app_insights` — all left at defaults.
+  `internal_gateway` in particular is inherited from the `new-aks` sibling and has a known
+  gap here: it registers a private LB IP but this example creates no private DNS zones for
+  the `*.i/*.s.azure.anyscaleuserdata.com` wildcards that `private-aks` considered necessary.
+- Only one region (westus2) and one GPU SKU (T4). Note that eastus2/westus3/southcentralus
+  had a **total regional core limit of 10** on the test subscription — too small for the
+  Automatic system pool, which is a quota trap worth checking before picking a region.
+- Spot: westus2 `lowPriorityCores` limit was 3, too small for a 16-vCPU spot node, so
+  `enable_spot = false` throughout. The spot NodePool rendering is unit-verified but never
+  applied to a cluster.
+
+## Context
+
+Three Anyscale-on-Azure Terraform stacks exist today, and none of them is an AKS **Automatic** variant
+carrying the quality bar of the Anyscale reference example:
+
+| Stack | What it is |
+|---|---|
+| [`pauldotyu/awesome-aks` → `2026-07-15-anyscale-on-aks-automatic`](https://github.com/pauldotyu/awesome-aks/tree/main/2026-07-15-anyscale-on-aks-automatic) | Upstream demo. AKS Automatic, ~950 lines of HCL, hardcoded names, manual `kubectl apply` of the gateway, no destroy handling. |
+| `examples/azure/anyscale-on-azure-new-aks` (this repo) | The polished reference. **Standard** AKS, one-apply UX, BYO VNet, feature switches, helper scripts, destroy-ordering hook, production-readiness guidance. |
+| `AKS-Anyscale-Private-Cluster-Sample` | The private/hardened lab built on top of the reference. |
+
+The goal is a fourth stack: **the `new-aks` example re-cut onto AKS Automatic**, living beside its
+siblings so all three can be compared directly. Automatic removes a large chunk of what `new-aks`
+configures by hand (node pools, Envoy Gateway, GPU operator, the NAP toggle) and imposes constraints of
+its own (Entra-only cluster auth, enforced deployment safeguards, a delegated API-server subnet). This is
+a re-cut, not a copy.
+
+---
+
+## Part 1 — Comparison
+
+### `anyscale-on-azure-new-aks` (Standard) vs. this example (Automatic)
+
+| Concern | `anyscale-on-azure-new-aks` | `anyscale-on-azure-aks-automatic` |
+|---|---|---|
+| Cluster resource | `azurerm_kubernetes_cluster`, SKU Free/Standard | `azurerm_kubernetes_automatic_cluster` (azurerm **≥ 4.81.0**, released 2026-07-14) |
+| Compute | 5 hand-managed pools: `sys`, `cpu16`, `cpu16spot`, `gpu×N`, `gpuspot×N` | **Karpenter/NAP only.** Managed system pool + default NodePool are built in; we add GPU/spot `NodePool` + `AKSNodeClass` CRs |
+| GPU drivers | NVIDIA GPU operator Helm chart (default) or `gpu_driver = "Install"` | AKS-managed drivers via the `EnableManagedGPUExperience` tag on the `AKSNodeClass` (needs `ManagedGPUExperiencePreview`) |
+| Ingress | Envoy Gateway Helm release + `EnvoyProxy` + `GatewayClass eg` | Built-in app-routing **Istio**, `gatewayClassName: approuting-istio` — no Helm release, no GatewayClass to create |
+| Networking | Azure CNI overlay + Cilium configured explicitly; **1** node subnet | Overlay + Cilium are Automatic's defaults; BYO VNet requires **3** subnets — API server (delegated to `Microsoft.ContainerService/managedClusters`, ≥ /28), user node, system node |
+| Cluster identity | `SystemAssigned` | **`UserAssigned`** (required for BYO VNet) + `Network Contributor` on the VNet |
+| Cluster auth | Local admin certs from `kube_config` drive the helm/kubernetes/kubectl providers | Local accounts disabled, Entra RBAC enforced → `kubelogin` + an `Azure Kubernetes Service RBAC Cluster Admin` assignment |
+| In-cluster apply | Terraform providers (`kubectl_manifest`, `helm_release`) | Rendered YAML + a `terraform_data` local-exec `kubectl apply` |
+| Policy | none | Azure Policy + **deployment safeguards in Enforcement** → the Anyscale namespaces must be excluded or the operator's pods are rejected at admission |
+| Monitoring | `oms_agent` / `monitor_metrics` blocks on the typed resource | Typed resource exposes no monitoring blocks → `azapi_update_resource` patch |
+| Regions | Anyscale-supported list (12) | Anyscale ∩ Automatic-GA: `eastus`, `eastus2`, `westus2`, `westus3`, `southcentralus`, `westeurope`, `swedencentral`, `uksouth`, `australiaeast`, `southeastasia`, `northeurope` — **`westcentralus` drops out** |
+| Unchanged | Anyscale cloud + `cloudResources` via azapi, operator extension on workload identity, deterministic `<cldrsrc-id>.<region>.cloudapp.azure.com` hostname, storage / ACR / identity / prometheus | same |
+
+### Upstream `awesome-aks` automatic vs. this example
+
+**Kept from upstream:** AKS Automatic itself, the `approuting-istio` gateway class, the DNS-label hostname
+trick, the deployment-safeguards namespace exclusion, the managed-GPU `AKSNodeClass`, and `sample-workload/`.
+
+**Added on top:**
+
+- Variables instead of hardcoded `anyscale<NN>` names.
+- BYO VNet (upstream uses the managed network).
+- Feature switches (`enable_monitoring`, `enable_otlp_app_insights`, `enable_nfs`, `enable_acr`, `internal_gateway`).
+- Single-apply gateway bootstrap — upstream stops at writing `anyscale-gateway.yaml` and tells you to apply it.
+- The destroy-time cloud pre-delete hook. Upstream `terraform destroy` wedges: the operator extension is
+  torn down first, and the Anyscale RP then returns 409 on the cloud delete.
+- Anyscale Platform role self-grant (subscription Owner does *not* carry over to the Anyscale RP).
+- `terraform.tfvars.example`, helper scripts, and the production-readiness table.
+- Typed `azurerm_kubernetes_automatic_cluster` instead of a raw azapi body.
+- Single-region default. Upstream splits `location` (`switzerlandnorth`) from `anyscale_cloud_location`
+  (`eastus`); we keep that split available as an override but default both to one region.
+
+---
+
+## Part 2 — Implementation
+
+**Location:** `examples/azure/anyscale-on-azure-aks-automatic/`
+
+### Key design decisions
+
+1. **Typed cluster resource.** `azurerm_kubernetes_automatic_cluster` covers `hosted_system`
+   (`node_subnet_id` + `system_node_subnet_id`), `api_server_access.subnet_id`, `private_cluster`, and
+   `web_app_routing_ingress { istio_enabled = true }`. This preserves the `new-aks` philosophy — typed GA
+   resource, azapi only for what the schema can't reach. Upstream used a raw azapi body because the typed
+   resource did not exist yet.
+   *Fallback:* if 4.81.0 proves flaky, swap in upstream's
+   `azapi_resource … managedClusters@2026-05-02-preview` body — everything downstream reads through
+   locals, so only `aks.tf` changes.
+2. **Two azapi patches** on top of the typed cluster:
+   - monitoring profile — `addonProfiles.omsagent` + `azureMonitorProfile.metrics` /
+     `.containerInsights` / (optional) `.appMonitoring` OTLP;
+   - `Microsoft.ContainerService/deploymentSafeguards@2025-05-02-preview` → `excludedNamespaces`.
+3. **Kubelet identity is not exported** by the typed resource (attributes are `identity`, `kube_config`,
+   `oidc_issuer_url`, `node_resource_group_id`, FQDNs). Read it with a `data "azapi_resource"` on the
+   cluster ID with `response_export_values = ["properties.identityProfile"]` to wire the `AcrPull`
+   assignment that `acr.tf` currently gets from `kubelet_identity[0].object_id`.
+4. **In-cluster bootstrap.** `templatefile` renders YAML to disk, then one `terraform_data` local-exec:
+   `az aks get-credentials --file ./.kubeconfig` → `kubelogin convert-kubeconfig -l azurecli` →
+   `kubectl apply` for namespace, then gateway, then GPU NodePools. Isolated kubeconfig, gitignored,
+   never touches `~/.kube/config`. `triggers_replace` keyed on the rendered manifest contents so edits
+   re-apply.
+5. **GPU via NAP.** `gpu_nodepool_configs` (map, empty by default) renders `AKSNodeClass` + `NodePool` CRs
+   carrying the Anyscale taints (`nvidia.com/gpu=present`, `node.anyscale.com/accelerator-type=GPU`,
+   `node.anyscale.com/capacity-type`) that the operator's existing
+   `anyscale_extension_configuration_defaults` tolerations in `anyscale.tf` already match. Optional spot
+   NodePool per entry. CPU capacity comes from Automatic's built-in default NodePool — no CPU pools to define.
+6. **Dropped from `new-aks`:** `gpu.tf`'s GPU-operator Helm release and its toleration block, every
+   `azurerm_kubernetes_cluster_node_pool`, the `helm` / `kubernetes` / `kubectl` providers, and the
+   `enable_node_auto_provisioning`, `gpu_driver_mode`, `gpu_operator_chart_version`, `nap_gpu_sku_name`,
+   `system_vm_size`, `cpu_vm_size`, `envoy_gateway` variables. NAP is always on; drivers are always
+   AKS-managed.
+
+### File-by-file
+
+| File | Source | Work |
+|---|---|---|
+| `versions.tf` | `new-aks` | azurerm `>= 4.81.0, < 5.0.0`; keep azapi, random, local, external. Delete the helm / kubernetes / kubectl provider blocks (they authenticate with certs that Automatic does not issue) |
+| `main.tf` | `new-aks` | Keep RG, `random_string` suffix + name locals, storage account (HNS + CORS + container), optional NFS. **Rewrite the network section:** 3 subnets — `apiserver` (delegated, `/28`), `nodes`, `systemnodes` — plus a cluster UAMI and `Network Contributor` on the VNet. NFS `network_rules` point at the `nodes` subnet as before |
+| `aks.tf` | rewrite | Typed automatic cluster; the two azapi patches; the azapi data read for kubelet identity; `Azure Kubernetes Service RBAC Cluster Admin` self-assignment so the bootstrap's `kubectl` is authorized |
+| `gateway.tf` | rewrite | Render `anyscale-gateway.yaml` — namespace + `Gateway` on `approuting-istio`, 3 listeners (HTTP, `*.i.…`, `*.s.…`), DNS-label annotation under `spec.infrastructure.annotations` (upstream's placement; `new-aks` puts it on the `EnvoyProxy`). Plus the bootstrap local-exec. Keep the `internal_gateway` LB-polling path from `new-aks` — the `kubectl` machinery is already present |
+| `gpu.tf` | rewrite | Render `nvidia-nodepool.yaml` from `gpu_nodepool_configs` |
+| `anyscale.tf` | `new-aks`, near-verbatim | Change `networking.gateway.className` → `approuting-istio`; `depends_on` the bootstrap instead of `kubectl_manifest.gateway`. Keep cloud + `cloudResources`, contributor grants, self-grant, and the **pre-delete destroy hook** unchanged |
+| `acr.tf` | `new-aks` | Copy; repoint `kubelet_acr_pull` at the azapi-read kubelet object ID |
+| `identity.tf` | `new-aks` | Copy; `issuer` comes from the automatic cluster's `oidc_issuer_url` |
+| `monitoring.tf`, `prometheus.tf` | `new-aks` | Copy as-is; retarget the cluster reference in the Prometheus DCR association |
+| `variables.tf` | `new-aks` | Prune the six variables listed in decision 6. Add `apiserver_subnet_cidr`, `system_nodes_subnet_cidr`, `gpu_nodepool_configs`, `deployment_safeguards_excluded_namespaces`, `anyscale_cloud_location`. Narrow the `azure_location` validation list to the Anyscale ∩ Automatic-GA intersection |
+| `outputs.tf` | `new-aks` + upstream | Keep all; add the OTLP endpoints (upstream has them as top-level outputs) and the gateway hostname. Keep the `anyscale-aks-cloud.yaml` summary file |
+| `README.md` | new | Both comparison tables above + prereqs, deploy, verify, destroy, production-readiness |
+| `terraform.tfvars.example`, `.gitignore` | `new-aks` | `.gitignore` adds the rendered `anyscale-gateway.yaml` / `nvidia-nodepool.yaml` |
+| `azure-login.sh`, `select-region.sh`, `select-gpu.sh`, `diagnose-head-pod.sh` | `new-aks` | Copy. `select-region.sh` region list → the intersection; `select-gpu.sh` writes `gpu_nodepool_configs` instead of `gpu_pool_configs` |
+| `sample-workload/{job.yaml,main.py}` | upstream | Copy |
+
+### New prerequisites to document
+
+- `kubelogin` (`az aks install-cli` installs both it and `kubectl`).
+- Azure CLI ≥ 2.86.
+- `Microsoft.PolicyInsights` registered, on top of the providers `new-aks` already lists.
+- `ManagedGPUExperiencePreview` registered when using GPU NodePools.
+- The deploying principal needs `Azure Kubernetes Service RBAC Cluster Admin` — the stack self-assigns it.
+
+## Verification
+
+1. `terraform fmt -check` and `terraform init && terraform validate`.
+2. `terraform plan` against a real subscription with `azure_location = "eastus2"` — confirm
+   `networking.gateway.hostname` is **not** `(known after apply)`, i.e. the deterministic-hostname trick
+   survived the port.
+3. `terraform apply`, then:
+   - `kubectl get nodes` — managed system pool Ready.
+   - `kubectl get po -n anyscale-operator` — operator Running. This is the real test of the
+     deployment-safeguards exclusion; without it admission rejects the operator's pods.
+   - `kubectl get gateway -n anyscale-operator` — Programmed once the operator mints the TLS secrets.
+   - `anyscale cloud verify --id $(terraform output -raw anyscale_cloud_id)` with
+     `ANYSCALE_HOST=https://console.azure.anyscale.com`.
+   - `anyscale job submit -f sample-workload/job.yaml --cloud <name> --wait`. With a GPU NodePool
+     configured this also proves NAP provisions a GPU node with AKS-managed drivers.
+4. `terraform destroy` — must finish without the 409 wedge, proving the pre-delete hook carried over.
+
+## Risks
+
+- `azurerm_kubernetes_automatic_cluster` is one release old. Fallback documented in decision 1.
+- Deployment safeguards may reject Anyscale *workload* pods, not just the operator's. The excluded-namespace
+  list is a variable so it can be widened after the first real workload run.
+- Anyscale on Azure, managed GPU, and OTLP App Insights are all preview surface; the region intersection
+  and API versions will move.

--- a/examples/azure/anyscale-on-azure-aks-automatic/README.md
+++ b/examples/azure/anyscale-on-azure-aks-automatic/README.md
@@ -1,0 +1,221 @@
+# Anyscale on AKS Automatic
+
+One `terraform apply` stands up an **AKS Automatic** cluster and registers it as an Anyscale cloud on the Azure-hosted control plane (`https://console.azure.anyscale.com`) — infrastructure, cloud registration, operator, and gateway in a single pass.
+
+This is the [`anyscale-on-azure-new-aks`](../anyscale-on-azure-new-aks) reference example re-cut onto AKS Automatic. Automatic removes a large chunk of what that example configures by hand — node pools, the Envoy Gateway chart, the NVIDIA GPU operator — and imposes constraints of its own: Entra-only cluster auth, enforced deployment safeguards, and a three-subnet BYO VNet.
+
+## What gets deployed
+
+| Type | Resource | File |
+|---|---|---|
+| Azure infra | Resource group, VNet, **three** subnets (delegated API-server `/28`, user nodes, system nodes) | `main.tf` |
+| Azure infra | Cluster user-assigned identity + `Network Contributor` on the VNet | `main.tf` |
+| Azure infra | Storage account (**HNS / ADLS Gen2**, TLS 1.2, OAuth-default) + private blob container; optional Premium NFS account | `main.tf` |
+| Azure infra | `azurerm_kubernetes_automatic_cluster` — API Server VNet Integration, app-routing Istio, hosted-system subnets | `aks.tf` |
+| Azure infra | azapi patches: **Gateway API installation** + nginx controller off, monitoring profile, **deployment-safeguards exclusion** | `aks.tf` |
+| Azure infra | Entra RBAC grants (`RBAC Cluster Admin`, `Cluster User`) for the deploying principal | `aks.tf` |
+| Azure infra | User-assigned identity + federated credential + `Storage Blob Data Contributor` | `identity.tf` |
+| Azure infra | ACR + kubelet `AcrPull` + operator `AcrPush` / `Container Registry Tasks Contributor` | `acr.tf` |
+| Anyscale | `Anyscale.Platform/clouds` + `clouds/cloudResources/default` (native azapi) | `anyscale.tf` |
+| Anyscale | `Anyscale.AKS.Operator` marketplace extension (Entra workload-identity auth) | `anyscale.tf` |
+| In-cluster | Operator namespace + 3-listener `Gateway` on `approuting-istio`, applied via `kubectl` | `gateway.tf` |
+| In-cluster | Karpenter `AKSNodeClass` + GPU `NodePool`s with AKS-managed drivers (opt-in) | `gpu.tf` |
+| Observability | Azure Monitor workspace + managed Prometheus DCE/DCR/recording rules; Log Analytics + Container Insights | `monitoring.tf`, `prometheus.tf` |
+
+## Part 1 — How this differs from `anyscale-on-azure-new-aks`
+
+| Concern | `anyscale-on-azure-new-aks` (Standard) | This example (Automatic) |
+|---|---|---|
+| Cluster resource | `azurerm_kubernetes_cluster`, SKU Free/Standard | `azurerm_kubernetes_automatic_cluster` (azurerm **≥ 4.81.0**) |
+| Compute | 5 hand-managed pools: `sys`, `cpu16`, `cpu16spot`, `gpu×N`, `gpuspot×N` | **Karpenter/NAP only.** Managed system pool + built-in default NodePool; we add GPU `NodePool` + `AKSNodeClass` CRs |
+| GPU drivers | NVIDIA GPU operator Helm chart (default) or `gpu_driver = "Install"` | AKS-managed via the `EnableManagedGPUExperience` tag on the `AKSNodeClass` (needs `ManagedGPUExperiencePreview`) |
+| Ingress | Envoy Gateway Helm release + `EnvoyProxy` + `GatewayClass eg` | Built-in app-routing **Istio**, `gatewayClassName: approuting-istio` — no Helm release, no GatewayClass to create |
+| LB annotations | On the `EnvoyProxy` object | On the Gateway's `spec.infrastructure.annotations` (no `EnvoyProxy` exists) |
+| Networking | Azure CNI overlay + Cilium configured explicitly; **1** node subnet | Overlay + Cilium are Automatic's defaults; BYO VNet requires **3** subnets |
+| Cluster identity | `SystemAssigned` | **`UserAssigned`** (required for BYO VNet) + `Network Contributor` on the VNet |
+| Cluster auth | Local admin certs from `kube_config` drive the helm/kubernetes/kubectl providers | Local accounts disabled, Entra RBAC enforced → `kubelogin` + an `Azure Kubernetes Service RBAC Cluster Admin` assignment |
+| In-cluster apply | Terraform providers (`kubectl_manifest`, `helm_release`) | Rendered YAML + a `terraform_data` local-exec `kubectl apply` |
+| Policy | none | Azure Policy + **deployment safeguards in Enforcement** → the Anyscale namespace must be excluded or the operator's pods are rejected at admission |
+| Monitoring | `oms_agent` / `monitor_metrics` blocks on the typed resource | Typed resource exposes no monitoring blocks → `azapi_update_resource` patch |
+| Regions | Anyscale-supported list (12) | Anyscale ∩ Automatic-GA (11) — **`westcentralus` drops out** |
+| Unchanged | Anyscale cloud + `cloudResources` via azapi, operator extension on workload identity, deterministic `<cldrsrc-id>.<region>.cloudapp.azure.com` hostname, storage / ACR / identity / prometheus | same |
+
+### Variables that no longer exist
+
+`system_vm_size`, `cpu_vm_size`, `gpu_driver_mode`, `gpu_operator_chart_version`, `enable_node_auto_provisioning`, `nap_gpu_sku_name`, `envoy_gateway`, and `enable_blob_driver`. AKS Automatic manages the system pool, always runs node auto-provisioning, installs GPU drivers itself, ships the Istio gateway implementation, and enables the storage CSI drivers by default. `gpu_pool_configs` becomes `gpu_nodepool_configs` with a slightly richer schema.
+
+## Part 2 — How this differs from upstream `awesome-aks`
+
+Upstream: [`pauldotyu/awesome-aks` → `2026-07-15-anyscale-on-aks-automatic`](https://github.com/pauldotyu/awesome-aks/tree/main/2026-07-15-anyscale-on-aks-automatic).
+
+**Kept:** AKS Automatic itself, the `approuting-istio` gateway class, the DNS-label hostname trick, the deployment-safeguards namespace exclusion, the managed-GPU `AKSNodeClass`, and `sample-workload/`.
+
+**Added:**
+
+| | |
+|---|---|
+| Variables | Instead of hardcoded `anyscale<NN>` names |
+| BYO VNet | Upstream uses the AKS-managed network |
+| Feature switches | `enable_monitoring`, `enable_otlp_app_insights`, `enable_nfs`, `enable_acr`, `internal_gateway`, `api_server_authorized_ip_ranges` |
+| Single-apply gateway | Upstream stops at writing `anyscale-gateway.yaml` and tells you to `kubectl apply` it yourself |
+| Destroy hook | Upstream `terraform destroy` wedges: the operator extension is torn down first, and the Anyscale RP then returns 409 on the cloud delete |
+| Platform role self-grant | Subscription Owner does *not* carry over to the Anyscale RP |
+| Typed cluster resource | Instead of a raw azapi `managedClusters` body |
+| Single-region default | Upstream splits `location` from `anyscale_cloud_location`; that split is available here as an override but both default to one region |
+| Tooling | `terraform.tfvars.example`, helper scripts, production-readiness guidance |
+
+## Prerequisites
+
+- **Azure CLI ≥ 2.86** logged in (`./azure-login.sh`), **Terraform ≥ 1.5**, and the **Anyscale CLI** for verification.
+- **`kubectl` and `kubelogin`** — both required, unlike the `new-aks` sibling where kubectl is optional. Automatic issues no admin certificate, so the bootstrap authenticates with an Entra token:
+  ```bash
+  az aks install-cli    # installs kubectl AND kubelogin
+  ```
+- A subscription with these resource providers registered: `Anyscale.Platform`, `Microsoft.Authorization`, `Microsoft.ContainerRegistry`, `Microsoft.ContainerService`, `Microsoft.Insights`, `Microsoft.ManagedIdentity`, `Microsoft.Monitor`, `Microsoft.Network`, `Microsoft.OperationalInsights`, `Microsoft.PolicyInsights`, `Microsoft.Resources`, `Microsoft.Storage`
+  (`az provider register --namespace <name>`; the azurerm provider is configured with `resource_provider_registrations = "none"`).
+  `Microsoft.PolicyInsights` is the one the `new-aks` sibling does not need — deployment safeguards depend on it.
+- A region in the Anyscale ∩ AKS-Automatic intersection — `./select-region.sh` scans quota and writes `azure_location` for you.
+- The deploying principal needs `Azure Kubernetes Service RBAC Cluster Admin` on the cluster. **The stack self-assigns it** (`assign_current_principal_cluster_access`, default true), which requires permission to create role assignments — i.e. Owner or User Access Administrator on the resource group.
+- **Required preview features.** The Gateway API surface is preview, and without both of these the gateway bootstrap fails with `no matches for kind "Gateway"`:
+  ```bash
+  az feature register --namespace Microsoft.ContainerService --name ManagedGatewayAPIPreview
+  az feature register --namespace Microsoft.ContainerService --name AppRoutingIstioGatewayAPIPreview
+  # wait for both to report Registered, then propagate:
+  az provider register --namespace Microsoft.ContainerService
+  ```
+  Check with `az feature list --namespace Microsoft.ContainerService --query "[?contains(name,'GatewayAPI')].{name:name,state:properties.state}" -o table`. Registration is asynchronous.
+- Only if you configure GPU NodePools:
+  ```bash
+  az feature register --namespace Microsoft.ContainerService --name ManagedGPUExperiencePreview
+  az provider register --namespace Microsoft.ContainerService   # propagate
+  ```
+
+## Deploy
+
+```bash
+./azure-login.sh                 # ① authenticate + pick subscription
+./select-region.sh               # ② quota-scan → write azure_location to terraform.tfvars
+./select-gpu.sh                  # ③ optional: opt into GPU NodePools
+cp terraform.tfvars.example terraform.tfvars   # fill in azure_subscription_id etc.
+
+terraform init
+terraform plan
+terraform apply                  # ④ infra → cloud registration → gateway → operator
+```
+
+**Expect ~60 minutes for a cold apply.** Measured on a clean westus2 deploy: cluster create `8m30s`, ingress-profile reconcile `24m52s` (it installs the Gateway API CRDs — slow and unavoidable, and it ranged 16–25 min across runs), monitoring patch `5m9s`, gateway bootstrap `13s`, operator extension `17m3s`. `terraform destroy` takes ~15 min.
+
+> **Region quota trap:** several Anyscale-supported regions default to a **total regional core limit of 10**, which is not enough for the AKS Automatic system pool — the cluster create fails late. `./select-region.sh` scans for this; check it before picking a region.
+
+### Helper scripts
+
+| Script | Purpose |
+|---|---|
+| `azure-login.sh` | Azure CLI sign-in and subscription selection |
+| `select-region.sh` | Scan subscription quota across the supported regions and write `azure_location` |
+| `select-gpu.sh` | Opt into GPU capacity by writing a `gpu_nodepool_configs` block |
+| `scan-regional-quotas.sh` | Standalone CPU/GPU quota report (the engine behind `select-region.sh`) |
+| `diagnose-head-pod.sh` | Post-deploy triage when a Ray head pod won't schedule |
+
+### What the bootstrap does
+
+`gateway.tf` renders `anyscale-namespace.yaml`, `anyscale-gateway.yaml`, and (when GPU is configured) `nvidia-nodepool.yaml` to disk — all gitignored — then runs one local-exec:
+
+```
+az aks get-credentials --file ./.kubeconfig     # isolated, never ~/.kube/config
+kubelogin convert-kubeconfig -l azurecli        # Entra token from the existing az login
+kubectl apply -f …                              # namespace → gateway → GPU NodePools
+```
+
+Between the namespace and the Gateway it **waits for the Gateway API CRDs and the `approuting-istio` GatewayClass to actually exist** (up to `gateway.api_ready_timeout_seconds`, default 20 min). The ingress-profile patch returns as soon as ARM accepts it, but the CRDs land in the cluster minutes later. `triggers_replace` keys on manifest *content*, so editing a listener re-applies on the next `terraform apply`.
+
+> **If the bootstrap times out waiting for Gateway API CRDs**, check `az aks show … --query ingressProfile.gatewayApi`. If it's `null`, the two preview features above are not registered — no amount of retrying fixes that.
+
+### Deterministic gateway hostname
+
+The Gateway's `spec.infrastructure.annotations` carry `service.beta.kubernetes.io/azure-dns-label-name: <cldrsrc-id>`, so the load balancer's public hostname is known **at plan time**:
+
+```
+<cldrsrc-id-hyphenated>.<region>.cloudapp.azure.com
+```
+
+That hostname is baked directly into the operator extension's `networking.gateway.hostname` — no LB polling, no `az k8s-extension update` follow-up. (A polling fallback exists only behind `internal_gateway = true`, where a private LB IP must be read back from the Gateway status.)
+
+## Feature switches
+
+| Variable | Default | Effect |
+|---|---|---|
+| `enable_deployment_safeguards_exclusion` | `true` | Excludes the Anyscale namespace from Azure Policy enforcement. **Leave this on** — see below |
+| `enable_monitoring` | `true` | Managed Prometheus + Container Insights + omsagent, applied as an azapi patch |
+| `enable_otlp_app_insights` | `false` | App Insights OTLP endpoints + the cluster's appMonitoring profile (**preview**) |
+| `internal_gateway` | `false` | Internal Standard LB — VNet-only data plane; falls back to LB polling |
+| `api_server_authorized_ip_ranges` | `[]` | Narrow the public API server to known egress IPs. Must include wherever Terraform runs, or the bootstrap's `kubectl` is locked out |
+| `enable_default_nginx_ingress_controller` | `false` | Keep app routing's nginx controller (a second public LB) alongside Istio |
+| `enable_nfs` | `false` | Premium NFS FileStorage account locked to the node subnet |
+| `enable_acr` | `true` | Customer-owned ACR + pull/push/tasks role assignments |
+| `gpu_nodepool_configs` | `{}` | Karpenter GPU NodePools with AKS-managed drivers |
+
+### About deployment safeguards
+
+AKS Automatic runs Azure Policy deployment safeguards at **Enforcement** level, which rejects pods without resource limits, running as root, or using `latest` tags. The Anyscale operator does not satisfy those constraints — it runs an init container with elevated capabilities, and the Ray pods it creates are shaped by the Anyscale control plane, not by this Terraform.
+
+Without the exclusion patch, the operator's pods are denied at admission and the symptom is a Deployment stuck at `0/1` replicas, not an obvious policy error. If a real workload turns up rejections in another namespace, widen `deployment_safeguards_excluded_namespaces` rather than dropping `deployment_safeguards_level` cluster-wide.
+
+## Verify
+
+```bash
+az aks get-credentials -g $(terraform output -raw azure_resource_group_name) \
+                       -n $(terraform output -raw azure_aks_cluster_name)
+kubelogin convert-kubeconfig -l azurecli      # required — no local accounts
+
+kubectl get nodes                             # managed system pool Ready
+kubectl get po -n anyscale-operator           # operator Running ← the safeguards test
+kubectl get gateway -n anyscale-operator      # Programmed once the operator mints the TLS secrets
+
+export ANYSCALE_HOST=https://console.azure.anyscale.com
+anyscale login
+anyscale cloud list                           # the cloud should appear
+
+# End-to-end: proves the operator was admitted AND Karpenter provisions on demand.
+cd sample-workload
+anyscale job submit -f job.yaml \
+  --cloud "$(cd .. && terraform output -raw anyscale_cloud_cli_name)" --wait
+```
+
+> **The `--cloud` value is not the cloud's Azure name.** The Anyscale control plane registers the cloud under its **full ARM resource ID, lowercased** — so `--cloud anyscale-auto-t1-cloud` fails with `API Exception (404) ... "Cloud with name ... does not exist."` Use the `anyscale_cloud_cli_name` output, which renders the correct value. Note also that `anyscale_cloud_resource_id` (`cldrsrc_…`) and the CLI's cloud ID (`cld_…`) are **different identifiers**; `anyscale cloud list` shows the `cld_…` one.
+
+The Gateway's HTTPS listeners report `Programmed=False` until the Anyscale operator creates the TLS Secrets they reference. That is expected immediately after apply — the load balancer and its DNS label are allocated as soon as the Gateway exists, which is what the extension needs.
+
+A summary of every ID you need lands in `anyscale-aks-cloud.yaml` (gitignored) after apply. If a workspace pod won't schedule, run `./diagnose-head-pod.sh`.
+
+## Destroy
+
+```bash
+terraform destroy
+```
+
+Destroy ordering is handled automatically: a destroy-time hook deletes the Anyscale cloud (child `cloudResources` first, retrying while the control plane drains sessions) **while the operator is still installed**, before the extension and cluster are torn down — otherwise the Anyscale RP returns 409 and wedges the resource group. Upstream `awesome-aks` has no equivalent and does wedge.
+
+## Production readiness
+
+This example optimizes for a fast, single-command first deploy. AKS Automatic already covers several things the `new-aks` sibling leaves to you — Entra-only cluster auth, node auto-upgrade and OS patching, Azure Policy, a Standard-tier SLA — so the remaining gap is narrower. Before running real workloads:
+
+| Evaluation default | Hardening step |
+|---|---|
+| Public AKS API server | `api_server_authorized_ip_ranges` (include your egress IP). A fully private API server is **out of scope here** — the bootstrap needs data-plane reach; use [`anyscale-on-azure-private-aks`](../anyscale-on-azure-private-aks) instead |
+| Public gateway LB | `internal_gateway = true` (VNet-only data plane) |
+| Public storage / ACR endpoints | Private endpoints; ACR needs `acr_sku = "Premium"` |
+| Anyscale namespace excluded from safeguards | Keep the exclusion as narrow as the operator actually needs; audit workload pods against the safeguards rules |
+| Local Terraform state | Remote backend (e.g. the `azurerm` backend with a state storage account) |
+| LRS storage, single zone | ZRS/GRS replication; Karpenter NodePools with zone spread requirements |
+| No NetworkPolicy objects | Cilium is enforcing-capable out of the box — write policies for the Anyscale namespace |
+
+## Known risks
+
+- `azurerm_kubernetes_automatic_cluster` is a recent addition. If it proves unreliable, the fallback is upstream's raw `azapi_resource … managedClusters` body — everything downstream reads through locals, so only `aks.tf` changes.
+- The deployment-safeguards child resource, the managed-GPU experience, the App Insights OTLP API, and Anyscale on Azure itself are all preview surface. API versions are variables (`deployment_safeguards_api_version`, `anyscale_platform.clouds_api_version`) precisely because they will move.
+- The default nginx ingress controller is created during cluster creation and removed by a patch immediately after, so a first apply briefly allocates a public IP that is then deleted.
+
+## License
+
+Apache License 2.0 — see [`LICENSE`](../../../LICENSE) and [`NOTICE`](../../../NOTICE). This deployment is derived from and adapts two upstream examples: [anyscale/terraform-kubernetes-anyscale-foundation-modules](https://github.com/anyscale/terraform-kubernetes-anyscale-foundation-modules) (Apache 2.0) and [pauldotyu/awesome-aks](https://github.com/pauldotyu/awesome-aks) (MIT).

--- a/examples/azure/anyscale-on-azure-aks-automatic/acr.tf
+++ b/examples/azure/anyscale-on-azure-aks-automatic/acr.tf
@@ -1,0 +1,74 @@
+###############################################################################
+# Azure Container Registry — customer-owned registry for Anyscale workload
+# images (cluster envs, fine-tuned models, ad-hoc Dockerfiles produced by the
+# operator's image builder when `IMAGE_BUILD_BACKEND_ACR` is in effect).
+#
+# This is opt-in via `var.enable_acr` (default true). The AKS extension itself
+# pulls the operator image from `arcmktplaceprod.azurecr.io` regardless — this
+# ACR is for the workloads you launch from the Anyscale console, not for the
+# operator binary.
+###############################################################################
+
+locals {
+  acr_name_base = replace(var.aks_cluster_name, "-", "")
+  # ACR names are also globally unique. Reserve 3 chars for "acr" + 5 for the
+  # shared random suffix = 42 chars max for the base (well inside the 50 limit).
+  acr_name = coalesce(var.acr_name, "${substr(local.acr_name_base, 0, 42)}acr${local.name_suffix}")
+}
+
+resource "azurerm_container_registry" "acr" {
+  count = var.enable_acr ? 1 : 0
+
+  name                = local.acr_name
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  sku                 = var.acr_sku
+  admin_enabled       = false
+  # Public network access — match the example's overall public-networking
+  # posture. Premium SKU is required if you want to disable this and use
+  # Private Link.
+  public_network_access_enabled = true
+  # zone_redundancy_enabled is a Premium-only feature; AzureRM accepts the
+  # flag on lower SKUs but Azure ignores it. Force false on non-Premium so
+  # there is no apply-time confusion.
+  zone_redundancy_enabled = var.acr_sku == "Premium" ? var.acr_zone_redundancy_enabled : false
+
+  tags = var.tags
+}
+
+###############################################################################
+# Grant the AKS kubelet identity AcrPull on this registry so pods can pull
+# images.
+###############################################################################
+resource "azurerm_role_assignment" "kubelet_acr_pull" {
+  count = var.enable_acr ? 1 : 0
+
+  scope                = azurerm_container_registry.acr[0].id
+  role_definition_name = "AcrPull"
+  # `azurerm_kubernetes_automatic_cluster` does not export `kubelet_identity`,
+  # so the object ID comes from the azapi read of the cluster in aks.tf.
+  principal_id = local.aks_kubelet_object_id
+}
+
+###############################################################################
+# Operator image-builder roles (from the awesome-aks demo). Without these the
+# operator's ACR image-build backend fails: it pushes built images (AcrPush)
+# and drives ACR Tasks builds (Container Registry Tasks Contributor).
+###############################################################################
+resource "azurerm_role_assignment" "operator_acr_push" {
+  count = var.enable_acr ? 1 : 0
+
+  scope                            = azurerm_container_registry.acr[0].id
+  role_definition_name             = "AcrPush"
+  principal_id                     = azurerm_user_assigned_identity.anyscale_operator.principal_id
+  skip_service_principal_aad_check = true
+}
+
+resource "azurerm_role_assignment" "operator_acr_tasks" {
+  count = var.enable_acr ? 1 : 0
+
+  scope                            = azurerm_container_registry.acr[0].id
+  role_definition_name             = "Container Registry Tasks Contributor"
+  principal_id                     = azurerm_user_assigned_identity.anyscale_operator.principal_id
+  skip_service_principal_aad_check = true
+}

--- a/examples/azure/anyscale-on-azure-aks-automatic/aks.tf
+++ b/examples/azure/anyscale-on-azure-aks-automatic/aks.tf
@@ -1,0 +1,371 @@
+###############################################################################
+# AKS AUTOMATIC CLUSTER
+#
+# `azurerm_kubernetes_automatic_cluster` (azurerm >= 4.81.0) is a deliberately
+# small resource, because AKS Automatic decides most of what the `new-aks`
+# sibling configures by hand:
+#
+#   * Azure CNI overlay + Cilium dataplane and network policy — always on.
+#   * Node Auto Provisioning (managed Karpenter) — always on. There is no
+#     `default_node_pool` block and no `azurerm_kubernetes_cluster_node_pool`
+#     anywhere in this stack; workload capacity comes from the built-in
+#     `default` Karpenter NodePool, and GPU capacity from the NodePool CRs
+#     rendered by gpu.tf.
+#   * A managed system node pool, auto-upgrade channels, and node OS patching.
+#   * Entra ID authentication with Kubernetes RBAC, local accounts DISABLED.
+#   * Azure Policy with deployment safeguards in **Enforcement** — see the
+#     exclusion patch further down, which the Anyscale operator depends on.
+#   * Standard SKU tier (this is not a Free-tier cluster).
+#
+# What is left to declare: where it lives on the network, who it runs as, and
+# that we want the app-routing Istio Gateway API implementation.
+###############################################################################
+
+locals {
+  # Shared by the azapi patches and the kubelet-identity read below.
+  # Bump together.
+  aks_preview_api_version = "2026-03-02-preview"
+
+  # AKS Automatic ships the app-routing Istio Gateway API implementation; the
+  # GatewayClass it registers is named `approuting-istio`. This replaces the
+  # Envoy Gateway Helm release + custom `GatewayClass eg` from `new-aks`.
+  app_routing_gateway_class_name = "approuting-istio"
+}
+
+#trivy:ignore:avd-azu-0040
+#trivy:ignore:avd-azu-0041
+#trivy:ignore:avd-azu-0042
+resource "azurerm_kubernetes_automatic_cluster" "aks" {
+
+  #checkov:skip=CKV_AZURE_115: "Ensure that AKS enables private clusters"
+  #checkov:skip=CKV_AZURE_117: "Ensure that AKS uses disk encryption set"
+  #checkov:skip=CKV_AZURE_6: "Ensure AKS has an API Server Authorized IP Ranges enabled"
+
+  name                = var.aks_cluster_name
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  # BYO VNet ("hosted system"). Both subnets are required together — the
+  # managed system pool and the Karpenter-provisioned user nodes are separated
+  # so a workload node cannot exhaust the address space CoreDNS and the
+  # Karpenter controller need.
+  hosted_system {
+    node_subnet_id        = azurerm_subnet.nodes.id
+    system_node_subnet_id = azurerm_subnet.system_nodes.id
+  }
+
+  # API Server VNet Integration. The control plane's inbound NICs are injected
+  # into the delegated subnet from main.tf. The API server is still reachable
+  # over its public FQDN unless var.api_server_authorized_ip_ranges narrows it
+  # (or private_cluster is enabled below).
+  api_server_access {
+    subnet_id            = azurerm_subnet.apiserver.id
+    authorized_ip_ranges = length(var.api_server_authorized_ip_ranges) > 0 ? var.api_server_authorized_ip_ranges : null
+  }
+
+  # UserAssigned is mandatory for BYO VNet — see the identity comment in
+  # main.tf for why SystemAssigned cannot work here.
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.aks.id]
+  }
+
+  # NO `private_cluster` BLOCK, DELIBERATELY.
+  #
+  # The typed resource supports one, but this example cannot: the bootstrap in
+  # gateway.tf reaches the cluster over the DATA plane (`kubectl apply` against
+  # the API server). Against a private API server that has no route from wherever
+  # Terraform runs, the first apply hangs and you end up with a cluster that has
+  # no namespace, no Gateway, and no operator — a half-built deployment whose
+  # failure mode looks like a network timeout.
+  #
+  # Making it work needs the bootstrap to switch to `az aks command invoke`
+  # (kubectl in an AKS-scheduled pod, streamed through ARM — a control-plane
+  # call that works against a private API server from anywhere `az` works),
+  # plus private DNS and egress handling.
+  #
+  # That is exactly what `anyscale-on-azure-private-aks` already does. Use that
+  # example for private deployments rather than bolting a flag on here.
+  #
+  # For a middle ground, `api_server_authorized_ip_ranges` narrows the public
+  # API server to known egress IPs without breaking the bootstrap.
+
+  # The ingress story. `istio_enabled` registers the `approuting-istio`
+  # GatewayClass and its managed controller — the whole reason gateway.tf has
+  # no Helm release and no GatewayClass of its own.
+  #
+  # App routing has two independent halves: that Istio GatewayClass (wanted)
+  # and a default nginx ingress controller (not wanted — it would stand up a
+  # second PUBLIC load balancer, billed and exposed for nothing). The typed
+  # schema only accepts AnnotationControlled / Internal / External for
+  # `default_nginx_controller`, so switching it off entirely happens in the
+  # azapi patch below.
+  web_app_routing_ingress {
+    istio_enabled = true
+  }
+
+  tags = var.tags
+
+  timeouts {
+    create = "1h"
+    update = "1h"
+    delete = "1h"
+  }
+
+  # The cluster cannot join the BYO subnets until its identity can write to
+  # them. Without this the create fails partway through with a subnet
+  # authorization error.
+  depends_on = [
+    azurerm_role_assignment.aks_network_contributor,
+  ]
+}
+
+###############################################################################
+# KUBELET IDENTITY — read back via azapi.
+#
+# The typed resource exports `identity`, `kube_config`, `oidc_issuer_url`,
+# `node_resource_group_id` and the FQDNs — but NOT `kubelet_identity`, which
+# `acr.tf` needs for the AcrPull assignment. Read it straight off the ARM
+# representation of the cluster instead.
+###############################################################################
+data "azapi_resource" "aks" {
+  type        = "Microsoft.ContainerService/managedClusters@${local.aks_preview_api_version}"
+  resource_id = azurerm_kubernetes_automatic_cluster.aks.id
+
+  response_export_values = ["properties.identityProfile"]
+}
+
+locals {
+  aks_kubelet_object_id = try(
+    data.azapi_resource.aks.output.properties.identityProfile.kubeletidentity.objectId,
+    null,
+  )
+}
+
+###############################################################################
+# CLUSTER ADMIN ACCESS (Entra RBAC).
+#
+# AKS Automatic disables local accounts and enforces Entra RBAC, so a
+# kubeconfig on its own authenticates nothing — the caller also needs an AKS
+# RBAC role. The gateway bootstrap in gateway.tf runs `kubectl` as the
+# signed-in principal, so without these two assignments its very first
+# `kubectl apply` fails with a 403 that reads like a networking problem.
+#
+#   * RBAC Cluster Admin — authorizes the Kubernetes API calls themselves.
+#   * Cluster User Role  — authorizes `az aks get-credentials` (ARM action
+#                          Microsoft.ContainerService/managedClusters/
+#                          listClusterUserCredential/action).
+#
+# Role assignments take a little while to propagate; the bootstrap retries.
+###############################################################################
+resource "azurerm_role_assignment" "current_principal_cluster_admin" {
+  count = var.assign_current_principal_cluster_access ? 1 : 0
+
+  scope                = azurerm_kubernetes_automatic_cluster.aks.id
+  role_definition_name = "Azure Kubernetes Service RBAC Cluster Admin"
+  principal_id         = data.azurerm_client_config.current.object_id
+}
+
+resource "azurerm_role_assignment" "current_principal_cluster_user" {
+  count = var.assign_current_principal_cluster_access ? 1 : 0
+
+  scope                = azurerm_kubernetes_automatic_cluster.aks.id
+  role_definition_name = "Azure Kubernetes Service Cluster User Role"
+  principal_id         = data.azurerm_client_config.current.object_id
+}
+
+# Additional principals (a platform team group, a CI service principal) that
+# should be able to reach the cluster directly.
+resource "azurerm_role_assignment" "cluster_admin" {
+  for_each = var.aks_cluster_admin_principal_ids
+
+  scope                = azurerm_kubernetes_automatic_cluster.aks.id
+  role_definition_name = "Azure Kubernetes Service RBAC Cluster Admin"
+  principal_id         = each.value
+}
+
+###############################################################################
+# PATCH 0 — INGRESS PROFILE: INSTALL GATEWAY API, TURN OFF DEFAULT NGINX.
+#
+# THIS PATCH IS WHAT MAKES THE GATEWAY WORK. Two independent fields, and the
+# typed resource can express neither:
+#
+#   gatewayAPI.installation = "Standard"
+#     Installs the Gateway API CRDs (gateways/httproutes/gatewayclasses).
+#     `web_app_routing_ingress { istio_enabled = true }` does NOT do this — it
+#     only sets webAppRouting.gatewayApiImplementations.appRoutingIstio, which
+#     configures the Istio *implementation* while leaving `ingressProfile.gatewayAPI`
+#     null and the cluster with zero Gateway CRDs. Applying a `Gateway` then
+#     fails with:
+#       no matches for kind "Gateway" in version "gateway.networking.k8s.io/v1"
+#     which reads like the addon is still reconciling, but never resolves.
+#
+#   webAppRouting.nginx.defaultIngressControllerType = "None"
+#     The typed schema only accepts AnnotationControlled / Internal / External,
+#     and its default (AnnotationControlled) makes AKS create an
+#     NginxIngressController whose Service is a PUBLIC load balancer. This
+#     example routes everything through the Istio Gateway, so that controller
+#     is pure cost and exposure. The controller is created during cluster
+#     creation and removed by this patch — a few minutes of an unused public IP
+#     on first apply.
+#
+# Both fields are preview surface and need feature flags on the subscription
+# (see the README prerequisites):
+#   az feature register --namespace Microsoft.ContainerService --name ManagedGatewayAPIPreview
+#   az feature register --namespace Microsoft.ContainerService --name AppRoutingIstioGatewayAPIPreview
+#   az provider register --namespace Microsoft.ContainerService
+#
+# This reconcile is SLOW — 10+ minutes is normal. Everything in-cluster
+# depends on it, which is why terraform_data.cluster_bootstrap depends_on it
+# rather than racing it.
+###############################################################################
+resource "azapi_update_resource" "app_routing" {
+  type        = "Microsoft.ContainerService/managedClusters@${local.aks_preview_api_version}"
+  resource_id = azurerm_kubernetes_automatic_cluster.aks.id
+
+  body = {
+    properties = {
+      ingressProfile = {
+        gatewayAPI = {
+          installation = "Standard"
+        }
+        webAppRouting = {
+          enabled = true
+          gatewayAPIImplementations = {
+            appRoutingIstio = {
+              mode = "Enabled"
+            }
+          }
+          nginx = {
+            defaultIngressControllerType = var.enable_default_nginx_ingress_controller ? "AnnotationControlled" : "None"
+          }
+        }
+      }
+    }
+  }
+
+  timeouts {
+    create = "45m"
+    update = "45m"
+  }
+}
+
+###############################################################################
+# PATCH 1 — MONITORING PROFILE.
+#
+# `azurerm_kubernetes_cluster` has typed `oms_agent` and `monitor_metrics`
+# blocks; `azurerm_kubernetes_automatic_cluster` has neither. The same
+# configuration goes on as an ARM PATCH, which is exactly what the typed blocks
+# would have produced:
+#
+#   addonProfiles.omsagent           → Container Insights → Log Analytics
+#   azureMonitorProfile.metrics      → managed Prometheus (DCE/DCR in
+#                                      prometheus.tf routes it onward)
+#   azureMonitorProfile.appMonitoring→ OTLP auto-instrumentation (preview)
+#
+# MUST BE SERIALIZED AGAINST PATCH 0. Both patches target the SAME
+# managedClusters resource, and ARM does not allow two concurrent writes to a
+# cluster — Terraform runs them in parallel by default and the loser gets:
+#
+#   RESPONSE 409: EtagMismatch
+#   "Operation is not allowed: Another operation is in progress."
+#
+# There is no dependency between the two bodies, so nothing in the graph forces
+# an order; the depends_on below exists purely to serialize the ARM writes.
+# Any future patch against the cluster must join this chain.
+###############################################################################
+resource "azapi_update_resource" "monitoring" {
+  count = var.enable_monitoring ? 1 : 0
+
+  type        = "Microsoft.ContainerService/managedClusters@${local.aks_preview_api_version}"
+  resource_id = azurerm_kubernetes_automatic_cluster.aks.id
+
+  depends_on = [azapi_update_resource.app_routing]
+
+  timeouts {
+    create = "45m"
+    update = "45m"
+  }
+
+  body = {
+    properties = {
+      addonProfiles = {
+        omsagent = {
+          enabled = true
+          config = {
+            logAnalyticsWorkspaceResourceID = azurerm_log_analytics_workspace.logs[0].id
+            useAADAuth                      = "true"
+          }
+        }
+      }
+      azureMonitorProfile = merge(
+        {
+          metrics = {
+            enabled = true
+            kubeStateMetrics = {
+              metricAnnotationsAllowList = ""
+              metricLabelsAllowlist      = ""
+            }
+          }
+          containerInsights = {
+            enabled                         = true
+            logAnalyticsWorkspaceResourceId = azurerm_log_analytics_workspace.logs[0].id
+          }
+        },
+        # OTLP auto-instrumentation points the cluster at the App Insights
+        # component created in monitoring.tf.
+        var.enable_otlp_app_insights ? {
+          appMonitoring = {
+            autoInstrumentation  = { enabled = true }
+            openTelemetryMetrics = { enabled = true }
+            openTelemetryLogs    = { enabled = true }
+          }
+        } : {},
+      )
+    }
+  }
+}
+
+###############################################################################
+# PATCH 2 — DEPLOYMENT SAFEGUARDS EXCLUSION.  ← DO NOT SKIP THIS.
+#
+# AKS Automatic turns on Azure Policy with deployment safeguards in
+# **Enforcement** level. Among other things that mutates/denies workloads that
+# do not set resource limits, run as non-root, or use `latest` tags.
+#
+# The Anyscale operator does not satisfy those constraints: it runs an init
+# container with elevated capabilities, and the Ray pods it creates are shaped
+# by the Anyscale control plane, not by this Terraform. Left in Enforcement
+# over the Anyscale namespaces, admission rejects the operator's pods and the
+# cloud never becomes usable — the failure surfaces as an operator deployment
+# stuck at 0/1 replicas, not as a policy error, so it is easy to misdiagnose.
+#
+# This PATCHes the existing safeguards object (AKS Automatic always creates
+# one) to exclude the Anyscale namespaces. If a first real workload run turns
+# up other namespaces being rejected, widen the list via the variable rather
+# than dropping the safeguards level.
+#
+# NOTE ON THE RESOURCE SHAPE: `deploymentSafeguards` is an EXTENSION resource,
+# not a child of managedClusters — the RP lists it as a root-level type, so it
+# is addressed as `<cluster-id>/providers/Microsoft.ContainerService/
+# deploymentSafeguards/default`. Getting this wrong produces a 404 on an
+# otherwise correct-looking patch. Verify with:
+#   az provider show -n Microsoft.ContainerService \
+#     --query "resourceTypes[?resourceType=='deploymentSafeguards']"
+###############################################################################
+resource "azapi_update_resource" "deployment_safeguards" {
+  count = var.enable_deployment_safeguards_exclusion ? 1 : 0
+
+  type        = "Microsoft.ContainerService/deploymentSafeguards@${var.deployment_safeguards_api_version}"
+  resource_id = "${azurerm_kubernetes_automatic_cluster.aks.id}/providers/Microsoft.ContainerService/deploymentSafeguards/default"
+
+  body = {
+    properties = {
+      level = var.deployment_safeguards_level
+      excludedNamespaces = distinct(concat(
+        [var.anyscale_operator_namespace],
+        var.deployment_safeguards_excluded_namespaces,
+      ))
+    }
+  }
+}

--- a/examples/azure/anyscale-on-azure-aks-automatic/anyscale.tf
+++ b/examples/azure/anyscale-on-azure-aks-automatic/anyscale.tf
@@ -1,0 +1,347 @@
+###############################################################################
+# Anyscale Azure-managed control plane.
+#
+# Two Azure Resource Provider integrations turn the AKS cluster into an
+# Anyscale-managed cloud:
+#
+#   1. `Anyscale.Platform/clouds` (+ `clouds/cloudResources`) — registers the
+#      cloud with the Azure-hosted Anyscale control plane at
+#      https://console.azure.anyscale.com and produces a stable `cldrsrc_…` ID.
+#      Created NATIVELY via azapi rather than through an ARM-template
+#      deployment wrapper — the cloud is a first-class object in Terraform
+#      state, so create/destroy ordering falls out of the dependency graph.
+#
+#   2. `Microsoft.KubernetesConfiguration/extensions` with extension type
+#      `Anyscale.AKS.Operator` — installs the operator marketplace extension
+#      into the cluster and wires it to the cloud above. The operator
+#      authenticates to the control plane via Microsoft Entra workload
+#      identity, NOT a CLI token.
+#
+# This file is near-identical to its `new-aks` counterpart. AKS Automatic
+# changes exactly two things: the gateway class name, and the fact that the
+# in-cluster prerequisites arrive via the bootstrap local-exec rather than the
+# kubectl provider.
+###############################################################################
+
+locals {
+  anyscale_cloud_name = coalesce(var.anyscale_cloud_name, "${var.aks_cluster_name}-cloud")
+  # The Anyscale cloud always lives in the deployment's resource group, even
+  # when local.anyscale_cloud_location differs from the cluster's region.
+  anyscale_cloud_arm_id = "${azurerm_resource_group.rg.id}/providers/Anyscale.Platform/clouds/${local.anyscale_cloud_name}"
+
+  # Common operator-side extension settings. The toleration defaults match the
+  # taints set by the Karpenter GPU NodePools in gpu.tf — the same taints the
+  # `new-aks` sibling puts on its static GPU node pools, so this block is
+  # unchanged between the two stacks.
+  anyscale_extension_configuration_defaults = {
+    "workloads.accelerator.tolerations.default[0].key"      = "node.anyscale.com/accelerator-type"
+    "workloads.accelerator.tolerations.default[0].value"    = "GPU"
+    "workloads.accelerator.tolerations.default[0].effect"   = "NoSchedule"
+    "workloads.accelerator.tolerations.default[1].key"      = "nvidia.com/gpu"
+    "workloads.accelerator.tolerations.default[1].operator" = "Exists"
+    "workloads.accelerator.tolerations.default[1].effect"   = "NoSchedule"
+    "workloads.instanceTypes.enableDefaults"                = "true"
+  }
+
+  anyscale_extension_configuration_settings = merge(
+    local.anyscale_extension_configuration_defaults,
+    var.anyscale_platform.extension_configuration_settings,
+  )
+}
+
+###############################################################################
+# Step 1a: the Anyscale.Platform/clouds resource.
+###############################################################################
+resource "azapi_resource" "anyscale_cloud" {
+  type      = "Anyscale.Platform/clouds@${var.anyscale_platform.clouds_api_version}"
+  parent_id = azurerm_resource_group.rg.id
+  location  = local.anyscale_cloud_location
+  name      = local.anyscale_cloud_name
+
+  # required while the azapi local schema catalog lags the preview API version
+  schema_validation_enabled = false
+
+  body = {
+    properties = var.enable_acr ? {
+      acrResourceId = azurerm_container_registry.acr[0].id
+    } : {}
+  }
+
+  tags = merge(var.tags, { "anyscale-cloud" = local.anyscale_cloud_name })
+
+  response_export_values = [
+    "properties.ssoUrl",
+  ]
+
+  depends_on = [
+    azurerm_kubernetes_automatic_cluster.aks,
+  ]
+}
+
+###############################################################################
+# Step 1b: the cloudResources child — binds the cloud to this deployment's
+# storage (as ADLS Gen2 via abfss://) and the operator's managed identity.
+###############################################################################
+resource "azapi_resource" "anyscale_cloud_resource" {
+  type      = "Anyscale.Platform/clouds/cloudResources@${var.anyscale_platform.clouds_api_version}"
+  parent_id = azapi_resource.anyscale_cloud.id
+  location  = local.anyscale_cloud_location
+  name      = "default"
+
+  schema_validation_enabled = false
+
+  body = {
+    properties = {
+      provider                    = "Azure"
+      computeStack                = "K8S"
+      cloudStorageBucketEndpoint  = azurerm_storage_account.sa.primary_blob_endpoint
+      cloudStorageBucketName      = "abfss://${azurerm_storage_container.blob.name}@${azurerm_storage_account.sa.primary_dfs_host}"
+      anyscaleOperatorIamIdentity = azurerm_user_assigned_identity.anyscale_operator.principal_id
+    }
+  }
+
+  tags = merge(var.tags, { "anyscale-cloud" = local.anyscale_cloud_name })
+
+  response_export_values = [
+    "properties.cloudResourceId",
+  ]
+
+  depends_on = [
+    azurerm_kubernetes_automatic_cluster.aks,
+    azurerm_role_assignment.anyscale_blob_contrib,
+    azurerm_federated_identity_credential.anyscale_operator_fic,
+  ]
+}
+
+# The cloudResources child exports `cloudResourceId` (e.g. `cldrsrc_abcd…`).
+# The Anyscale operator names its TLS Secret resources — and this stack names
+# the gateway's public DNS label — using the hyphenated form of this ID.
+locals {
+  anyscale_cloud_resource_id            = azapi_resource.anyscale_cloud_resource.output.properties.cloudResourceId
+  anyscale_cloud_resource_id_hyphenated = replace(local.anyscale_cloud_resource_id, "_", "-")
+
+  anyscale_gateway_certificate_secret_name         = "anyscale-${local.anyscale_cloud_resource_id_hyphenated}-certificate"
+  anyscale_gateway_service_certificate_secret_name = "anyscale-svc-${local.anyscale_cloud_resource_id_hyphenated}-certificate"
+}
+
+###############################################################################
+# Team access: "Anyscale Platform Contributor" on the cloud resource.
+#
+# Azure subscription Owner/Contributor does NOT grant the ability to create
+# Anyscale workspaces/jobs/services — that requires this Anyscale-provider
+# role assigned ON the Anyscale.Platform/clouds resource itself. Optional:
+# populate var.anyscale_platform_contributors to assign it from Terraform,
+# or do it later via the portal (cloud resource > Access control (IAM)).
+#
+# NOTE: "Anyscale Platform Contributor" is a role definition published by the
+# Anyscale.Platform RP and resolved by name at the cloud scope. If name
+# resolution ever fails in your tenant, swap role_definition_name for
+# role_definition_id with the role's full definition ID.
+###############################################################################
+resource "azurerm_role_assignment" "anyscale_platform_contributor" {
+  for_each = { for c in var.anyscale_platform_contributors : c.principal_id => c }
+
+  scope = azapi_resource.anyscale_cloud.id
+  # Exact role definition name published by the Anyscale.Platform RP — note the
+  # trailing "Role" (the portal label drops it, but the role definition keeps it).
+  # Other options: "Anyscale Platform Administrator Role", "Anyscale Platform Reader Role".
+  role_definition_name = "Anyscale Platform Contributor Role"
+  principal_id         = each.value.principal_id
+  principal_type       = each.value.principal_type
+}
+
+###############################################################################
+# Self-grant: give the principal running Terraform (the signed-in `az` user)
+# both the Contributor and Reader platform roles on the cloud resource.
+#
+# Subscription Owner/Contributor does NOT carry over to the Anyscale RP, so the
+# operator running the deploy still can't open the cloud in the console or
+# create workspaces/jobs/services until these are assigned.
+#
+# Implemented as a local-exec so "whoever is running the apply" gets access
+# without having to look up their own object ID first. Trade-off: not tracked
+# in state and not removed on destroy (the assignments disappear with the
+# cloud resource anyway). Authentication reuses the same `az login` Terraform
+# already depends on.
+#
+# `az role assignment create` is idempotent (re-running returns the existing
+# assignment), and we retry briefly to ride out Entra principal-replication lag.
+###############################################################################
+resource "terraform_data" "anyscale_platform_self_grant" {
+  count = var.assign_current_user_platform_roles ? 1 : 0
+
+  triggers_replace = {
+    cloud_arm_id = local.anyscale_cloud_arm_id
+    subscription = var.azure_subscription_id
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-EOT
+      set -euo pipefail
+      az account set --subscription "${var.azure_subscription_id}"
+      ASSIGNEE="$(az ad signed-in-user show --query id -o tsv)"
+      SCOPE="${local.anyscale_cloud_arm_id}"
+      for ROLE in "Anyscale Platform Contributor Role" "Anyscale Platform Reader Role"; do
+        echo "[anyscale] Granting '$ROLE' to $ASSIGNEE on $SCOPE"
+        for attempt in 1 2 3 4 5; do
+          if az role assignment create \
+              --assignee "$ASSIGNEE" \
+              --role "$ROLE" \
+              --scope "$SCOPE" \
+              --only-show-errors >/dev/null; then
+            break
+          fi
+          if [ "$attempt" -eq 5 ]; then
+            echo "[anyscale] ERROR: failed to assign '$ROLE' after $attempt attempts" >&2
+            exit 1
+          fi
+          echo "[anyscale] assign '$ROLE' attempt $attempt failed (principal replication?); retrying in 15s..."
+          sleep 15
+        done
+      done
+      echo "[anyscale] Platform role grants complete."
+    EOT
+  }
+
+  depends_on = [azapi_resource.anyscale_cloud]
+}
+
+###############################################################################
+# Step 2: install the Anyscale.AKS.Operator marketplace extension.
+#
+# The gateway hostname is DETERMINISTIC on the public path — a DNS label
+# derived from the cloud resource ID is stamped onto the gateway LB service
+# (see gateway.tf), so `networking.gateway.hostname` is computable at plan
+# time and no `az k8s-extension update` follow-up (or LB polling) is needed.
+#
+# `networking.gateway.className` is the one Automatic-specific value here:
+# `approuting-istio`, the GatewayClass AKS registers for us, in place of the
+# `eg` class the `new-aks` sibling creates alongside its Envoy Gateway chart.
+#
+# IMPORTANT: configuration_protected_settings explicitly sets the CLI token to
+# the empty string. Omitting the key entirely is NOT enough — the AKS extension
+# PATCH semantics treat a missing key as "leave previous value in place", so
+# any earlier value would persist in the Helm release. With this field forced
+# empty, the operator falls through to the Microsoft Entra workload-identity
+# exchange (UAMI federated to the AKS OIDC issuer, registered as the cloud's
+# operator principal by the cloudResources child).
+###############################################################################
+resource "azurerm_kubernetes_cluster_extension" "anyscale_operator" {
+  name              = var.anyscale_platform.extension_resource_name
+  cluster_id        = azurerm_kubernetes_automatic_cluster.aks.id
+  extension_type    = "Anyscale.AKS.Operator"
+  release_train     = var.anyscale_platform.release_train
+  release_namespace = var.anyscale_operator_namespace
+
+  plan {
+    name      = var.anyscale_platform.plan_name
+    publisher = var.anyscale_platform.plan_publisher
+    product   = var.anyscale_platform.plan_product
+  }
+
+  configuration_settings = merge(
+    {
+      "global.cloudDeploymentId"      = local.anyscale_cloud_resource_id
+      "global.controlPlaneURL"        = var.anyscale_platform.control_plane_url
+      "global.auth.iamIdentity"       = azurerm_user_assigned_identity.anyscale_operator.client_id
+      "global.auth.audience"          = var.anyscale_platform.auth_audience
+      "workloads.serviceAccount.name" = var.anyscale_operator_serviceaccount
+
+      # Gateway integration — these come from gateway.tf.
+      "networking.gateway.enabled"    = "true"
+      "networking.gateway.name"       = var.gateway.name
+      "networking.gateway.className"  = local.app_routing_gateway_class_name
+      "networking.gateway.namespace"  = var.anyscale_operator_namespace
+      "networking.gateway.apiVersion" = "gateway.networking.k8s.io/v1"
+      "networking.gateway.hostname"   = local.gateway_hostname
+    },
+    local.anyscale_extension_configuration_settings,
+  )
+
+  configuration_protected_settings = {
+    "global.auth.anyscaleCliToken" = ""
+  }
+
+  depends_on = [
+    azapi_resource.anyscale_cloud_resource,
+    azurerm_federated_identity_credential.anyscale_operator_fic,
+    # The namespace, the Gateway, and the deployment-safeguards exclusion all
+    # have to be in place before the operator's pods are admitted.
+    terraform_data.cluster_bootstrap,
+    azapi_update_resource.deployment_safeguards,
+  ]
+}
+
+###############################################################################
+# Destroy ordering: delete the Anyscale cloud BEFORE the operator extension
+# and the AKS cluster.
+#
+# WHY THIS EXISTS even with native azapi cloud resources: Terraform's destroy
+# order is the reverse of the dependency graph, so the extension (which
+# depends on the cloud) would be uninstalled FIRST — and with the operator
+# gone, the Anyscale control plane rejects the cloud delete with a 409
+# ("has N associated Clusters that are still active") until its bookkeeping
+# drains, wedging the destroy. Upstream awesome-aks has no equivalent hook and
+# does wedge.
+#
+# Because this resource depends_on the AKS cluster, the extension AND the
+# cloud resources, Terraform destroys it before all of them (running the
+# when=destroy provisioner). The operator is therefore still alive to drain
+# its sessions while the cloud is deleted via the CLI. The subsequent azapi
+# destroys of the already-deleted cloud resources are no-ops (ARM returns
+# 204 for DELETE on a nonexistent resource).
+#
+# The provisioner deletes the cloudResources/default child first (the parent
+# cannot be removed while nested resources exist), then the cloud itself,
+# retrying until the control plane finishes draining or the timeout elapses.
+# Authentication uses the same `az` login Terraform already relies on.
+###############################################################################
+resource "terraform_data" "anyscale_cloud_predelete" {
+  input = {
+    cloud_arm_id    = local.anyscale_cloud_arm_id
+    timeout_seconds = 900
+    poll_interval   = 20
+  }
+
+  provisioner "local-exec" {
+    when        = destroy
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-EOT
+      set -uo pipefail
+      CLOUD="${self.input.cloud_arm_id}"
+      echo "[anyscale] Deleting Anyscale cloud before AKS teardown: $CLOUD"
+      deadline=$(( $(date +%s) + ${self.input.timeout_seconds} ))
+      err="$(mktemp)"
+      while :; do
+        # Child must go before the parent cloud resource.
+        az resource delete --ids "$CLOUD/cloudResources/default" --only-show-errors >/dev/null 2>&1 || true
+        if az resource delete --ids "$CLOUD" --only-show-errors >/dev/null 2>"$err"; then
+          echo "[anyscale] Cloud deleted."
+          break
+        fi
+        if grep -qiE "not.?found|does not exist|could not be found" "$err"; then
+          echo "[anyscale] Cloud already gone."
+          break
+        fi
+        if [ "$(date +%s)" -ge "$deadline" ]; then
+          echo "[anyscale] ERROR: timed out deleting cloud after ${self.input.timeout_seconds}s" >&2
+          cat "$err" >&2
+          exit 1
+        fi
+        echo "[anyscale] Cloud delete pending (control plane draining sessions); retry in ${self.input.poll_interval}s..."
+        sleep ${self.input.poll_interval}
+      done
+    EOT
+  }
+
+  # depends_on makes Terraform destroy THIS resource (running the hook) before
+  # the extension, the cloud resources, and the cluster — keeping the operator
+  # alive during the cloud delete.
+  depends_on = [
+    azurerm_kubernetes_automatic_cluster.aks,
+    azurerm_kubernetes_cluster_extension.anyscale_operator,
+    azapi_resource.anyscale_cloud,
+    azapi_resource.anyscale_cloud_resource,
+  ]
+}

--- a/examples/azure/anyscale-on-azure-aks-automatic/azure-login.sh
+++ b/examples/azure/anyscale-on-azure-aks-automatic/azure-login.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Azure CLI login and (optionally) select a subscription.
+# Anyscale operator marketplace offer (create directly in the portal):
+#   https://portal.azure.com/#create/anyscale1750870039553.anyscale-operator-aksanyscale-operator
+#
+# Usage:
+#   ./azure-login.sh                 # log in, keep the default subscription
+#   ./azure-login.sh <sub-id|name>   # log in and switch to that subscription
+#   AZURE_SUBSCRIPTION=<sub> ./azure-login.sh
+
+set -euo pipefail
+
+if ! command -v az &>/dev/null; then
+  echo "az not found. Install the Azure CLI first: https://learn.microsoft.com/cli/azure/install-azure-cli"
+  exit 1
+fi
+
+# Subscription is optional: pass it as the first arg or via AZURE_SUBSCRIPTION.
+# Nothing is hard-coded — if unset, the CLI's current default is kept.
+SUBSCRIPTION="${1:-${AZURE_SUBSCRIPTION:-}}"
+
+echo ">>> Signing in to Azure (a browser window will open)..."
+az login >/dev/null
+
+if [[ -n "$SUBSCRIPTION" ]]; then
+  echo ">>> Selecting subscription: $SUBSCRIPTION"
+  az account set --subscription "$SUBSCRIPTION"
+fi
+
+echo ""
+echo "Active subscription:"
+az account show --query '{name:name, id:id, tenant:tenantId}' -o table
+echo ""
+echo "Anyscale operator offer: https://portal.azure.com/#create/anyscale1750870039553.anyscale-operator-aksanyscale-operator"

--- a/examples/azure/anyscale-on-azure-aks-automatic/diagnose-head-pod.sh
+++ b/examples/azure/anyscale-on-azure-aks-automatic/diagnose-head-pod.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Capture WHY the Anyscale head pod won't schedule on AKS.
+# Run this, THEN start the workspace in the Anyscale UI. It waits for the
+# Ray head pod to appear, then dumps the scheduling decision + autoscaler reason.
+set -uo pipefail
+
+# Write captured logs to a gitignored diagnostics/ folder next to this script.
+OUT="$(cd "$(dirname "$0")" && pwd)/diagnostics"
+mkdir -p "$OUT"
+echo "Writing diagnostics to: $OUT"
+
+echo "==> Waiting for a Ray/Anyscale workload pod to appear (start the workspace now)..."
+POD=""; NS=""
+for i in $(seq 1 240); do   # up to ~20 min
+  read -r NS POD <<<"$(kubectl get pods -A -o jsonpath='{range .items[?(@.metadata.labels.ray\.io/node-type)]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' 2>/dev/null | head -1)"
+  if [ -z "$POD" ]; then
+    # fall back: any pending pod outside system namespaces
+    read -r NS POD <<<"$(kubectl get pods -A --field-selector status.phase=Pending -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' 2>/dev/null | grep -viE '^(kube-system|aks-istio-system|app-routing-system|gatekeeper-system|anyscale-operator) ' | head -1)"
+  fi
+  [ -n "$POD" ] && break
+  sleep 5
+done
+
+if [ -z "$POD" ]; then
+  echo "No workload pod found. Capturing operator logs + cluster events instead."
+  kubectl logs -n anyscale-operator -l app.kubernetes.io/name=anyscale-operator --tail=200 --all-containers >"$OUT/operator_logs.log" 2>&1
+  kubectl get events -A --sort-by=.lastTimestamp | tail -60 >"$OUT/events.log" 2>&1
+  echo "Saved operator_logs.log + events.log"
+  exit 0
+fi
+
+echo "==> Found pod: $NS/$POD"
+kubectl describe pod -n "$NS" "$POD"            >"$OUT/head_pod_describe.log" 2>&1
+kubectl get pod -n "$NS" "$POD" -o yaml         >"$OUT/head_pod.yaml"         2>&1
+
+echo "==> Scheduling constraints actually applied to the pod:"
+kubectl get pod -n "$NS" "$POD" -o jsonpath='{"--- requests ---\n"}{range .spec.containers[*]}{.name}{": "}{.resources.requests}{"\n"}{end}{"--- nodeSelector ---\n"}{.spec.nodeSelector}{"\n--- tolerations ---\n"}{range .spec.tolerations[*]}{.key}{"="}{.value}{":"}{.effect}{"\n"}{end}{"--- nodeAffinity ---\n"}{.spec.affinity.nodeAffinity}{"\n"}' | tee "$OUT/head_pod_constraints.txt"
+
+echo; echo "==> Autoscaler scale-up decision (look for NotTriggerScaleUp / predicate failures):"
+kubectl get events -A --field-selector reason=NotTriggerScaleUp --sort-by=.lastTimestamp 2>/dev/null | tail -20 | tee "$OUT/notriggerscaleup.log"
+kubectl get events -n "$NS" --sort-by=.lastTimestamp 2>/dev/null | tail -30 >"$OUT/pod_events.log"
+kubectl get configmap -n kube-system cluster-autoscaler-status -o yaml >"$OUT/ca_status.log" 2>&1
+
+echo; echo "==> Key line from describe (FailedScheduling):"
+grep -iE "FailedScheduling|untolerated|didn't match|Insufficient|scale up|nodeAffinity" "$OUT/head_pod_describe.log" | tail -15
+
+echo; echo "Done. Share these files: head_pod_describe.log, head_pod_constraints.txt, notriggerscaleup.log"

--- a/examples/azure/anyscale-on-azure-aks-automatic/gateway.tf
+++ b/examples/azure/anyscale-on-azure-aks-automatic/gateway.tf
@@ -1,0 +1,370 @@
+###############################################################################
+# GATEWAY + IN-CLUSTER BOOTSTRAP.
+#
+# The Anyscale Azure-managed control plane routes workspace and service traffic
+# through an in-cluster Gateway API `Gateway` exposed via an Azure Standard
+# load balancer. The Anyscale operator (installed by anyscale.tf) creates the
+# TLS Secret resources the HTTPS listeners reference.
+#
+# WHAT AUTOMATIC REMOVES: the `new-aks` sibling installs the Envoy Gateway Helm
+# chart, an `EnvoyProxy` config object, and a `GatewayClass eg`. None of that
+# exists here — `web_app_routing_ingress { istio_enabled = true }` on the
+# cluster (aks.tf) makes AKS install and manage the Istio Gateway API
+# controller and register the `approuting-istio` GatewayClass. Only the
+# namespace and the `Gateway` itself are ours to create.
+#
+# THE HOSTNAME TRICK (kept from upstream awesome-aks and from `new-aks`): the
+# gateway's LB service carries a `service.beta.kubernetes.io/azure-dns-label-name`
+# annotation derived from the Anyscale cloud resource ID, so its public
+# hostname is DETERMINISTIC:
+#
+#   <cldrsrc-id-hyphenated>.<region>.cloudapp.azure.com
+#
+# That makes `networking.gateway.hostname` computable before the LB exists — no
+# LB polling, no `az k8s-extension update` follow-up. The polling path survives
+# only behind var.internal_gateway (internal LBs get a private IP and no public
+# DNS label).
+#
+# WHERE THE ANNOTATIONS GO: with a managed Istio GatewayClass there is no
+# `EnvoyProxy` to hang LB annotations on — the controller derives the Service
+# from the Gateway, so the annotations ride on `spec.infrastructure.annotations`
+# (Gateway API v1.1+). This is upstream's placement.
+###############################################################################
+
+locals {
+  gateway_public_hostname = "${local.anyscale_cloud_resource_id_hyphenated}.${var.azure_location}.cloudapp.azure.com"
+
+  # What the operator extension registers with the Anyscale control plane.
+  gateway_hostname = var.internal_gateway ? data.external.gateway_lb[0].result.address : local.gateway_public_hostname
+
+  # NOTE: the `anyscale-on-azure-private-aks` sibling sets
+  # `gateway.istio.io/name-override` here to keep the generated Service name
+  # short. Deliberately NOT carried over: on this path the annotation lives on
+  # `spec.infrastructure.annotations`, and the managed Istio controller does
+  # not honour its own annotations from there — verified on a real deploy,
+  # where the Service came up as `gateway-approuting-istio` regardless. The
+  # generated name is well inside the 63-char label limit, so the override
+  # bought nothing but the false impression that it was doing something.
+  # (The `service.beta.kubernetes.io/*` annotations below DO propagate.)
+  gateway_infrastructure_annotations = merge(
+    {
+      "service.beta.kubernetes.io/azure-load-balancer-internal" = var.internal_gateway ? "true" : "false"
+    },
+    # DNS labels only apply to public LB frontends.
+    var.internal_gateway ? {} : {
+      "service.beta.kubernetes.io/azure-dns-label-name" = local.anyscale_cloud_resource_id_hyphenated
+    },
+  )
+
+  ###############################################################################
+  # Rendered manifests.
+  #
+  # These are plain strings in Terraform state, written to disk next to the
+  # module (gitignored) so they can be inspected, diffed, and re-applied by hand
+  # during triage. The bootstrap below applies them in order.
+  ###############################################################################
+  namespace_manifest = yamlencode({
+    apiVersion = "v1"
+    kind       = "Namespace"
+    metadata = {
+      name = var.anyscale_operator_namespace
+      # The Anyscale operator runs an init container that needs elevated
+      # capabilities, so the namespace must sit on the privileged Pod Security
+      # profile. Baseline/restricted blocks the operator pod at admission.
+      labels = {
+        "pod-security.kubernetes.io/enforce" = "privileged"
+      }
+    }
+  })
+
+  gateway_manifest = yamlencode({
+    apiVersion = "gateway.networking.k8s.io/v1"
+    kind       = "Gateway"
+    metadata = {
+      name      = var.gateway.name
+      namespace = var.anyscale_operator_namespace
+    }
+    spec = {
+      gatewayClassName = local.app_routing_gateway_class_name
+      infrastructure = {
+        annotations = local.gateway_infrastructure_annotations
+      }
+      listeners = [
+        {
+          name     = "http"
+          port     = 80
+          protocol = "HTTP"
+          allowedRoutes = {
+            namespaces = { from = "Same" }
+          }
+        },
+        {
+          name     = "https"
+          port     = 443
+          protocol = "HTTPS"
+          hostname = "*.i.azure.anyscaleuserdata.com"
+          tls = {
+            mode = "Terminate"
+            certificateRefs = [{
+              kind = "Secret"
+              name = local.anyscale_gateway_certificate_secret_name
+            }]
+          }
+          allowedRoutes = {
+            namespaces = { from = "Same" }
+          }
+        },
+        {
+          name     = "https-session"
+          port     = 443
+          protocol = "HTTPS"
+          hostname = "*.s.azure.anyscaleuserdata.com"
+          tls = {
+            mode = "Terminate"
+            certificateRefs = [{
+              kind = "Secret"
+              name = local.anyscale_gateway_service_certificate_secret_name
+            }]
+          }
+          allowedRoutes = {
+            namespaces = { from = "Same" }
+          }
+        },
+      ]
+    }
+  })
+
+  kubeconfig_path = "${path.module}/.kubeconfig"
+}
+
+resource "local_file" "namespace_manifest" {
+  filename        = "${path.module}/anyscale-namespace.yaml"
+  file_permission = "0600"
+  content         = local.namespace_manifest
+}
+
+resource "local_file" "gateway_manifest" {
+  filename        = "${path.module}/anyscale-gateway.yaml"
+  file_permission = "0600"
+  content         = local.gateway_manifest
+}
+
+###############################################################################
+# THE BOOTSTRAP — one local-exec, three kubectl applies.
+#
+# `new-aks` does this with the kubernetes/kubectl/helm providers authenticated
+# from the cluster's admin client certificate. AKS Automatic issues no such
+# certificate: local accounts are disabled, Entra RBAC is enforced. So:
+#
+#   az aks get-credentials --file ./.kubeconfig     # Entra-flavoured kubeconfig
+#   kubelogin convert-kubeconfig -l azurecli        # swap the exec plugin for
+#                                                   # the az CLI token provider
+#   kubectl apply …                                 # namespace → gateway → GPU
+#
+# ISOLATED KUBECONFIG: `--file ./.kubeconfig` (gitignored) instead of
+# ~/.kube/config. Nothing this stack does can disturb the operator's other
+# cluster contexts, and no stale context can be picked up here.
+#
+# `-l azurecli` reuses the `az login` Terraform already depends on — no device
+# code prompt mid-apply, which `-l devicelogin` would produce.
+#
+# The retry loop absorbs Entra role-assignment propagation (a fresh
+# "RBAC Cluster Admin" grant can take a minute or two to be honoured by the
+# API server) and the app-routing addon still reconciling its GatewayClass.
+#
+# `triggers_replace` keys on the rendered manifest CONTENT, so editing a
+# listener or an annotation re-applies. kubectl apply is idempotent.
+###############################################################################
+resource "terraform_data" "cluster_bootstrap" {
+  triggers_replace = {
+    cluster_id         = azurerm_kubernetes_automatic_cluster.aks.id
+    namespace_manifest = local.namespace_manifest
+    gateway_manifest   = local.gateway_manifest
+    gpu_manifest       = local.gpu_nodepool_manifest
+  }
+
+  input = {
+    subscription   = var.azure_subscription_id
+    resource_group = azurerm_resource_group.rg.name
+    cluster_name   = azurerm_kubernetes_automatic_cluster.aks.name
+    kubeconfig     = local.kubeconfig_path
+    namespace_file = local_file.namespace_manifest.filename
+    gateway_file   = local_file.gateway_manifest.filename
+    gpu_file       = length(var.gpu_nodepool_configs) > 0 ? local_file.gpu_nodepool_manifest[0].filename : ""
+    namespace      = var.anyscale_operator_namespace
+    gateway_class  = local.app_routing_gateway_class_name
+    api_timeout    = var.gateway.api_ready_timeout_seconds
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-EOT
+      set -euo pipefail
+
+      for bin in az kubectl kubelogin; do
+        command -v "$bin" >/dev/null 2>&1 || {
+          echo "[bootstrap] ERROR: '$bin' not found on PATH." >&2
+          echo "[bootstrap] Install kubectl and kubelogin with: az aks install-cli" >&2
+          exit 1
+        }
+      done
+
+      az account set --subscription "${self.input.subscription}"
+
+      export KUBECONFIG="${self.input.kubeconfig}"
+      echo "[bootstrap] fetching an isolated kubeconfig (not ~/.kube/config)"
+      az aks get-credentials \
+        --resource-group "${self.input.resource_group}" \
+        --name "${self.input.cluster_name}" \
+        --file "${self.input.kubeconfig}" \
+        --overwrite-existing \
+        --only-show-errors
+
+      # AKS Automatic hands back an Entra kubeconfig whose default exec plugin
+      # is the deprecated azure auth provider. Convert it to kubelogin's
+      # azurecli mode so it reuses the token `az` already holds.
+      kubelogin convert-kubeconfig -l azurecli --kubeconfig "${self.input.kubeconfig}"
+
+      # Wait for the Gateway API surface to actually exist before applying a
+      # Gateway. The ingressProfile PATCH returns once ARM accepts it, but the
+      # CRDs and the GatewayClass land in the cluster minutes later. Blind
+      # retries are the wrong tool here — they cannot distinguish "still
+      # reconciling" from "gatewayAPI.installation was never set", which is a
+      # config error that no amount of retrying fixes.
+      wait_for() {
+        local label="$1" deadline
+        shift
+        deadline=$(( $(date +%s) + ${self.input.api_timeout} ))
+        until "$@" >/dev/null 2>&1; do
+          if [ "$(date +%s)" -ge "$deadline" ]; then
+            echo "[bootstrap] ERROR: timed out after ${self.input.api_timeout}s waiting for $label." >&2
+            echo "[bootstrap] Check that the ingress profile actually carries the" >&2
+            echo "[bootstrap] Gateway API installation:" >&2
+            echo "[bootstrap]   az aks show -g ${self.input.resource_group} -n ${self.input.cluster_name} \\" >&2
+            echo "[bootstrap]     --query ingressProfile.gatewayApi" >&2
+            echo "[bootstrap] If that is null, the ManagedGatewayAPIPreview /" >&2
+            echo "[bootstrap] AppRoutingIstioGatewayAPIPreview features are not" >&2
+            echo "[bootstrap] registered on this subscription — see the README." >&2
+            return 1
+          fi
+          echo "[bootstrap] waiting for $label..."
+          sleep 20
+        done
+        echo "[bootstrap] $label ready."
+      }
+
+      apply_with_retry() {
+        local label="$1" file="$2"
+        [ -n "$file" ] || return 0
+        for attempt in 1 2 3 4 5 6; do
+          if kubectl apply -f "$file"; then
+            echo "[bootstrap] $label applied."
+            return 0
+          fi
+          if [ "$attempt" -eq 6 ]; then
+            echo "[bootstrap] ERROR: applying $label failed after $attempt attempts." >&2
+            echo "[bootstrap] 'Forbidden' here usually means the Entra RBAC role" >&2
+            echo "[bootstrap] assignment has not propagated yet — re-run apply." >&2
+            return 1
+          fi
+          echo "[bootstrap] $label attempt $attempt failed; retrying in 30s..."
+          sleep 30
+        done
+      }
+
+      apply_with_retry "namespace" "${self.input.namespace_file}"
+
+      wait_for "Gateway API CRDs" \
+        kubectl get crd gateways.gateway.networking.k8s.io
+      kubectl wait --for=condition=Established \
+        --timeout=${self.input.api_timeout}s \
+        crd/gateways.gateway.networking.k8s.io
+      wait_for "GatewayClass ${self.input.gateway_class}" \
+        kubectl get gatewayclass "${self.input.gateway_class}"
+
+      apply_with_retry "gateway" "${self.input.gateway_file}"
+
+      if [ -n "${self.input.gpu_file}" ]; then
+        wait_for "Karpenter NodePool CRDs" kubectl get crd nodepools.karpenter.sh
+        wait_for "AKSNodeClass CRDs"       kubectl get crd aksnodeclasses.karpenter.azure.com
+        apply_with_retry "gpu nodepools" "${self.input.gpu_file}"
+      fi
+    EOT
+  }
+
+  depends_on = [
+    azurerm_kubernetes_automatic_cluster.aks,
+    # THE LOAD-BEARING ONE: the Gateway API CRDs and the `approuting-istio`
+    # GatewayClass only exist once this patch has reconciled. Without this
+    # edge Terraform runs the two concurrently and the Gateway apply fails
+    # with `no matches for kind "Gateway"`.
+    azapi_update_resource.app_routing,
+    # kubectl is unauthorized without the RBAC grants.
+    azurerm_role_assignment.current_principal_cluster_admin,
+    azurerm_role_assignment.current_principal_cluster_user,
+    # The Gateway's DNS label is derived from the cloud resource ID.
+    azapi_resource.anyscale_cloud_resource,
+    # Applying into the operator namespace before the exclusion lands risks
+    # the safeguards webhook rejecting it.
+    azapi_update_resource.deployment_safeguards,
+  ]
+}
+
+###############################################################################
+# INTERNAL-GATEWAY FALLBACK PATH (var.internal_gateway = true only).
+#
+# Internal LBs get a private IP from the node subnet and no public DNS label,
+# so the address must be read back from the Gateway status once the managed
+# Istio controller programs it. On the default public path neither of the
+# resources below is created.
+###############################################################################
+resource "terraform_data" "wait_for_gateway_lb" {
+  count = var.internal_gateway ? 1 : 0
+
+  input = {
+    namespace       = var.anyscale_operator_namespace
+    gateway_name    = var.gateway.name
+    timeout_seconds = var.gateway.lb_wait_timeout_seconds
+    poll_interval   = var.gateway.lb_poll_interval_seconds
+    kubeconfig      = local.kubeconfig_path
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-EOT
+      set -euo pipefail
+      export KUBECONFIG="${self.input.kubeconfig}"
+      deadline=$(( $(date +%s) + ${self.input.timeout_seconds} ))
+      while :; do
+        addr="$(kubectl get gateway ${self.input.gateway_name} -n ${self.input.namespace} \
+          -o jsonpath='{.status.addresses[0].value}' 2>/dev/null || true)"
+        if [ -n "$addr" ]; then
+          echo "[gateway] LB address: $addr"
+          exit 0
+        fi
+        if [ "$(date +%s)" -ge "$deadline" ]; then
+          echo "[gateway] ERROR: timed out waiting for LB address after ${self.input.timeout_seconds}s" >&2
+          kubectl describe gateway ${self.input.gateway_name} -n ${self.input.namespace} >&2 || true
+          exit 1
+        fi
+        sleep ${self.input.poll_interval}
+      done
+    EOT
+  }
+
+  depends_on = [terraform_data.cluster_bootstrap]
+}
+
+# Read the Gateway LB address back into Terraform state so the Anyscale
+# operator extension can consume it as a configuration_settings value.
+data "external" "gateway_lb" {
+  count = var.internal_gateway ? 1 : 0
+
+  program = [
+    "bash",
+    "-c",
+    "value=\"$(KUBECONFIG=${local.kubeconfig_path} kubectl get gateway ${var.gateway.name} -n ${var.anyscale_operator_namespace} -o jsonpath='{.status.addresses[0].value}' 2>/dev/null || true)\"; printf '{\"address\":\"%s\"}' \"$value\"",
+  ]
+
+  depends_on = [terraform_data.wait_for_gateway_lb]
+}

--- a/examples/azure/anyscale-on-azure-aks-automatic/gpu.tf
+++ b/examples/azure/anyscale-on-azure-aks-automatic/gpu.tf
@@ -1,0 +1,162 @@
+###############################################################################
+# GPU CAPACITY — Karpenter NodePools, not AKS node pools.
+#
+# There are no `azurerm_kubernetes_cluster_node_pool` resources in this stack.
+# AKS Automatic runs Node Auto Provisioning (managed Karpenter) unconditionally,
+# so capacity is declared as Kubernetes CRs and provisioned on demand:
+#
+#   AKSNodeClass — the node image / OS / disk template, and the switch that
+#                  asks AKS to manage the NVIDIA driver stack.
+#   NodePool     — the SKU constraints, taints, labels, and disruption policy.
+#
+# CPU capacity needs nothing here: Automatic ships a built-in `default`
+# NodePool that provisions general-purpose nodes. Only GPU needs declaring,
+# because GPU SKUs need the driver treatment and the Anyscale taints.
+#
+# DRIVERS: the `EnableManagedGPUExperience` tag on the AKSNodeClass asks AKS to
+# install and manage the driver, container toolkit, and device plugin. That
+# replaces the entire NVIDIA GPU operator Helm release from the `new-aks`
+# sibling (and its toleration gymnastics). It requires the preview feature:
+#
+#   az feature register --namespace Microsoft.ContainerService --name ManagedGPUExperiencePreview
+#   az provider register --namespace Microsoft.ContainerService
+#
+# TAINTS: identical to the static GPU pools in `new-aks`, so the operator's
+# `workloads.accelerator.tolerations.default[*]` settings in anyscale.tf match
+# unchanged and Anyscale workloads schedule the same way on either stack.
+###############################################################################
+
+locals {
+  ###########################################################################
+  # One NodePool variant per (config entry x capacity type). Flattened first
+  # so the manifest rendering below stays a single straightforward expression
+  # — Terraform has no user-defined functions, so the on-demand/spot
+  # difference is carried in the variant object rather than a helper.
+  ###########################################################################
+  gpu_nodepool_variants = flatten([
+    for key, cfg in var.gpu_nodepool_configs : [
+      for capacity_type in(cfg.enable_spot ? ["on-demand", "spot"] : ["on-demand"]) : {
+        key           = key
+        cfg           = cfg
+        capacity_type = capacity_type
+        # Karpenter's capacity-type value is lowercase-hyphenated; Anyscale's
+        # taint value is uppercase-underscored. They are not the same string.
+        anyscale_capacity_type = capacity_type == "spot" ? "SPOT" : "ON_DEMAND"
+        pool_name              = capacity_type == "spot" ? "${cfg.name}spot" : cfg.name
+        is_spot                = capacity_type == "spot"
+      }
+    ]
+  ])
+
+  # AKSNodeClass — one per config entry, shared by that entry's on-demand and
+  # spot NodePools.
+  gpu_nodeclass_documents = [
+    for key, cfg in var.gpu_nodepool_configs : yamlencode({
+      apiVersion = "karpenter.azure.com/v1beta1"
+      kind       = "AKSNodeClass"
+      metadata = {
+        name = cfg.name
+        annotations = {
+          "kubernetes.io/description" = "AKS node class for ${key} GPU nodes (${cfg.vm_size})."
+        }
+      }
+      spec = {
+        imageFamily  = cfg.image_family
+        osDiskSizeGB = cfg.os_disk_size_gb
+        # THIS TAG IS THE MANAGED-GPU SWITCH. Nodes created from this class get
+        # the AKS-managed NVIDIA driver + device plugin, which is why no GPU
+        # operator chart is installed anywhere in this stack.
+        tags = {
+          EnableManagedGPUExperience = "true"
+        }
+      }
+    })
+  ]
+
+  gpu_nodepool_documents = [
+    for v in local.gpu_nodepool_variants : yamlencode({
+      apiVersion = "karpenter.sh/v1"
+      kind       = "NodePool"
+      metadata = {
+        name = v.pool_name
+        annotations = {
+          "kubernetes.io/description" = "${v.key} GPU NodePool (${v.cfg.vm_size}, ${v.capacity_type})."
+        }
+      }
+      spec = {
+        disruption = {
+          budgets             = [{ nodes = "30%" }]
+          consolidateAfter    = "15m"
+          consolidationPolicy = "WhenEmpty"
+        }
+        # A hard ceiling on how much GPU this pool may ever provision. Karpenter
+        # scales to zero when idle, so this bounds the blast radius of a runaway
+        # workload rather than costing anything at rest.
+        limits = {
+          "nvidia.com/gpu" = v.cfg.max_gpus
+        }
+        template = {
+          metadata = {
+            labels = merge(
+              {
+                "kubernetes.azure.com/ebpf-dataplane" = "cilium"
+                "nvidia.com/gpu.product"              = v.cfg.product_name
+                "nvidia.com/gpu.count"                = v.cfg.gpu_count
+              },
+              v.is_spot ? {
+                "kubernetes.azure.com/scalesetpriority" = "spot"
+              } : {},
+            )
+          }
+          spec = {
+            expireAfter = "Never"
+            nodeClassRef = {
+              group = "karpenter.azure.com"
+              kind  = "AKSNodeClass"
+              name  = v.cfg.name
+            }
+            requirements = [
+              { key = "kubernetes.io/arch", operator = "In", values = ["amd64"] },
+              { key = "kubernetes.io/os", operator = "In", values = ["linux"] },
+              { key = "karpenter.sh/capacity-type", operator = "In", values = [v.capacity_type] },
+              { key = "karpenter.azure.com/sku-name", operator = "In", values = [v.cfg.vm_size] },
+            ]
+            # Cilium marks a fresh node NotReady until its agent is up; without
+            # this startup taint pods can land on a node with no dataplane.
+            startupTaints = [
+              { key = "node.cilium.io/agent-not-ready", value = "true", effect = "NoExecute" },
+            ]
+            taints = concat(
+              [
+                { key = "nvidia.com/gpu", value = "present", effect = "NoSchedule" },
+                { key = "node.anyscale.com/capacity-type", value = v.anyscale_capacity_type, effect = "NoSchedule" },
+                { key = "node.anyscale.com/accelerator-type", value = "GPU", effect = "NoSchedule" },
+              ],
+              v.is_spot ? [
+                { key = "kubernetes.azure.com/scalesetpriority", value = "spot", effect = "NoSchedule" },
+              ] : [],
+            )
+          }
+        }
+      }
+    })
+  ]
+
+  gpu_nodepool_manifest = join("\n---\n", concat(
+    local.gpu_nodeclass_documents,
+    local.gpu_nodepool_documents,
+  ))
+}
+
+###############################################################################
+# Rendered to disk (gitignored) and applied by the bootstrap in gateway.tf.
+# No file at all when gpu_nodepool_configs is empty — a CPU-only deploy gets no
+# GPU machinery whatsoever.
+###############################################################################
+resource "local_file" "gpu_nodepool_manifest" {
+  count = length(var.gpu_nodepool_configs) > 0 ? 1 : 0
+
+  filename        = "${path.module}/nvidia-nodepool.yaml"
+  file_permission = "0600"
+  content         = local.gpu_nodepool_manifest
+}

--- a/examples/azure/anyscale-on-azure-aks-automatic/identity.tf
+++ b/examples/azure/anyscale-on-azure-aks-automatic/identity.tf
@@ -1,0 +1,36 @@
+###############################################################################
+# MANAGED IDENTITY FOR ANYSCALE OPERATOR
+#
+# The operator authenticates to the Anyscale control plane via Microsoft
+# Entra workload identity: a user-assigned identity federated to the AKS
+# OIDC issuer, bound to the operator's Kubernetes service account.
+###############################################################################
+resource "azurerm_user_assigned_identity" "anyscale_operator" {
+  name                = "${var.aks_cluster_name}-anyscale-operator-mi"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  tags                = var.tags
+}
+
+###############################################################################
+# FEDERATED‑IDENTITY CREDENTIAL  (ServiceAccount --> User‑Assigned Identity)
+###############################################################################
+resource "azurerm_federated_identity_credential" "anyscale_operator_fic" {
+  name                = "anyscale-operator-fic"
+  resource_group_name = azurerm_resource_group.rg.name
+
+  parent_id = azurerm_user_assigned_identity.anyscale_operator.id      # user assigned identity
+  issuer    = azurerm_kubernetes_automatic_cluster.aks.oidc_issuer_url # OIDC issuer from AKS
+  subject   = "system:serviceaccount:${var.anyscale_operator_namespace}:${var.anyscale_operator_serviceaccount}"
+  audience  = ["api://AzureADTokenExchange"] # fixed value for AAD tokens
+}
+
+###############################################################################
+# ROLE ASSIGNMENTS (IDENTITY ←→ STORAGE ACCOUNT)
+###############################################################################
+resource "azurerm_role_assignment" "anyscale_blob_contrib" {
+  scope                            = azurerm_storage_account.sa.id
+  role_definition_name             = "Storage Blob Data Contributor"
+  principal_id                     = azurerm_user_assigned_identity.anyscale_operator.principal_id
+  skip_service_principal_aad_check = true
+}

--- a/examples/azure/anyscale-on-azure-aks-automatic/main.tf
+++ b/examples/azure/anyscale-on-azure-aks-automatic/main.tf
@@ -1,0 +1,229 @@
+###############################################################################
+# Global-uniqueness suffix
+#
+# Storage accounts and container registries share a *global* DNS namespace
+# across all of Azure, so a generic name like `anyscaledemosa` derived from the
+# default `aks_cluster_name` is almost guaranteed to collide with another
+# tenant's deployment. Append a short random suffix when the user has not
+# supplied an explicit override.
+###############################################################################
+resource "random_string" "name_suffix" {
+  length  = 5
+  upper   = false
+  special = false
+  numeric = true
+
+  keepers = {
+    aks_cluster_name = var.aks_cluster_name
+  }
+}
+
+data "azurerm_client_config" "current" {}
+
+locals {
+  name_suffix               = random_string.name_suffix.result
+  storage_account_name_base = replace(var.aks_cluster_name, "-", "")
+  # 24-char limit on storage account names. Reserve 2 for "sa" + 5 for suffix = 17 chars for the base.
+  storage_account_name_base_sa = length(local.storage_account_name_base) > 17 ? substr(local.storage_account_name_base, 0, 17) : local.storage_account_name_base
+  # Reserve 3 for "nfs" + 5 for suffix = 16 chars for the base.
+  storage_account_name_base_nfs = length(local.storage_account_name_base) > 16 ? substr(local.storage_account_name_base, 0, 16) : local.storage_account_name_base
+  storage_account_name          = coalesce(var.storage_account_name, "${local.storage_account_name_base_sa}sa${local.name_suffix}")
+  storage_account_name_nfs      = coalesce(var.storage_account_name_nfs, "${local.storage_account_name_base_nfs}nfs${local.name_suffix}")
+
+  # The Anyscale RP and AKS Automatic do not have to live in the same region.
+  # Both default to var.azure_location; anyscale_cloud_location is the override
+  # for "AKS Automatic here, Anyscale cloud there" (upstream awesome-aks splits
+  # them by default; this example does not).
+  anyscale_cloud_location = coalesce(var.anyscale_cloud_location, var.azure_location)
+}
+
+############################################
+# resource group
+############################################
+resource "azurerm_resource_group" "rg" {
+  name     = coalesce(var.azure_resource_group_name, "${var.aks_cluster_name}-rg")
+  location = var.azure_location
+  tags     = var.tags
+}
+
+############################################
+# storage (blob / ADLS Gen2)
+#
+# HNS is enabled so the container is addressable as ADLS Gen2 via abfss:// —
+# the Anyscale cloud resource registers the bucket with the dfs endpoint
+# (see anyscale.tf).
+############################################
+resource "azurerm_storage_account" "sa" {
+
+  #checkov:skip=CKV_AZURE_33: "Ensure Storage logging is enabled for Queue service for read, write and delete requests"
+  #checkov:skip=CKV_AZURE_59: "Ensure that Storage accounts disallow public access"
+  #checkov:skip=CKV_AZURE_244: "Avoid the use of local users for Azure Storage unless necessary"
+  #checkov:skip=CKV_AZURE_206: "Ensure that Storage Accounts use replication"
+  #checkov:skip=CKV2_AZURE_41: "Ensure storage account is configured with SAS expiration policy"
+  #checkov:skip=CKV2_AZURE_38: "Ensure soft-delete is enabled on Azure storage account"
+  #checkov:skip=CKV2_AZURE_1: "Ensure storage for critical data are encrypted with Customer Managed Key"
+  #checkov:skip=CKV2_AZURE_33: "Ensure storage account is configured with private endpoint"
+  #checkov:skip=CKV2_AZURE_40: "Ensure storage account is not configured with Shared Key authorization"
+  #checkov:skip=CKV2_AZURE_21: "Ensure Storage logging is enabled for Blob service for read requests"
+
+  name                     = local.storage_account_name
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = azurerm_resource_group.rg.location
+  account_kind             = "StorageV2"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  access_tier              = "Hot"
+
+  is_hns_enabled                  = true
+  min_tls_version                 = "TLS1_2"
+  https_traffic_only_enabled      = true
+  default_to_oauth_authentication = true
+  allow_nested_items_to_be_public = false
+
+  tags = var.tags
+
+  blob_properties {
+    cors_rule {
+      allowed_headers    = var.cors_rule.allowed_headers
+      allowed_methods    = var.cors_rule.allowed_methods
+      allowed_origins    = var.cors_rule.allowed_origins
+      exposed_headers    = var.cors_rule.expose_headers
+      max_age_in_seconds = var.cors_rule.max_age_in_seconds
+    }
+  }
+}
+
+# Storage bucket (similar to S3)
+resource "azurerm_storage_container" "blob" {
+
+  #checkov:skip=CKV2_AZURE_21: "Ensure Storage logging is enabled for Blob service for read requests"
+
+  name                  = "${var.aks_cluster_name}-blob"
+  storage_account_id    = azurerm_storage_account.sa.id
+  container_access_type = "private" # blobs are private but reachable via the public endpoint
+}
+
+############################################
+# storage (nfs) - optional
+############################################
+resource "azurerm_storage_account" "nfs" {
+  count = var.enable_nfs ? 1 : 0
+
+  name                       = local.storage_account_name_nfs
+  resource_group_name        = azurerm_resource_group.rg.name
+  location                   = azurerm_resource_group.rg.location
+  account_kind               = "FileStorage"
+  account_tier               = "Premium"
+  account_replication_type   = "ZRS"
+  https_traffic_only_enabled = false
+
+  allow_nested_items_to_be_public = false
+
+  network_rules {
+    default_action = "Deny"
+    # Karpenter-provisioned nodes land in the user node subnet, so that is the
+    # subnet the share has to trust. The system subnet hosts only AKS-managed
+    # system components, which never mount the share.
+    virtual_network_subnet_ids = [azurerm_subnet.nodes.id]
+    bypass                     = ["AzureServices"]
+  }
+
+  tags = var.tags
+}
+
+###############################################################################
+# NETWORKING — BYO VNet, THREE subnets.
+#
+# This is the biggest structural difference from the `new-aks` sibling, which
+# needs a single node subnet. AKS Automatic with a customer-owned VNet
+# ("hosted system" mode) requires all three:
+#
+#   1. apiserver   — API Server VNet Integration. MUST be delegated to
+#                    `Microsoft.ContainerService/managedClusters` and MUST be
+#                    at least a /28. Nothing else may share it.
+#   2. nodes       — the user node subnet. Karpenter provisions every workload
+#                    node here.
+#   3. systemnodes — the managed system node pool (CoreDNS, metrics-server,
+#                    Karpenter itself, the app-routing Istio controller).
+#
+# Azure CNI overlay is Automatic's default and is not negotiable, so pods do
+# NOT consume IPs from any of these subnets — they only need to be sized for
+# nodes (and, for the apiserver subnet, control-plane NICs).
+###############################################################################
+resource "azurerm_virtual_network" "vnet" {
+  name                = "${var.aks_cluster_name}-vnet"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  address_space       = [var.vnet_cidr]
+  tags                = var.tags
+}
+
+# API Server VNet Integration subnet. The delegation is what tells Azure it may
+# inject the control-plane's inbound NICs here; without it, cluster creation
+# fails late with a generic subnet error.
+resource "azurerm_subnet" "apiserver" {
+
+  #checkov:skip=CKV2_AZURE_31: "Ensure VNET subnet is configured with a Network Security Group (NSG)"
+
+  name                 = "aks-apiserver"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = [var.apiserver_subnet_cidr]
+
+  delegation {
+    name = "aks-delegation"
+    service_delegation {
+      name    = "Microsoft.ContainerService/managedClusters"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+    }
+  }
+}
+
+# Subnet for Karpenter-provisioned workload nodes.
+resource "azurerm_subnet" "nodes" {
+
+  #checkov:skip=CKV2_AZURE_31: "Ensure VNET subnet is configured with a Network Security Group (NSG)"
+
+  name                 = "aks-nodes"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = [var.nodes_subnet_cidr]
+  service_endpoints    = ["Microsoft.Storage"]
+}
+
+# Subnet for the AKS-managed system node pool.
+resource "azurerm_subnet" "system_nodes" {
+
+  #checkov:skip=CKV2_AZURE_31: "Ensure VNET subnet is configured with a Network Security Group (NSG)"
+
+  name                 = "aks-system-nodes"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = [var.system_nodes_subnet_cidr]
+  service_endpoints    = ["Microsoft.Storage"]
+}
+
+###############################################################################
+# CLUSTER IDENTITY — user-assigned, not system-assigned.
+#
+# A BYO VNet forces this. With SystemAssigned the identity does not exist until
+# the cluster is being created, so there is no principal to grant subnet
+# permissions to beforehand — and the cluster needs those permissions during
+# creation to join the subnets. Creating the identity first breaks the cycle.
+###############################################################################
+resource "azurerm_user_assigned_identity" "aks" {
+  name                = "${var.aks_cluster_name}-aks-mi"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  tags                = var.tags
+}
+
+# Network Contributor at VNet scope covers all three subnets: joining the node
+# subnets, injecting API-server NICs into the delegated subnet, and (later)
+# programming the gateway load balancer's frontend.
+resource "azurerm_role_assignment" "aks_network_contributor" {
+  scope                            = azurerm_virtual_network.vnet.id
+  role_definition_name             = "Network Contributor"
+  principal_id                     = azurerm_user_assigned_identity.aks.principal_id
+  skip_service_principal_aad_check = true
+}

--- a/examples/azure/anyscale-on-azure-aks-automatic/monitoring.tf
+++ b/examples/azure/anyscale-on-azure-aks-automatic/monitoring.tf
@@ -1,0 +1,70 @@
+###############################################################################
+# Observability workspaces (ported from the awesome-aks demo).
+#
+# - Azure Monitor workspace: destination for AKS managed-Prometheus metrics
+#   (data-collection wiring in prometheus.tf).
+# - Log Analytics workspace: destination for Container Insights (the omsagent
+#   addon on the cluster in aks.tf).
+# - App Insights with OTLP endpoints (opt-in, PREVIEW API): ingestion targets
+#   for Ray application logs/metrics/traces.
+###############################################################################
+
+resource "azurerm_monitor_workspace" "prometheus" {
+  count = var.enable_monitoring ? 1 : 0
+
+  name                = "metrics-${var.aks_cluster_name}"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  tags                = var.tags
+}
+
+resource "azurerm_log_analytics_workspace" "logs" {
+  count = var.enable_monitoring ? 1 : 0
+
+  name                = "logs-${var.aks_cluster_name}"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  retention_in_days   = var.log_analytics_retention_days
+  sku                 = "PerGB2018"
+  tags                = var.tags
+}
+
+###############################################################################
+# Application Insights with OTLP ingestion (PREVIEW Microsoft.Insights API).
+# Exports the OTLP logs/metrics/traces endpoints for Ray telemetry pipelines.
+###############################################################################
+resource "azapi_resource" "otel_app_insights" {
+  count = var.enable_monitoring && var.enable_otlp_app_insights ? 1 : 0
+
+  type      = "Microsoft.Insights/components@2025-01-23-preview"
+  name      = "otel-${var.aks_cluster_name}"
+  parent_id = azurerm_resource_group.rg.id
+  location  = azurerm_resource_group.rg.location
+
+  # required while the azapi local schema catalog lags the preview API version
+  schema_validation_enabled = false
+
+  body = {
+    kind = "web"
+    properties = {
+      ApplicationId                      = "otel-${var.aks_cluster_name}"
+      Application_Type                   = "web"
+      Flow_Type                          = "Redfield"
+      Request_Source                     = "IbizaAIExtension"
+      IngestionMode                      = "LogAnalytics"
+      WorkspaceResourceId                = azurerm_log_analytics_workspace.logs[0].id
+      AzureMonitorWorkspaceResourceId    = azurerm_monitor_workspace.prometheus[0].id
+      AzureMonitorWorkspaceIngestionMode = "Enabled"
+      publicNetworkAccessForIngestion    = "Enabled"
+      publicNetworkAccessForQuery        = "Enabled"
+    }
+  }
+
+  response_export_values = [
+    "properties.OTLPLogsEndpoint",
+    "properties.OTLPMetricsEndpoint",
+    "properties.OTLPTracesEndpoint",
+  ]
+
+  tags = var.tags
+}

--- a/examples/azure/anyscale-on-azure-aks-automatic/outputs.tf
+++ b/examples/azure/anyscale-on-azure-aks-automatic/outputs.tf
@@ -1,0 +1,239 @@
+###############################################################################
+# Azure infra outputs
+###############################################################################
+output "azure_resource_group_name" {
+  value       = azurerm_resource_group.rg.name
+  description = "Name of the Azure Resource Group."
+}
+
+output "azure_storage_account_name" {
+  value       = azurerm_storage_account.sa.name
+  description = "Name of the Azure Storage Account (HNS/ADLS Gen2 enabled)."
+}
+
+output "azure_storage_container_name" {
+  value       = azurerm_storage_container.blob.name
+  description = "Name of the Azure Storage Container."
+}
+
+output "azure_nfs_storage_account_name" {
+  value       = var.enable_nfs ? azurerm_storage_account.nfs[0].name : null
+  description = "Name of the optional Azure NFS Storage Account."
+}
+
+output "azure_aks_cluster_name" {
+  value       = azurerm_kubernetes_automatic_cluster.aks.name
+  description = "Name of the AKS Automatic cluster."
+}
+
+output "azure_aks_fqdn" {
+  value       = azurerm_kubernetes_automatic_cluster.aks.fully_qualified_domain_name
+  description = "API server FQDN of the AKS Automatic cluster."
+}
+
+output "azure_aks_oidc_issuer_url" {
+  value       = azurerm_kubernetes_automatic_cluster.aks.oidc_issuer_url
+  description = "OIDC issuer URL of the AKS cluster (used by workload-identity federation)."
+}
+
+output "azure_aks_node_resource_group_id" {
+  value       = azurerm_kubernetes_automatic_cluster.aks.node_resource_group_id
+  description = "Resource ID of the AKS-managed node resource group (where Karpenter-provisioned VMs and the gateway load balancer live)."
+}
+
+output "azure_vnet_id" {
+  value       = azurerm_virtual_network.vnet.id
+  description = "Resource ID of the VNet holding the API-server, node, and system-node subnets."
+}
+
+output "acr_login_server" {
+  value       = var.enable_acr ? azurerm_container_registry.acr[0].login_server : null
+  description = "Login server (e.g. myacr.azurecr.io) for the customer-owned ACR. Null when enable_acr=false."
+}
+
+output "anyscale_operator_client_id" {
+  value       = azurerm_user_assigned_identity.anyscale_operator.client_id
+  description = "Client ID of the Anyscale operator user-assigned managed identity."
+}
+
+###############################################################################
+# Anyscale Azure-managed cloud outputs
+###############################################################################
+output "anyscale_cloud_name" {
+  value       = local.anyscale_cloud_name
+  description = "Name of the registered Anyscale cloud (visible in console.azure.anyscale.com)."
+}
+
+output "anyscale_cloud_arm_id" {
+  value       = local.anyscale_cloud_arm_id
+  description = "Full ARM resource ID of the Anyscale.Platform/clouds resource."
+}
+
+output "anyscale_cloud_resource_id" {
+  value       = local.anyscale_cloud_resource_id
+  description = "Anyscale cloud resource ID (`cldrsrc_…`). Surfaced in the Anyscale console's cloud settings page."
+}
+
+# The name the Anyscale CLI knows this cloud by is NOT `anyscale_cloud_name` —
+# it is the full ARM resource ID, lowercased. Passing the Azure resource name to
+# `--cloud` fails with:
+#
+#   API Exception (404) ... "Cloud with name <name> does not exist."
+#
+# Verified against a live deployment. Use this output for `anyscale job submit
+# --cloud`, `anyscale service deploy --cloud`, etc.
+output "anyscale_cloud_cli_name" {
+  value       = lower(local.anyscale_cloud_arm_id)
+  description = "Cloud name to pass to the Anyscale CLI's --cloud flag (the lowercased ARM resource ID, which is what the control plane registers as the cloud's name)."
+}
+
+output "anyscale_cloud_sso_url" {
+  value       = azapi_resource.anyscale_cloud.output.properties.ssoUrl
+  description = "SSO URL for the Anyscale cloud."
+}
+
+output "anyscale_extension_resource_id" {
+  value       = azurerm_kubernetes_cluster_extension.anyscale_operator.id
+  description = "Full resource ID of the Anyscale.AKS.Operator AKS extension."
+}
+
+output "anyscale_operator_namespace" {
+  value       = var.anyscale_operator_namespace
+  description = "Kubernetes namespace where the Anyscale operator runs."
+}
+
+###############################################################################
+# Gateway outputs
+###############################################################################
+output "gateway_hostname" {
+  value       = local.gateway_hostname
+  description = "Hostname registered with the Anyscale control plane. Deterministic DNS-label hostname on the public path; private LB IP when internal_gateway=true."
+}
+
+output "gateway_class_name" {
+  value       = local.app_routing_gateway_class_name
+  description = "GatewayClass backing the Anyscale gateway. Fixed at `approuting-istio` — the managed Istio implementation AKS Automatic installs."
+}
+
+output "gateway_certificate_secret_name" {
+  value       = local.anyscale_gateway_certificate_secret_name
+  description = "Name of the TLS Secret the operator creates for `*.i.azure.anyscaleuserdata.com`."
+}
+
+output "gateway_service_certificate_secret_name" {
+  value       = local.anyscale_gateway_service_certificate_secret_name
+  description = "Name of the TLS Secret the operator creates for `*.s.azure.anyscaleuserdata.com`."
+}
+
+###############################################################################
+# GPU outputs
+###############################################################################
+output "gpu_nodepool_names" {
+  value       = [for v in local.gpu_nodepool_variants : v.pool_name]
+  description = "Karpenter NodePool names rendered from gpu_nodepool_configs (empty on a CPU-only deploy — Automatic's built-in `default` NodePool covers CPU)."
+}
+
+###############################################################################
+# Observability outputs
+###############################################################################
+output "azure_monitor_workspace_id" {
+  value       = var.enable_monitoring ? azurerm_monitor_workspace.prometheus[0].id : null
+  description = "Azure Monitor workspace (managed Prometheus) resource ID. Null when enable_monitoring=false."
+}
+
+output "log_analytics_workspace_id" {
+  value       = var.enable_monitoring ? azurerm_log_analytics_workspace.logs[0].id : null
+  description = "Log Analytics workspace resource ID. Null when enable_monitoring=false."
+}
+
+output "otlp_endpoints" {
+  value = var.enable_monitoring && var.enable_otlp_app_insights ? {
+    logs    = azapi_resource.otel_app_insights[0].output.properties.OTLPLogsEndpoint
+    metrics = azapi_resource.otel_app_insights[0].output.properties.OTLPMetricsEndpoint
+    traces  = azapi_resource.otel_app_insights[0].output.properties.OTLPTracesEndpoint
+  } : null
+  description = "OTLP ingestion endpoints for Ray application telemetry. Null unless enable_otlp_app_insights=true."
+}
+
+output "otlp_logs_endpoint" {
+  value       = var.enable_monitoring && var.enable_otlp_app_insights ? azapi_resource.otel_app_insights[0].output.properties.OTLPLogsEndpoint : null
+  description = "OTLP logs ingestion endpoint (flat form, matching the upstream awesome-aks outputs)."
+}
+
+output "otlp_metrics_endpoint" {
+  value       = var.enable_monitoring && var.enable_otlp_app_insights ? azapi_resource.otel_app_insights[0].output.properties.OTLPMetricsEndpoint : null
+  description = "OTLP metrics ingestion endpoint (flat form, matching the upstream awesome-aks outputs)."
+}
+
+output "otlp_traces_endpoint" {
+  value       = var.enable_monitoring && var.enable_otlp_app_insights ? azapi_resource.otel_app_insights[0].output.properties.OTLPTracesEndpoint : null
+  description = "OTLP traces ingestion endpoint (flat form, matching the upstream awesome-aks outputs)."
+}
+
+###############################################################################
+# Convenience commands
+#
+# Note the `kubelogin convert-kubeconfig` step — AKS Automatic disables local
+# accounts, so `az aks get-credentials` on its own produces a kubeconfig that
+# kubectl cannot authenticate with until the exec plugin is converted.
+###############################################################################
+output "aks_get_credentials_command" {
+  value       = "az aks get-credentials --resource-group ${azurerm_resource_group.rg.name} --name ${azurerm_kubernetes_automatic_cluster.aks.name} --overwrite-existing && kubelogin convert-kubeconfig -l azurecli"
+  description = "Refresh local kubeconfig against the deployed AKS Automatic cluster (includes the required kubelogin conversion)."
+}
+
+output "anyscale_console_url" {
+  value       = var.anyscale_platform.control_plane_url
+  description = "URL of the Anyscale console where the registered cloud is visible."
+}
+
+###############################################################################
+# Deployment summary file
+#
+# Writes a YAML summary of the deployment to anyscale-aks-cloud.yaml when the
+# apply completes. Because the content references the cloud, operator-extension
+# and gateway resources, Terraform schedules this write after they exist — so
+# the file reflects the finished deployment. The file embeds ARM resource IDs
+# (which include the subscription ID), so it is gitignored.
+###############################################################################
+resource "local_file" "cloud_summary" {
+  filename        = "${path.module}/anyscale-aks-cloud.yaml"
+  file_permission = "0600"
+
+  content = yamlencode({
+    anyscale_cloud = {
+      name               = local.anyscale_cloud_name
+      resource_id        = local.anyscale_cloud_resource_id
+      arm_id             = local.anyscale_cloud_arm_id
+      location           = local.anyscale_cloud_location
+      console_url        = var.anyscale_platform.control_plane_url
+      operator_namespace = var.anyscale_operator_namespace
+      extension_id       = azurerm_kubernetes_cluster_extension.anyscale_operator.id
+    }
+    azure = {
+      resource_group      = azurerm_resource_group.rg.name
+      aks_cluster         = azurerm_kubernetes_automatic_cluster.aks.name
+      aks_flavor          = "Automatic"
+      aks_fqdn            = azurerm_kubernetes_automatic_cluster.aks.fully_qualified_domain_name
+      node_resource_group = azurerm_kubernetes_automatic_cluster.aks.node_resource_group_id
+      oidc_issuer_url     = azurerm_kubernetes_automatic_cluster.aks.oidc_issuer_url
+      storage_account     = azurerm_storage_account.sa.name
+      storage_container   = azurerm_storage_container.blob.name
+      acr_login_server    = var.enable_acr ? azurerm_container_registry.acr[0].login_server : null
+    }
+    operator_identity = {
+      client_id    = azurerm_user_assigned_identity.anyscale_operator.client_id
+      principal_id = azurerm_user_assigned_identity.anyscale_operator.principal_id
+    }
+    gateway = {
+      hostname                   = local.gateway_hostname
+      class_name                 = local.app_routing_gateway_class_name
+      certificate_secret         = local.anyscale_gateway_certificate_secret_name
+      service_certificate_secret = local.anyscale_gateway_service_certificate_secret_name
+    }
+    gpu_nodepools = [for v in local.gpu_nodepool_variants : v.pool_name]
+    commands = {
+      get_credentials = "az aks get-credentials --resource-group ${azurerm_resource_group.rg.name} --name ${azurerm_kubernetes_automatic_cluster.aks.name} --overwrite-existing && kubelogin convert-kubeconfig -l azurecli"
+    }
+  })
+}

--- a/examples/azure/anyscale-on-azure-aks-automatic/prometheus.tf
+++ b/examples/azure/anyscale-on-azure-aks-automatic/prometheus.tf
@@ -1,0 +1,457 @@
+###############################################################################
+# Managed Prometheus wiring (ported verbatim from the awesome-aks demo,
+# renamed to this stack's resources and gated behind var.enable_monitoring).
+#
+# - Data-collection endpoint + rule routing Microsoft-PrometheusMetrics from
+#   the cluster (monitor_metrics profile in aks.tf) to the Azure Monitor
+#   workspace, plus the Container Insights (MSCI) rule to Log Analytics.
+# - The standard Node / Kubernetes / UX recording-rule groups Azure Monitor
+#   dashboards expect (the -Win group ships disabled, matching the demo).
+###############################################################################
+resource "azurerm_monitor_data_collection_endpoint" "msprom" {
+  count = var.enable_monitoring ? 1 : 0
+
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  name                = "MSProm-${azurerm_resource_group.rg.location}-${azurerm_kubernetes_automatic_cluster.aks.name}"
+  kind                = "Linux"
+}
+
+
+resource "azurerm_monitor_data_collection_rule" "msprom" {
+  count = var.enable_monitoring ? 1 : 0
+
+  resource_group_name         = azurerm_resource_group.rg.name
+  location                    = azurerm_resource_group.rg.location
+  name                        = "MSProm-${azurerm_kubernetes_automatic_cluster.aks.location}-${azurerm_kubernetes_automatic_cluster.aks.name}"
+  data_collection_endpoint_id = azurerm_monitor_data_collection_endpoint.msprom[0].id
+
+  data_sources {
+    prometheus_forwarder {
+      name    = "PrometheusDataSource"
+      streams = ["Microsoft-PrometheusMetrics"]
+    }
+  }
+
+  destinations {
+    monitor_account {
+      monitor_account_id = azurerm_monitor_workspace.prometheus[0].id
+      name               = azurerm_monitor_workspace.prometheus[0].name
+    }
+  }
+
+  data_flow {
+    streams      = ["Microsoft-PrometheusMetrics"]
+    destinations = [azurerm_monitor_workspace.prometheus[0].name]
+  }
+}
+
+resource "azurerm_monitor_data_collection_rule_association" "dcr1" {
+  count = var.enable_monitoring ? 1 : 0
+
+  target_resource_id      = azurerm_kubernetes_automatic_cluster.aks.id
+  data_collection_rule_id = azurerm_monitor_data_collection_rule.msprom[0].id
+  name                    = "dcr-${azurerm_kubernetes_automatic_cluster.aks.name}"
+}
+
+resource "azurerm_monitor_data_collection_rule_association" "dcr2" {
+  count = var.enable_monitoring ? 1 : 0
+
+  target_resource_id          = azurerm_kubernetes_automatic_cluster.aks.id
+  data_collection_endpoint_id = azurerm_monitor_data_collection_endpoint.msprom[0].id
+}
+
+resource "azurerm_monitor_alert_prometheus_rule_group" "node" {
+  count = var.enable_monitoring ? 1 : 0
+
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  cluster_name        = azurerm_kubernetes_automatic_cluster.aks.name
+  name                = "NodeRecordingRulesRuleGroup - ${azurerm_kubernetes_automatic_cluster.aks.name}"
+  rule_group_enabled  = true
+  interval            = "PT1M"
+  scopes              = [azurerm_monitor_workspace.prometheus[0].id]
+
+  rule {
+    record     = "instance:node_num_cpu:sum"
+    expression = "count without (cpu, mode) (node_cpu_seconds_total{job=\"node\",mode=\"idle\"})"
+  }
+
+  rule {
+    record     = "instance:node_cpu_utilisation:rate5m"
+    expression = "1 - avg without (cpu) (sum without (mode) (rate(node_cpu_seconds_total{job=\"node\", mode=~\"idle|iowait|steal\"}[5m])))"
+  }
+
+  rule {
+    record     = "instance:node_load1_per_cpu:ratio"
+    expression = "(node_load1{job=\"node\"}/  instance:node_num_cpu:sum{job=\"node\"})"
+  }
+
+  rule {
+    record     = "instance:node_memory_utilisation:ratio"
+    expression = "1 - ((node_memory_MemAvailable_bytes{job=\"node\"} or (node_memory_Buffers_bytes{job=\"node\"} + node_memory_Cached_bytes{job=\"node\"} + node_memory_MemFree_bytes{job=\"node\"} + node_memory_Slab_bytes{job=\"node\"})) / node_memory_MemTotal_bytes{job=\"node\"})"
+  }
+
+  rule {
+    record     = "instance:node_vmstat_pgmajfault:rate5m"
+    expression = "rate(node_vmstat_pgmajfault{job=\"node\"}[5m])"
+  }
+
+  rule {
+    record     = "instance_device:node_disk_io_time_seconds:rate5m"
+    expression = "rate(node_disk_io_time_seconds_total{job=\"node\", device!=\"\"}[5m])"
+  }
+
+  rule {
+    record     = "instance_device:node_disk_io_time_weighted_seconds:rate5m"
+    expression = "rate(node_disk_io_time_weighted_seconds_total{job=\"node\", device!=\"\"}[5m])"
+  }
+
+  rule {
+    record     = "instance:node_network_receive_bytes_excluding_lo:rate5m"
+    expression = "sum without (device) (rate(node_network_receive_bytes_total{job=\"node\", device!=\"lo\"}[5m]))"
+  }
+
+  rule {
+    record     = "instance:node_network_transmit_bytes_excluding_lo:rate5m"
+    expression = "sum without (device) (rate(node_network_transmit_bytes_total{job=\"node\", device!=\"lo\"}[5m]))"
+  }
+
+  rule {
+    record     = "instance:node_network_receive_drop_excluding_lo:rate5m"
+    expression = "sum without (device) (rate(node_network_receive_drop_total{job=\"node\", device!=\"lo\"}[5m]))"
+  }
+
+  rule {
+    record     = "instance:node_network_transmit_drop_excluding_lo:rate5m"
+    expression = "sum without (device) (rate(node_network_transmit_drop_total{job=\"node\", device!=\"lo\"}[5m]))"
+  }
+}
+
+resource "azurerm_monitor_alert_prometheus_rule_group" "k8s" {
+  count = var.enable_monitoring ? 1 : 0
+
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  cluster_name        = azurerm_kubernetes_automatic_cluster.aks.name
+  name                = "KubernetesRecordingRulesRuleGroup - ${azurerm_kubernetes_automatic_cluster.aks.name}"
+  rule_group_enabled  = true
+  interval            = "PT1M"
+  scopes              = [azurerm_monitor_workspace.prometheus[0].id]
+
+  rule {
+    record     = "node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate"
+    expression = "sum by (cluster, namespace, pod, container) (irate(container_cpu_usage_seconds_total{job=\"cadvisor\", image!=\"\"}[5m])) * on (cluster, namespace, pod) group_left(node) topk by (cluster, namespace, pod) (1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=\"\"}))"
+  }
+
+  rule {
+    record     = "node_namespace_pod_container:container_memory_working_set_bytes"
+    expression = "container_memory_working_set_bytes{job=\"cadvisor\", image!=\"\"}* on (namespace, pod) group_left(node) topk by(namespace, pod) (1, max by(namespace, pod, node) (kube_pod_info{node!=\"\"}))"
+  }
+
+  rule {
+    record     = "node_namespace_pod_container:container_memory_rss"
+    expression = "container_memory_rss{job=\"cadvisor\", image!=\"\"}* on (namespace, pod) group_left(node) topk by(namespace, pod) (1, max by(namespace, pod, node) (kube_pod_info{node!=\"\"}))"
+  }
+
+  rule {
+    record     = "node_namespace_pod_container:container_memory_cache"
+    expression = "container_memory_cache{job=\"cadvisor\", image!=\"\"}* on (namespace, pod) group_left(node) topk by(namespace, pod) (1, max by(namespace, pod, node) (kube_pod_info{node!=\"\"}))"
+  }
+
+  rule {
+    record     = "node_namespace_pod_container:container_memory_swap"
+    expression = "container_memory_swap{job=\"cadvisor\", image!=\"\"}* on (namespace, pod) group_left(node) topk by(namespace, pod) (1, max by(namespace, pod, node) (kube_pod_info{node!=\"\"}))"
+  }
+
+  rule {
+    record     = "cluster:namespace:pod_memory:active:kube_pod_container_resource_requests"
+    expression = "kube_pod_container_resource_requests{resource=\"memory\",job=\"kube-state-metrics\"} * on(namespace, pod, cluster)group_left() max by (namespace, pod, cluster) ((kube_pod_status_phase{phase=~\"Pending|Running\"} == 1))"
+  }
+
+  rule {
+    record     = "namespace_memory:kube_pod_container_resource_requests:sum"
+    expression = "sum by (namespace, cluster) (sum by (namespace, pod, cluster) (max by (namespace, pod, container, cluster) (kube_pod_container_resource_requests{resource=\"memory\",job=\"kube-state-metrics\"}) * on(namespace, pod, cluster) group_left() max by (namespace, pod, cluster) (kube_pod_status_phase{phase=~\"Pending|Running\"} == 1)))"
+  }
+
+  rule {
+    record     = "cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests"
+    expression = "kube_pod_container_resource_requests{resource=\"cpu\",job=\"kube-state-metrics\"} * on (namespace, pod, cluster)group_left() max by (namespace, pod, cluster) ((kube_pod_status_phase{phase=~\"Pending|Running\"} == 1))"
+  }
+
+  rule {
+    record     = "namespace_cpu:kube_pod_container_resource_requests:sum"
+    expression = "sum by (namespace, cluster) (sum by(namespace, pod, cluster) (max by(namespace, pod, container, cluster) (kube_pod_container_resource_requests{resource=\"cpu\",job=\"kube-state-metrics\"}) * on(namespace, pod, cluster) group_left() max by (namespace, pod, cluster) (kube_pod_status_phase{phase=~\"Pending|Running\"} == 1)))"
+  }
+
+  rule {
+    record     = "cluster:namespace:pod_memory:active:kube_pod_container_resource_limits"
+    expression = "kube_pod_container_resource_limits{resource=\"memory\",job=\"kube-state-metrics\"} * on (namespace, pod, cluster)group_left() max by (namespace, pod, cluster) ((kube_pod_status_phase{phase=~\"Pending|Running\"} == 1))"
+  }
+
+  rule {
+    record     = "namespace_memory:kube_pod_container_resource_limits:sum"
+    expression = "sum by (namespace, cluster) (sum by (namespace, pod, cluster) (max by (namespace, pod, container, cluster) (kube_pod_container_resource_limits{resource=\"memory\",job=\"kube-state-metrics\"}) * on(namespace, pod, cluster) group_left() max by (namespace, pod, cluster) (kube_pod_status_phase{phase=~\"Pending|Running\"} == 1)))"
+  }
+
+  rule {
+    record     = "cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits"
+    expression = "kube_pod_container_resource_limits{resource=\"cpu\",job=\"kube-state-metrics\"} * on (namespace, pod, cluster)group_left() max by (namespace, pod, cluster) ( (kube_pod_status_phase{phase=~\"Pending|Running\"} == 1) )"
+  }
+
+  rule {
+    record     = "namespace_cpu:kube_pod_container_resource_limits:sum"
+    expression = "sum by (namespace, cluster) (sum by (namespace, pod, cluster) (max by(namespace, pod, container, cluster) (kube_pod_container_resource_limits{resource=\"cpu\",job=\"kube-state-metrics\"}) * on(namespace, pod, cluster) group_left() max by (namespace, pod, cluster) (kube_pod_status_phase{phase=~\"Pending|Running\"} == 1)))"
+  }
+
+  rule {
+    record     = "namespace_workload_pod:kube_pod_owner:relabel"
+    expression = "max by (cluster, namespace, workload, pod) (label_replace(label_replace(kube_pod_owner{job=\"kube-state-metrics\", owner_kind=\"ReplicaSet\"}, \"replicaset\", \"$1\", \"owner_name\", \"(.*)\") * on(replicaset, namespace) group_left(owner_name) topk by(replicaset, namespace) (1, max by (replicaset, namespace, owner_name) (kube_replicaset_owner{job=\"kube-state-metrics\"})), \"workload\", \"$1\", \"owner_name\", \"(.*)\"))"
+    labels = {
+      "workload_type" = "deployment"
+    }
+  }
+
+  rule {
+    record     = "namespace_workload_pod:kube_pod_owner:relabel"
+    expression = "max by (cluster, namespace, workload, pod) (label_replace(kube_pod_owner{job=\"kube-state-metrics\", owner_kind=\"DaemonSet\"}, \"workload\", \"$1\", \"owner_name\", \"(.*)\"))"
+    labels = {
+      "workload_type" = "daemonset"
+    }
+  }
+
+  rule {
+    record     = "namespace_workload_pod:kube_pod_owner:relabel"
+    expression = "max by (cluster, namespace, workload, pod) (label_replace(kube_pod_owner{job=\"kube-state-metrics\", owner_kind=\"StatefulSet\"}, \"workload\", \"$1\", \"owner_name\", \"(.*)\"))"
+    labels = {
+      "workload_type" = "statefulset"
+    }
+  }
+
+  rule {
+    record     = "namespace_workload_pod:kube_pod_owner:relabel"
+    expression = "max by (cluster, namespace, workload, pod) (label_replace(kube_pod_owner{job=\"kube-state-metrics\", owner_kind=\"Job\"}, \"workload\", \"$1\", \"owner_name\", \"(.*)\"))"
+    labels = {
+      "workload_type" = "job"
+    }
+  }
+
+  rule {
+    record     = ":node_memory_MemAvailable_bytes:sum"
+    expression = "sum(node_memory_MemAvailable_bytes{job=\"node\"} or (node_memory_Buffers_bytes{job=\"node\"} + node_memory_Cached_bytes{job=\"node\"} + node_memory_MemFree_bytes{job=\"node\"} + node_memory_Slab_bytes{job=\"node\"})) by (cluster)"
+  }
+
+  rule {
+    record     = "cluster:node_cpu:ratio_rate5m"
+    expression = "sum(rate(node_cpu_seconds_total{job=\"node\",mode!=\"idle\",mode!=\"iowait\",mode!=\"steal\"}[5m])) by (cluster) /count(sum(node_cpu_seconds_total{job=\"node\"}) by (cluster, instance, cpu)) by (cluster)"
+  }
+}
+
+resource "azurerm_monitor_data_collection_rule" "msci" {
+  count = var.enable_monitoring ? 1 : 0
+
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  name                = "MSCI-${azurerm_resource_group.rg.location}-${azurerm_kubernetes_automatic_cluster.aks.name}"
+  kind                = "Linux"
+
+  data_sources {
+    extension {
+      name           = "ContainerInsightsExtension"
+      extension_name = "ContainerInsights"
+      streams        = ["Microsoft-ContainerInsights-Group-Default"]
+      extension_json = <<JSON
+      {
+        "dataCollectionSettings": {
+          "interval": "1m",
+          "namespaceFilteringMode": "Off",
+          "enableContainerLogV2": true
+        }
+      }
+      JSON
+    }
+  }
+
+  destinations {
+    log_analytics {
+      workspace_resource_id = azurerm_log_analytics_workspace.logs[0].id
+      name                  = azurerm_log_analytics_workspace.logs[0].name
+    }
+  }
+
+  data_flow {
+    streams      = ["Microsoft-ContainerInsights-Group-Default"]
+    destinations = [azurerm_log_analytics_workspace.logs[0].name]
+  }
+}
+
+resource "azurerm_monitor_data_collection_rule_association" "msci" {
+  count = var.enable_monitoring ? 1 : 0
+
+  target_resource_id      = azurerm_kubernetes_automatic_cluster.aks.id
+  data_collection_rule_id = azurerm_monitor_data_collection_rule.msci[0].id
+  name                    = "msci-${azurerm_kubernetes_automatic_cluster.aks.name}"
+}
+
+# prometheus based container insights
+resource "azurerm_monitor_alert_prometheus_rule_group" "ux" {
+  count = var.enable_monitoring ? 1 : 0
+
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  cluster_name        = azurerm_kubernetes_automatic_cluster.aks.name
+  name                = "UXRecordingRulesRuleGroup - ${azurerm_kubernetes_automatic_cluster.aks.name}"
+  description         = "UX Recording Rules for Linux"
+  rule_group_enabled  = true
+  interval            = "PT1M"
+  scopes = [
+    azurerm_monitor_workspace.prometheus[0].id,
+    azurerm_kubernetes_automatic_cluster.aks.id
+  ]
+
+  rule {
+    record     = "ux:pod_cpu_usage:sum_irate"
+    expression = "(sum by (namespace, pod, cluster, microsoft_resourceid) (\n\tirate(container_cpu_usage_seconds_total{container != \"\", pod != \"\", job = \"cadvisor\"}[5m])\n)) * on (pod, namespace, cluster, microsoft_resourceid) group_left (node, created_by_name, created_by_kind)\n(max by (node, created_by_name, created_by_kind, pod, namespace, cluster, microsoft_resourceid) (kube_pod_info{pod != \"\", job = \"kube-state-metrics\"}))"
+  }
+
+  rule {
+    record     = "ux:controller_cpu_usage:sum_irate"
+    expression = "sum by (namespace, node, cluster, created_by_name, created_by_kind, microsoft_resourceid) (\nux:pod_cpu_usage:sum_irate\n)\n"
+  }
+
+  rule {
+    record     = "ux:pod_workingset_memory:sum"
+    expression = "(\n\t    sum by (namespace, pod, cluster, microsoft_resourceid) (\n\t\tcontainer_memory_working_set_bytes{container != \"\", pod != \"\", job = \"cadvisor\"}\n\t    )\n\t) * on (pod, namespace, cluster, microsoft_resourceid) group_left (node, created_by_name, created_by_kind)\n(max by (node, created_by_name, created_by_kind, pod, namespace, cluster, microsoft_resourceid) (kube_pod_info{pod != \"\", job = \"kube-state-metrics\"}))"
+  }
+
+  rule {
+    record     = "ux:controller_workingset_memory:sum"
+    expression = "sum by (namespace, node, cluster, created_by_name, created_by_kind, microsoft_resourceid) (\nux:pod_workingset_memory:sum\n)"
+  }
+
+  rule {
+    record     = "ux:pod_rss_memory:sum"
+    expression = "(\n\t    sum by (namespace, pod, cluster, microsoft_resourceid) (\n\t\tcontainer_memory_rss{container != \"\", pod != \"\", job = \"cadvisor\"}\n\t    )\n\t) * on (pod, namespace, cluster, microsoft_resourceid) group_left (node, created_by_name, created_by_kind)\n(max by (node, created_by_name, created_by_kind, pod, namespace, cluster, microsoft_resourceid) (kube_pod_info{pod != \"\", job = \"kube-state-metrics\"}))"
+  }
+
+  rule {
+    record     = "ux:controller_rss_memory:sum"
+    expression = "sum by (namespace, node, cluster, created_by_name, created_by_kind, microsoft_resourceid) (\nux:pod_rss_memory:sum\n)"
+  }
+
+  rule {
+    record     = "ux:pod_container_count:sum"
+    expression = "sum by (node, created_by_name, created_by_kind, namespace, cluster, pod, microsoft_resourceid) (\n(\n(\nsum by (container, pod, namespace, cluster, microsoft_resourceid) (kube_pod_container_info{container != \"\", pod != \"\", container_id != \"\", job = \"kube-state-metrics\"})\nor sum by (container, pod, namespace, cluster, microsoft_resourceid) (kube_pod_init_container_info{container != \"\", pod != \"\", container_id != \"\", job = \"kube-state-metrics\"})\n)\n* on (pod, namespace, cluster, microsoft_resourceid) group_left (node, created_by_name, created_by_kind)\n(\nmax by (node, created_by_name, created_by_kind, pod, namespace, cluster, microsoft_resourceid) (\n\tkube_pod_info{pod != \"\", job = \"kube-state-metrics\"}\n)\n)\n)\n\n)"
+  }
+
+  rule {
+    record     = "ux:controller_container_count:sum"
+    expression = "sum by (node, created_by_name, created_by_kind, namespace, cluster, microsoft_resourceid) (\nux:pod_container_count:sum\n)"
+  }
+
+  rule {
+    record     = "ux:pod_container_restarts:max"
+    expression = "max by (node, created_by_name, created_by_kind, namespace, cluster, pod, microsoft_resourceid) (\n(\n(\nmax by (container, pod, namespace, cluster, microsoft_resourceid) (kube_pod_container_status_restarts_total{container != \"\", pod != \"\", job = \"kube-state-metrics\"})\nor sum by (container, pod, namespace, cluster, microsoft_resourceid) (kube_pod_init_status_restarts_total{container != \"\", pod != \"\", job = \"kube-state-metrics\"})\n)\n* on (pod, namespace, cluster, microsoft_resourceid) group_left (node, created_by_name, created_by_kind)\n(\nmax by (node, created_by_name, created_by_kind, pod, namespace, cluster, microsoft_resourceid) (\n\tkube_pod_info{pod != \"\", job = \"kube-state-metrics\"}\n)\n)\n)\n\n)"
+  }
+
+  rule {
+    record     = "ux:controller_container_restarts:max"
+    expression = "max by (node, created_by_name, created_by_kind, namespace, cluster, microsoft_resourceid) (\nux:pod_container_restarts:max\n)"
+  }
+
+  rule {
+    record     = "ux:pod_resource_limit:sum"
+    expression = "(sum by (cluster, pod, namespace, resource, microsoft_resourceid) (\n(\n\tmax by (cluster, microsoft_resourceid, pod, container, namespace, resource)\n\t (kube_pod_container_resource_limits{container != \"\", pod != \"\", job = \"kube-state-metrics\"})\n)\n)unless (count by (pod, namespace, cluster, resource, microsoft_resourceid)\n\t(kube_pod_container_resource_limits{container != \"\", pod != \"\", job = \"kube-state-metrics\"})\n!= on (pod, namespace, cluster, microsoft_resourceid) group_left()\n sum by (pod, namespace, cluster, microsoft_resourceid)\n (kube_pod_container_info{container != \"\", pod != \"\", job = \"kube-state-metrics\"}) \n)\n\n)* on (namespace, pod, cluster, microsoft_resourceid) group_left (node, created_by_kind, created_by_name)\n(\n\tkube_pod_info{pod != \"\", job = \"kube-state-metrics\"}\n)"
+  }
+
+  rule {
+    record     = "ux:controller_resource_limit:sum"
+    expression = "sum by (cluster, namespace, created_by_name, created_by_kind, node, resource, microsoft_resourceid) (\nux:pod_resource_limit:sum\n)"
+  }
+
+  rule {
+    record     = "ux:controller_pod_phase_count:sum"
+    expression = "sum by (cluster, phase, node, created_by_kind, created_by_name, namespace, microsoft_resourceid) ( (\n(kube_pod_status_phase{job=\"kube-state-metrics\",pod!=\"\"})\n or (label_replace((count(kube_pod_deletion_timestamp{job=\"kube-state-metrics\",pod!=\"\"}) by (namespace, pod, cluster, microsoft_resourceid) * count(kube_pod_status_reason{reason=\"NodeLost\", job=\"kube-state-metrics\"} == 0) by (namespace, pod, cluster, microsoft_resourceid)), \"phase\", \"terminating\", \"\", \"\"))) * on (pod, namespace, cluster, microsoft_resourceid) group_left (node, created_by_name, created_by_kind)\n(\nmax by (node, created_by_name, created_by_kind, pod, namespace, cluster, microsoft_resourceid) (\nkube_pod_info{job=\"kube-state-metrics\",pod!=\"\"}\n)\n)\n)"
+  }
+
+  rule {
+    record     = "ux:cluster_pod_phase_count:sum"
+    expression = "sum by (cluster, phase, node, namespace, microsoft_resourceid) (\nux:controller_pod_phase_count:sum\n)"
+  }
+
+  rule {
+    record     = "ux:node_cpu_usage:sum_irate"
+    expression = "sum by (instance, cluster, microsoft_resourceid) (\n(1 - irate(node_cpu_seconds_total{job=\"node\", mode=\"idle\"}[5m]))\n)"
+  }
+
+  rule {
+    record     = "ux:node_memory_usage:sum"
+    expression = "sum by (instance, cluster, microsoft_resourceid) ((\nnode_memory_MemTotal_bytes{job = \"node\"}\n- node_memory_MemFree_bytes{job = \"node\"} \n- node_memory_cached_bytes{job = \"node\"}\n- node_memory_buffers_bytes{job = \"node\"}\n))"
+  }
+
+  rule {
+    record     = "ux:node_network_receive_drop_total:sum_irate"
+    expression = "sum by (instance, cluster, microsoft_resourceid) (irate(node_network_receive_drop_total{job=\"node\", device!=\"lo\"}[5m]))"
+  }
+
+  rule {
+    record     = "ux:node_network_transmit_drop_total:sum_irate"
+    expression = "sum by (instance, cluster, microsoft_resourceid) (irate(node_network_transmit_drop_total{job=\"node\", device!=\"lo\"}[5m]))"
+  }
+}
+
+resource "azurerm_monitor_alert_prometheus_rule_group" "uxw" {
+  count = var.enable_monitoring ? 1 : 0
+
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  cluster_name        = azurerm_kubernetes_automatic_cluster.aks.name
+  name                = "UXRecordingRulesRuleGroup-Win - ${azurerm_kubernetes_automatic_cluster.aks.name}"
+  description         = "UX Recording Rules for Windows"
+  rule_group_enabled  = false
+  interval            = "PT1M"
+  scopes = [
+    azurerm_monitor_workspace.prometheus[0].id,
+    azurerm_kubernetes_automatic_cluster.aks.id
+  ]
+
+  rule {
+    record     = "ux:pod_cpu_usage_windows:sum_irate"
+    expression = "sum by (cluster, pod, namespace, node, created_by_kind, created_by_name, microsoft_resourceid) (\n\t(\n\t\tmax by (instance, container_id, cluster, microsoft_resourceid) (\n\t\t\tirate(windows_container_cpu_usage_seconds_total{ container_id != \"\", job = \"windows-exporter\"}[5m])\n\t\t) * on (container_id, cluster, microsoft_resourceid) group_left (container, pod, namespace) (\n\t\t\tmax by (container, container_id, pod, namespace, cluster, microsoft_resourceid) (\n\t\t\t\tkube_pod_container_info{container != \"\", pod != \"\", container_id != \"\", job = \"kube-state-metrics\"}\n\t\t\t)\n\t\t)\n\t) * on (pod, namespace, cluster, microsoft_resourceid) group_left (node, created_by_name, created_by_kind)\n\t(\n\t\tmax by (node, created_by_name, created_by_kind, pod, namespace, cluster, microsoft_resourceid) (\n\t\t  kube_pod_info{ pod != \"\", job = \"kube-state-metrics\"}\n\t\t)\n\t)\n)"
+  }
+
+  rule {
+    record     = "ux:controller_cpu_usage_windows:sum_irate"
+    expression = "sum by (namespace, node, cluster, created_by_name, created_by_kind, microsoft_resourceid) (\nux:pod_cpu_usage_windows:sum_irate\n)\n"
+  }
+
+  rule {
+    record     = "ux:pod_workingset_memory_windows:sum"
+    expression = "sum by (cluster, pod, namespace, node, created_by_kind, created_by_name, microsoft_resourceid) (\n\t(\n\t\tmax by (instance, container_id, cluster, microsoft_resourceid) (\n\t\t\twindows_container_memory_usage_private_working_set_bytes{ container_id != \"\", job = \"windows-exporter\"}\n\t\t) * on (container_id, cluster, microsoft_resourceid) group_left (container, pod, namespace) (\n\t\t\tmax by (container, container_id, pod, namespace, cluster, microsoft_resourceid) (\n\t\t\t\tkube_pod_container_info{container != \"\", pod != \"\", container_id != \"\", job = \"kube-state-metrics\"}\n\t\t\t)\n\t\t)\n\t) * on (pod, namespace, cluster, microsoft_resourceid) group_left (node, created_by_name, created_by_kind)\n\t(\n\t\tmax by (node, created_by_name, created_by_kind, pod, namespace, cluster, microsoft_resourceid) (\n\t\t  kube_pod_info{ pod != \"\", job = \"kube-state-metrics\"}\n\t\t)\n\t)\n)"
+  }
+
+  rule {
+    record     = "ux:controller_workingset_memory_windows:sum"
+    expression = "sum by (namespace, node, cluster, created_by_name, created_by_kind, microsoft_resourceid) (\nux:pod_workingset_memory_windows:sum\n)"
+  }
+
+  rule {
+    record     = "ux:node_cpu_usage_windows:sum_irate"
+    expression = "sum by (instance, cluster, microsoft_resourceid) (\n(1 - irate(windows_cpu_time_total{job=\"windows-exporter\", mode=\"idle\"}[5m]))\n)"
+  }
+
+  rule {
+    record     = "ux:node_memory_usage_windows:sum"
+    expression = "sum by (instance, cluster, microsoft_resourceid) ((\nwindows_os_visible_memory_bytes{job = \"windows-exporter\"}\n- windows_memory_available_bytes{job = \"windows-exporter\"}\n))"
+  }
+
+  rule {
+    record     = "ux:node_network_packets_received_drop_total_windows:sum_irate"
+    expression = "sum by (instance, cluster, microsoft_resourceid) (irate(windows_net_packets_received_discarded_total{job=\"windows-exporter\", device!=\"lo\"}[5m]))"
+  }
+
+  rule {
+    record     = "ux:node_network_packets_outbound_drop_total_windows:sum_irate"
+    expression = "sum by (instance, cluster, microsoft_resourceid) (irate(windows_net_packets_outbound_discarded_total{job=\"windows-exporter\", device!=\"lo\"}[5m]))"
+  }
+}

--- a/examples/azure/anyscale-on-azure-aks-automatic/sample-workload/job.yaml
+++ b/examples/azure/anyscale-on-azure-aks-automatic/sample-workload/job.yaml
@@ -1,0 +1,31 @@
+# Smoke-test job for a freshly deployed Anyscale-on-AKS-Automatic cloud.
+#
+#   export ANYSCALE_HOST=https://console.azure.anyscale.com
+#   anyscale job submit -f job.yaml \
+#     --cloud "$(cd .. && terraform output -raw anyscale_cloud_cli_name)" --wait
+#
+# NOTE: --cloud takes the cloud's FULL LOWERCASED ARM RESOURCE ID, which is what
+# the Anyscale control plane registers as its name — not the Azure resource name
+# from `anyscale_cloud_name`. Passing the latter returns a 404. The
+# `anyscale_cloud_cli_name` output renders the right value.
+#
+# A green run proves the operator was admitted (deployment safeguards
+# exclusion), Karpenter provisioned worker capacity on demand, and the cloud's
+# storage and image plumbing work.
+name: anyscale-aks-automatic-smoke-test
+
+entrypoint: python main.py
+
+working_dir: .
+
+# No image_uri: the Anyscale default runtime image already carries Ray, which
+# is all main.py needs on the CPU path. For the GPU path, point this at an
+# image with a CUDA-enabled torch build — e.g. one built from your own ACR
+# (terraform output acr_login_server).
+# image_uri: <your-acr>.azurecr.io/anyscale-gpu:latest
+
+# Fail fast rather than retrying into a misconfiguration.
+max_retries: 0
+
+# env_vars:
+#   RUN_GPU_CHECK: "1"   # requires a gpu_nodepool_configs entry

--- a/examples/azure/anyscale-on-azure-aks-automatic/sample-workload/main.py
+++ b/examples/azure/anyscale-on-azure-aks-automatic/sample-workload/main.py
@@ -1,0 +1,82 @@
+"""Smoke-test workload for an Anyscale-on-AKS-Automatic cloud.
+
+Proves three things end to end, in order of how likely they are to be the
+thing that is broken:
+
+  1. The Anyscale operator scheduled a Ray head pod at all. On AKS Automatic
+     that means deployment safeguards did NOT reject it — the single most
+     common first-deploy failure (see the exclusion patch in aks.tf).
+  2. Karpenter provisioned worker capacity on demand. There are no
+     pre-provisioned node pools in this stack; every worker node is created
+     in response to a pending Ray task.
+  3. Optionally, that a GPU node came up with working AKS-managed NVIDIA
+     drivers — the replacement for the GPU operator chart in the
+     `anyscale-on-azure-new-aks` sibling.
+
+Run it with `anyscale job submit -f job.yaml --wait`, or from a workspace
+terminal with `python main.py`.
+"""
+
+import os
+import platform
+import socket
+
+import ray
+
+
+@ray.remote
+def whoami() -> dict:
+    """Runs on a Ray worker — i.e. on a Karpenter-provisioned node."""
+    return {
+        "hostname": socket.gethostname(),
+        "node_ip": ray.util.get_node_ip_address(),
+        "python": platform.python_version(),
+    }
+
+
+@ray.remote(num_gpus=1)
+def gpu_check() -> dict:
+    """Runs only on a GPU node, and only if a GPU NodePool exists.
+
+    Importing torch here rather than at module scope keeps the CPU-only path
+    working on images without it.
+    """
+    import torch
+
+    return {
+        "hostname": socket.gethostname(),
+        "cuda_available": torch.cuda.is_available(),
+        "device_count": torch.cuda.device_count(),
+        "device_name": torch.cuda.get_device_name(0) if torch.cuda.is_available() else None,
+    }
+
+
+def main() -> None:
+    ray.init()
+
+    print("=== cluster ===")
+    print(f"ray version:  {ray.__version__}")
+    print(f"cluster CPUs: {ray.cluster_resources().get('CPU')}")
+    print(f"cluster GPUs: {ray.cluster_resources().get('GPU', 0)}")
+
+    # Enough tasks that Ray must scale out past the head node, which is what
+    # forces Karpenter to provision.
+    print("\n=== workers (forces Karpenter to provision) ===")
+    for result in ray.get([whoami.remote() for _ in range(8)]):
+        print(result)
+
+    # Opt in with RUN_GPU_CHECK=1 once a gpu_nodepool_configs entry exists.
+    # Without one this task would stay Pending forever, so it is not the
+    # default.
+    if os.environ.get("RUN_GPU_CHECK") == "1":
+        print("\n=== gpu ===")
+        print(ray.get(gpu_check.remote()))
+    else:
+        print("\n=== gpu ===")
+        print("skipped — set RUN_GPU_CHECK=1 and configure gpu_nodepool_configs to test GPUs")
+
+    print("\nOK")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/azure/anyscale-on-azure-aks-automatic/scan-regional-quotas.sh
+++ b/examples/azure/anyscale-on-azure-aks-automatic/scan-regional-quotas.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# Scan Azure regions for CPU and GPU deployment capacity from subscription quotas.
+#
+# Usage:
+#   ./scan-regional-quotas.sh              # summary only (recommended)
+#   VERBOSE=1 ./scan-regional-quotas.sh    # summary + per-region detail
+#
+# Optional environment variables:
+#   AZURE_SUBSCRIPTION     Subscription ID or name (default: current account)
+#   REGIONS                Explicit region list (space- or comma-separated) to scan
+#                          instead of discovering via az account list-locations.
+#                          e.g. REGIONS="eastus westus2 westeurope". Used by
+#                          select-region.sh to restrict the scan to Anyscale-
+#                          supported regions.
+#   REGION_FILTER          JMESPath filter for az account list-locations
+#   MIN_CPU_VCPUS          Minimum free regional vCPUs required (default: 12 = 3x D4s_v5)
+#   MIN_GPU_VCPUS          Minimum free vCPUs per GPU family (default: 1)
+#   CPU_FAMILY_PATTERN     Require headroom in a VM family (regex), e.g. 'DSv5'
+#   NODE_VM_SIZE           Sets CPU_FAMILY_PATTERN from VM size (e.g. Standard_D4s_v5)
+#   VERBOSE=1              Print per-region quota tables in addition to summary
+
+set -euo pipefail
+
+REGION_FILTER="${REGION_FILTER:-[?metadata.regionType=='Physical']}"
+MIN_CPU_VCPUS="${MIN_CPU_VCPUS:-12}"
+MIN_GPU_VCPUS="${MIN_GPU_VCPUS:-1}"
+VERBOSE="${VERBOSE:-0}"
+CPU_FAMILY_PATTERN="${CPU_FAMILY_PATTERN:-}"
+
+if [[ -n "${NODE_VM_SIZE:-}" ]]; then
+  case "${NODE_VM_SIZE}" in
+    Standard_D4s_v5|Standard_D4s_v6|Standard_D2s_v5|Standard_D8s_v5) CPU_FAMILY_PATTERN='DSv5|Dsv5|Dv5' ;;
+    Standard_E4s_v5|Standard_E8s_v5) CPU_FAMILY_PATTERN='ESv5|Esv5|Ev5' ;;
+  esac
+fi
+
+GPU_FAMILY_RE='Standard NC|Standard ND|Standard NV|Standard NG|NDISR'
+SUBSCRIPTION="${AZURE_SUBSCRIPTION:-$(az account show --query id -o tsv)}"
+
+if ! command -v az &>/dev/null || ! command -v jq &>/dev/null; then
+  echo "Requires: az (Azure CLI) and jq" >&2
+  exit 1
+fi
+
+TMP="$(mktemp)"
+RESULTS="$(mktemp)"
+trap 'rm -f "$TMP" "$RESULTS"' EXIT
+
+if [[ -n "${REGIONS:-}" ]]; then
+  # Explicit region list wins over discovery. Accept commas or whitespace.
+  printf '%s\n' ${REGIONS//,/ } | sort -u >"$TMP"
+else
+  az account list-locations \
+    --query "${REGION_FILTER}.name" -o tsv 2>/dev/null | sort -u >"$TMP"
+fi
+
+analyze_region() {
+  local loc="$1"
+  local json="$2"
+  echo "$json" | jq -c \
+    --arg loc "$loc" \
+    --argjson min_cpu "$MIN_CPU_VCPUS" \
+    --argjson min_gpu "$MIN_GPU_VCPUS" \
+    --arg gpu_re "$GPU_FAMILY_RE" \
+    --arg cpu_fam_re "${CPU_FAMILY_PATTERN}" '
+    (.[] | select(.name.value == "cores")) as $cores |
+    {
+      region: $loc,
+      cpu: (
+        if $cores == null then
+          {ok: false, usage: "n/a", avail: 0, label: "Total Regional vCPUs"}
+        else
+          (($cores.limit | tonumber) - ($cores.currentValue | tonumber)) as $avail |
+          {
+            ok: ($avail >= $min_cpu and ($cores.limit | tonumber) > 0),
+            usage: "\($cores.currentValue)/\($cores.limit)",
+            avail: $avail,
+            label: ($cores.name.localizedValue // "Total Regional vCPUs")
+          }
+        end
+      ),
+      cpu_family: (
+        if ($cpu_fam_re | length) == 0 then null
+        else
+          [.[] |
+            select(.name.localizedValue | test($cpu_fam_re; "i")) |
+            select((.limit | tonumber) > 0) |
+            {
+              name: .name.localizedValue,
+              usage: "\(.currentValue)/\(.limit)",
+              avail: ((.limit | tonumber) - (.currentValue | tonumber))
+            }
+          ] as $fams |
+          if ($fams | length) == 0 then
+            {ok: false, name: "(no matching family)", usage: "n/a", avail: 0}
+          else
+            ($fams | max_by(.avail)) as $best |
+            {ok: ($best.avail >= $min_cpu), name: $best.name, usage: $best.usage, avail: $best.avail}
+          end
+        end
+      ),
+      gpu: [
+        .[] |
+        select((.limit | tonumber) > 0) |
+        select(.name.localizedValue | test($gpu_re; "i")) |
+        ((.limit | tonumber) - (.currentValue | tonumber)) as $avail |
+        select($avail >= $min_gpu) |
+        {
+          name: .name.localizedValue,
+          usage: "\(.currentValue)/\(.limit)",
+          avail: $avail
+        }
+      ],
+      gpu_quota_no_headroom: (
+        [.[] |
+          select((.limit | tonumber) > 0) |
+          select(.name.localizedValue | test($gpu_re; "i")) |
+          select((.currentValue | tonumber) >= (.limit | tonumber)) |
+          .name.localizedValue
+        ] | length > 0
+      )
+    } |
+    if .cpu_family != null and .cpu_family.ok == false then
+      .cpu.ok = false
+    else . end
+  '
+}
+
+total=0
+scanned=0
+
+while read -r loc; do
+  [[ -z "$loc" ]] && continue
+  total=$((total + 1))
+
+  json="$(az vm list-usage -l "$loc" --subscription "$SUBSCRIPTION" -o json 2>/dev/null)" || continue
+  echo "$json" | jq -e . >/dev/null 2>&1 || continue
+  scanned=$((scanned + 1))
+
+  analyze_region "$loc" "$json" >>"$RESULTS"
+
+  if [[ "$VERBOSE" == "1" ]]; then
+    echo "=== ${loc} ==="
+    echo "$json" | jq -r --arg re "$GPU_FAMILY_RE" '
+      .[] | select(.name.value == "cores" or .name.value == "virtualMachines") |
+      "  CPU\t\(.name.localizedValue)\t\(.currentValue)/\(.limit)"
+    '
+    echo "$json" | jq -r --arg re "$GPU_FAMILY_RE" '
+      .[] | select((.limit | tonumber) > 0) |
+      select(.name.localizedValue | test($re; "i")) |
+      "  GPU\t\(.name.localizedValue)\t\(.currentValue)/\(.limit)"
+    '
+    echo ""
+  fi
+done <"$TMP"
+
+sub_name="$(az account show --subscription "$SUBSCRIPTION" --query name -o tsv 2>/dev/null || echo "$SUBSCRIPTION")"
+
+echo "=============================================================================="
+echo "REGION AVAILABILITY SUMMARY"
+echo "=============================================================================="
+echo "Subscription:     $sub_name"
+echo "Subscription ID:  $SUBSCRIPTION"
+echo "Regions scanned:  $scanned / $total (physical)"
+echo "CPU requirement:  >= ${MIN_CPU_VCPUS} free regional vCPUs (cores quota)"
+if [[ -n "$CPU_FAMILY_PATTERN" ]]; then
+  echo "                  + VM family matching /${CPU_FAMILY_PATTERN}/ with same headroom"
+fi
+echo "GPU requirement:  >= ${MIN_GPU_VCPUS} free vCPUs in NC/ND/NV/NG/NDISR families"
+echo ""
+echo "Note: Quota headroom != guaranteed capacity. A region can still be out of stock."
+echo "=============================================================================="
+echo ""
+
+print_cpu_table() {
+  echo "CPU — regions OK to deploy CPU nodes"
+  echo "------------------------------------------------------------------------------"
+  local rows
+  rows="$(jq -r 'select(.cpu.ok) | [.region, .cpu.usage, (.cpu.avail|tostring), (if .cpu_family then .cpu_family.name else "" end)] | @tsv' "$RESULTS" | sort -u)"
+  if [[ -z "$rows" ]]; then
+    echo "  (none — request quota increase or lower MIN_CPU_VCPUS)"
+  else
+    printf "  %-18s %-12s %-8s %s\n" "REGION" "USAGE" "FREE" "VM_FAMILY"
+    while IFS=$'\t' read -r region usage avail fam; do
+      printf "  %-18s %-12s %-8s %s\n" "$region" "$usage" "$avail" "${fam:-}"
+    done <<<"$rows"
+  fi
+  echo ""
+}
+
+print_gpu_table() {
+  echo "GPU — regions OK to deploy GPU nodes"
+  echo "------------------------------------------------------------------------------"
+  local rows
+  rows="$(jq -r '. as $r | $r.gpu[]? | [$r.region, .name, .usage, (.avail|tostring)] | @tsv' "$RESULTS" | sort -u)"
+  if [[ -z "$rows" ]]; then
+    echo "  (none — request GPU quota or lower MIN_GPU_VCPUS)"
+  else
+    printf "  %-18s %-42s %-12s %s\n" "REGION" "GPU_FAMILY" "USAGE" "FREE"
+    while IFS=$'\t' read -r region fam usage avail; do
+      printf "  %-18s %-42s %-12s %s\n" "$region" "$fam" "$usage" "$avail"
+    done <<<"$rows"
+  fi
+  echo ""
+}
+
+print_cpu_table
+print_gpu_table
+
+echo "BOTH CPU + GPU — use these --location values for mixed clusters"
+echo "------------------------------------------------------------------------------"
+if ! jq -e 'select(.cpu.ok) | select((.gpu | length) > 0)' "$RESULTS" >/dev/null 2>&1; then
+  echo "  (none)"
+else
+  jq -r '
+    select(.cpu.ok) |
+    select((.gpu | length) > 0) |
+    "\(.region)|CPU \(.cpu.usage) (\(.cpu.avail) free) | GPU \(.gpu[0].name) \(.gpu[0].usage) (\(.gpu[0].avail) free)"
+  ' "$RESULTS" | sort -u | while IFS='|' read -r region detail; do
+    printf "  %-18s %s\n" "$region" "$detail"
+  done
+fi
+echo ""
+
+echo "CPU ONLY (no GPU headroom in subscription)"
+echo "------------------------------------------------------------------------------"
+jq -r '
+  select(.cpu.ok) |
+  select((.gpu | length) == 0) |
+  .region
+' "$RESULTS" | sort -u | sed 's/^/  /' || echo "  (none)"
+echo ""
+
+echo "GPU ONLY (CPU quota does not meet requirement)"
+echo "------------------------------------------------------------------------------"
+jq -r '
+  select(.cpu.ok | not) |
+  select((.gpu | length) > 0) |
+  .region
+' "$RESULTS" | sort -u | sed 's/^/  /' || echo "  (none)"
+echo ""
+
+echo "NOT DEPLOYABLE — insufficient CPU and no GPU headroom"
+echo "------------------------------------------------------------------------------"
+jq -r '
+  select(.cpu.ok | not) |
+  select((.gpu | length) == 0) |
+  .region
+' "$RESULTS" | sort -u | head -20 | sed 's/^/  /'
+not_count="$(jq -r 'select(.cpu.ok | not) | select((.gpu | length) == 0) | .region' "$RESULTS" | wc -l | tr -d ' ')"
+if [[ "$not_count" -gt 20 ]]; then
+  echo "  ... and $((not_count - 20)) more regions"
+fi
+echo ""
+
+echo "=============================================================================="
+echo "NEXT STEPS"
+echo "=============================================================================="
+best="$(jq -r 'select(.cpu.ok) | select((.gpu | length) > 0) | .region' "$RESULTS" | sort -u | head -1)"
+if [[ -z "$best" ]]; then
+  best="$(jq -r 'select(.cpu.ok) | .region' "$RESULTS" | sort -u | head -1)"
+fi
+if [[ -n "$best" ]]; then
+  echo "  az group create --name my-new-rg --location ${best}"
+  echo "  az aks create --resource-group my-new-rg --name <cluster> --location ${best} \\"
+  echo "    --node-count 3 --node-vm-size Standard_D4s_v5 --network-plugin azure \\"
+  echo "    --enable-oidc-issuer --enable-workload-identity --generate-ssh-keys"
+else
+  echo "  No region meets requirements. Increase quota in Azure Portal > Subscriptions > Usage + quotas."
+fi
+echo ""
+echo "  Check one region:     az vm list-usage -l eastus -o table"
+echo "  Match your VM SKU:    NODE_VM_SIZE=Standard_D4s_v5 ./scan-regional-quotas.sh"
+echo "  Full per-region dump: VERBOSE=1 ./scan-regional-quotas.sh"
+echo "=============================================================================="

--- a/examples/azure/anyscale-on-azure-aks-automatic/select-gpu.sh
+++ b/examples/azure/anyscale-on-azure-aks-automatic/select-gpu.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+# Interactive GPU picker for the Anyscale-on-Azure example.
+#
+# The example ships with NO GPU NodePools by default (var.gpu_nodepool_configs = {}),
+# so a plain `terraform apply` never tries to create a GPU SKU that has no quota
+# or capacity in your region. Use this script to opt in to GPU capacity.
+#
+# On AKS Automatic these become Karpenter NodePool + AKSNodeClass custom
+# resources (gpu.tf), not AKS node pools. Drivers are AKS-managed.
+#
+# Flow:
+#   1. Ask which GPU type you want, from the Anyscale-supported Azure catalog.
+#   2. If you don't have one in mind, scan your chosen region for GPU SKUs that
+#      are BOTH available to your subscription AND have vCPU quota headroom.
+#   3. Write the chosen `gpu_nodepool_configs` block into terraform.tfvars.
+#
+# Each selected GPU type becomes one on-demand NodePool AND one spot NodePool
+# in gpu.tf, sharing a single AKSNodeClass.
+#
+# Usage:
+#   ./select-gpu.sh                  # interactive: choose or scan, then write tfvars
+#   ./select-gpu.sh --region eastus2 # scan/validate against a specific region
+#   ./select-gpu.sh --scan           # jump straight to the region scan
+#   ./select-gpu.sh --no-write       # choose only; don't edit terraform.tfvars
+#
+# Optional environment variables:
+#   AZURE_SUBSCRIPTION   Subscription ID or name (default: current az account)
+#   GPU_SCAN_REGION      Region to validate against (default: azure_location in
+#                        terraform.tfvars, else westus2)
+#   TFVARS_FILE          Target tfvars file to update (default: terraform.tfvars)
+
+set -euo pipefail
+
+# -----------------------------------------------------------------------------
+# Anyscale-supported Azure GPU catalog — SINGLE SOURCE OF TRUTH for this script.
+# Format: KEY|POOL_NAME|VM_SIZE|PRODUCT_NAME|GPU_COUNT
+#   KEY          logical map key written into gpu_nodepool_configs (e.g. "A100")
+#   POOL_NAME    AKS node pool name: lowercase alphanumeric, <= 8 chars
+#                (spot pools append "spot", AKS allows 12)
+#   VM_SIZE      Azure VM SKU
+#   PRODUCT_NAME nvidia.com/gpu.product node label the Anyscale operator selects on
+#   GPU_COUNT    GPUs per VM
+# These are the NVIDIA accelerator products Anyscale recognises on Azure. Keep the
+# product_name values aligned with the operator's instance-type catalog.
+# -----------------------------------------------------------------------------
+GPU_CATALOG=(
+  "T4|gput4|Standard_NC16as_T4_v3|NVIDIA-T4|1"
+  "A10|gpua10|Standard_NV36ads_A10_v5|NVIDIA-A10|1"
+  "A100|gpua100|Standard_NC24ads_A100_v4|NVIDIA-A100|1"
+  "A100x8|a100x8|Standard_ND96amsr_A100_v4|NVIDIA-A100|8"
+  "H100|gpuh100|Standard_NC40ads_H100_v5|NVIDIA-H100|1"
+  "H100x8|h100x8|Standard_ND96isr_H100_v5|NVIDIA-H100|8"
+)
+
+TFVARS_FILE="${TFVARS_FILE:-terraform.tfvars}"
+
+WRITE=1
+SCAN_FIRST=0
+REGION_ARG=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-write) WRITE=0 ;;
+    --scan)     SCAN_FIRST=1 ;;
+    --region)   REGION_ARG="${2:-}"; shift ;;
+    --region=*) REGION_ARG="${1#*=}" ;;
+    -h|--help)  sed -n '2,30p' "$0"; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+if ! command -v az &>/dev/null || ! command -v jq &>/dev/null; then
+  echo "Requires: az (Azure CLI) and jq. Install with: brew install azure-cli jq" >&2
+  exit 1
+fi
+
+if ! az account show &>/dev/null; then
+  echo "Not signed in to Azure. Run ./azure-login.sh (or 'az login') first." >&2
+  exit 1
+fi
+
+SUBSCRIPTION="${AZURE_SUBSCRIPTION:-$(az account show --query id -o tsv)}"
+SUB_NAME="$(az account show --subscription "$SUBSCRIPTION" --query name -o tsv 2>/dev/null || echo "$SUBSCRIPTION")"
+
+# -----------------------------------------------------------------------------
+# Resolve the region: --region > GPU_SCAN_REGION > azure_location in tfvars > default.
+# -----------------------------------------------------------------------------
+tfvars_region=""
+if [[ -f "$TFVARS_FILE" ]]; then
+  tfvars_region="$(grep -E '^[[:space:]]*azure_location[[:space:]]*=' "$TFVARS_FILE" 2>/dev/null \
+    | head -1 | sed -E 's/.*=[[:space:]]*"?([a-z0-9]+)"?.*/\1/' || true)"
+fi
+REGION="${REGION_ARG:-${GPU_SCAN_REGION:-${tfvars_region:-westus2}}}"
+
+echo "=============================================================================="
+echo "ANYSCALE-ON-AZURE — GPU NODE POOL SELECTION"
+echo "=============================================================================="
+echo "Subscription:    $SUB_NAME"
+echo "Subscription ID: $SUBSCRIPTION"
+echo "Region:          $REGION   (override with --region <name>)"
+echo ""
+
+# -----------------------------------------------------------------------------
+# Scan the region once: which catalog SKUs are available + have quota?
+# Populates AVAIL[idx] = ok|restricted|missing and FREE[idx] = free vCPUs (-1 unknown),
+# VCPUS[idx] = vCPUs per VM. Lazily run only when needed (menu choice 's' or --scan).
+# -----------------------------------------------------------------------------
+declare -a AVAIL=() FREE=() VCPUS=()
+SCANNED=0
+
+scan_region() {
+  [[ "$SCANNED" == "1" ]] && return 0
+  echo "Scanning $REGION for GPU SKU availability and quota (this takes a moment)..."
+  echo ""
+
+  local skus usage
+  skus="$(az vm list-skus -l "$REGION" --resource-type virtualMachines --all -o json 2>/dev/null || echo '[]')"
+  usage="$(az vm list-usage -l "$REGION" --subscription "$SUBSCRIPTION" -o json 2>/dev/null || echo '[]')"
+
+  local i entry vm_size sku vcpus family avail free
+  for i in "${!GPU_CATALOG[@]}"; do
+    IFS='|' read -r _ _ vm_size _ _ <<<"${GPU_CATALOG[$i]}"
+
+    sku="$(echo "$skus" | jq -c --arg n "$vm_size" 'map(select(.name==$n)) | .[0] // null')"
+    if [[ "$sku" == "null" || -z "$sku" ]]; then
+      AVAIL[$i]="missing"; VCPUS[$i]=0; FREE[$i]=-1; continue
+    fi
+
+    # Available unless a Location restriction makes it NotAvailableForSubscription.
+    avail="$(echo "$sku" | jq -r '
+      (.restrictions // [])
+      | map(select(.type=="Location" and .reasonCode=="NotAvailableForSubscription"))
+      | if length > 0 then "restricted" else "ok" end')"
+    vcpus="$(echo "$sku" | jq -r '(.capabilities // []) | map(select(.name=="vCPUs"))[0].value // "0"')"
+    family="$(echo "$sku" | jq -r '.family // ""')"
+
+    # Free vCPUs in that SKU's quota family (-1 if the family is not reported).
+    free="$(echo "$usage" | jq -r --arg f "$family" '
+      map(select(.name.value==$f))[0]
+      | if . == null then -1 else ((.limit|tonumber) - (.currentValue|tonumber)) end')"
+
+    AVAIL[$i]="$avail"; VCPUS[$i]="$vcpus"; FREE[$i]="$free"
+  done
+  SCANNED=1
+}
+
+# Deployable = available in region AND quota family has room for >= 1 VM.
+is_deployable() {
+  local i="$1"
+  [[ "${AVAIL[$i]:-}" == "ok" ]] || return 1
+  local free="${FREE[$i]:--1}" vcpus="${VCPUS[$i]:-0}"
+  # Unknown quota family (-1) → don't block; let apply surface a quota error if any.
+  [[ "$free" == "-1" ]] && return 0
+  (( free >= vcpus ))
+}
+
+status_label() {
+  local i="$1"
+  [[ "$SCANNED" == "1" ]] || { echo ""; return; }
+  case "${AVAIL[$i]:-}" in
+    missing)    echo "not offered in $REGION" ;;
+    restricted) echo "NOT available to your subscription in $REGION" ;;
+    ok)
+      local free="${FREE[$i]:--1}" vcpus="${VCPUS[$i]:-0}"
+      if [[ "$free" == "-1" ]]; then echo "available (quota unknown)"
+      elif (( free >= vcpus )); then echo "deployable — ${free} free vCPUs (needs ${vcpus})"
+      else echo "available but NO quota — ${free} free vCPUs (needs ${vcpus})"
+      fi ;;
+    *) echo "" ;;
+  esac
+}
+
+print_catalog() {
+  local i key pool vm_size product count st
+  printf "  %-3s %-8s %-28s %-16s %-5s %s\n" "#" "TYPE" "VM_SIZE" "PRODUCT" "GPUS" "$([[ $SCANNED == 1 ]] && echo "STATUS ($REGION)")"
+  for i in "${!GPU_CATALOG[@]}"; do
+    IFS='|' read -r key pool vm_size product count <<<"${GPU_CATALOG[$i]}"
+    st="$(status_label "$i")"
+    printf "  %-3s %-8s %-28s %-16s %-5s %s\n" "$((i + 1))" "$key" "$vm_size" "$product" "$count" "$st"
+  done
+}
+
+# -----------------------------------------------------------------------------
+# Menu.
+# -----------------------------------------------------------------------------
+[[ "$SCAN_FIRST" == "1" ]] && scan_region
+
+echo "Anyscale-supported Azure GPU SKUs:"
+echo "------------------------------------------------------------------------------"
+print_catalog
+echo ""
+echo "Each type you pick becomes one ON-DEMAND pool + one SPOT pool (autoscaling 0-10)."
+echo ""
+echo "Choose:"
+echo "  - one or more numbers (comma-separated, e.g. 1,3) to select those GPU types"
+echo "  - s : scan $REGION and show which are actually deployable, then choose"
+echo "  - n : none — deploy CPU-only (clears gpu_nodepool_configs)"
+echo "  - q : quit without changes"
+echo ""
+
+declare -a SELECTED_IDX=()
+
+parse_selection() {
+  # Validate a comma/space-separated list of 1-based catalog numbers.
+  local raw="$1" tok idx
+  SELECTED_IDX=()
+  for tok in ${raw//,/ }; do
+    if [[ ! "$tok" =~ ^[0-9]+$ ]]; then echo "  '$tok' is not a number." >&2; return 1; fi
+    idx=$((tok - 1))
+    if (( idx < 0 || idx >= ${#GPU_CATALOG[@]} )); then
+      echo "  $tok is out of range (1-${#GPU_CATALOG[@]})." >&2; return 1
+    fi
+    SELECTED_IDX+=("$idx")
+  done
+  [[ "${#SELECTED_IDX[@]}" -gt 0 ]]
+}
+
+while true; do
+  read -r -p "Selection > " choice
+  case "$choice" in
+    q|Q) echo "Aborted. No changes made."; exit 0 ;;
+    n|N) SELECTED_IDX=(); break ;;
+    s|S)
+      scan_region
+      echo ""
+      echo "Deployable GPU types in $REGION:"
+      echo "------------------------------------------------------------------------------"
+      print_catalog
+      echo ""
+      any_deployable=0
+      for i in "${!GPU_CATALOG[@]}"; do is_deployable "$i" && any_deployable=1; done
+      if [[ "$any_deployable" == "0" ]]; then
+        echo "No catalog GPU SKU is deployable in $REGION (none available with quota)."
+        echo "Options: request GPU quota (Azure Portal > Usage + quotas), pick another"
+        echo "region with ./select-region.sh, or choose 'n' for a CPU-only cluster."
+        echo ""
+      fi
+      echo "Enter number(s) of the GPU type(s) to use (or n / q):"
+      ;;
+    '') echo "  Enter a number, s, n, or q." ;;
+    *)
+      if parse_selection "$choice"; then
+        # If we've scanned, warn (don't block) on non-deployable picks.
+        if [[ "$SCANNED" == "1" ]]; then
+          for i in "${SELECTED_IDX[@]}"; do
+            if ! is_deployable "$i"; then
+              IFS='|' read -r key _ _ _ _ <<<"${GPU_CATALOG[$i]}"
+              echo "  WARNING: $key is '$(status_label "$i")'. apply may fail."
+            fi
+          done
+        fi
+        break
+      fi
+      ;;
+  esac
+done
+
+# -----------------------------------------------------------------------------
+# Build the gpu_nodepool_configs HCL block.
+# -----------------------------------------------------------------------------
+build_block() {
+  local i key pool vm_size product count
+  if [[ "${#SELECTED_IDX[@]}" -eq 0 ]]; then
+    echo "gpu_nodepool_configs = {}"
+    return
+  fi
+  echo "gpu_nodepool_configs = {"
+  for i in "${SELECTED_IDX[@]}"; do
+    IFS='|' read -r key pool vm_size product count <<<"${GPU_CATALOG[$i]}"
+    printf '  %s = {\n' "$key"
+    printf '    name         = "%s"\n' "$pool"
+    printf '    vm_size      = "%s"\n' "$vm_size"
+    printf '    product_name = "%s"\n' "$product"
+    printf '    gpu_count    = "%s"\n' "$count"
+    printf '  }\n'
+  done
+  echo "}"
+}
+
+BLOCK="$(build_block)"
+
+echo ""
+echo "=============================================================================="
+echo "gpu_nodepool_configs"
+echo "=============================================================================="
+echo "$BLOCK"
+echo ""
+
+if [[ "$WRITE" == "0" ]]; then
+  echo "Skipping $TFVARS_FILE update (--no-write). To apply manually, paste the block"
+  echo "above into terraform.tfvars, or pass it via -var-file."
+  exit 0
+fi
+
+# -----------------------------------------------------------------------------
+# Write into terraform.tfvars: remove any existing top-level gpu_nodepool_configs
+# block (brace-balanced), then append the new one.
+# -----------------------------------------------------------------------------
+[[ -f "$TFVARS_FILE" ]] || : >"$TFVARS_FILE"
+
+if grep -qE '^[[:space:]]*gpu_nodepool_configs[[:space:]]*=' "$TFVARS_FILE"; then
+  tmp="$(mktemp)"
+  awk '
+    skip == 1 {
+      depth += gsub(/{/, "{") - gsub(/}/, "}")
+      if (depth <= 0) skip = 0
+      next
+    }
+    $0 ~ /^[[:space:]]*gpu_nodepool_configs[[:space:]]*=/ {
+      skip = 1
+      depth = gsub(/{/, "{") - gsub(/}/, "}")
+      if (depth <= 0) skip = 0
+      next
+    }
+    { print }
+  ' "$TFVARS_FILE" >"$tmp"
+  # Drop trailing blank lines left behind, then re-append the new block.
+  awk 'NF {blank=0} !NF {blank++} {lines[NR]=$0} END {for(i=1;i<=NR-blank;i++) print lines[i]}' "$tmp" >"$TFVARS_FILE"
+  rm -f "$tmp"
+  echo "Replaced existing gpu_nodepool_configs in $TFVARS_FILE"
+else
+  echo "Appended gpu_nodepool_configs to $TFVARS_FILE"
+fi
+
+{
+  echo ""
+  echo "$BLOCK"
+} >>"$TFVARS_FILE"
+
+echo ""
+echo "Next:"
+echo "  terraform plan      # review the GPU node pools that will be created"
+echo "  terraform apply"

--- a/examples/azure/anyscale-on-azure-aks-automatic/select-region.sh
+++ b/examples/azure/anyscale-on-azure-aks-automatic/select-region.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# Interactive region picker for the Anyscale-on-Azure example.
+#
+# Flow:
+#   1. Print the regions supported by BOTH Anyscale.Platform/clouds and AKS
+#      Automatic (the intersection — westcentralus is Anyscale-only and drops out).
+#   2. Scan your subscription's CPU (and GPU) quota in each of those regions.
+#   3. Prompt you to choose a deployable region and write it to terraform.tfvars
+#      as `azure_location`.
+#
+# Usage:
+#   ./select-region.sh                 # interactive: scan, choose, write tfvars
+#   ./select-region.sh --detailed      # also print the full scan-regional-quotas.sh report
+#   ./select-region.sh --no-write      # scan + choose, but don't touch terraform.tfvars
+#
+# Optional environment variables:
+#   AZURE_SUBSCRIPTION   Subscription ID or name (default: current az account)
+#   MIN_CPU_VCPUS        Minimum free regional vCPUs to consider a region deployable
+#                        (default: 24 — headroom for the system + CPU node pools)
+#   CPU_VM_SIZE          VM size used to derive the CPU family quota check
+#                        (default: Standard_D8s_v5 — a representative CPU worker.
+#                        AKS Automatic sizes nodes via Karpenter, so this is a
+#                        quota yardstick, not a configured VM size.)
+#   TFVARS_FILE          Target tfvars file to update (default: terraform.tfvars)
+
+set -euo pipefail
+
+# -----------------------------------------------------------------------------
+# Anyscale ∩ AKS Automatic regions — SINGLE SOURCE OF TRUTH for this script.
+# Keep in sync with the validation block in variables.tf, the README, and
+# terraform.tfvars.example.
+# -----------------------------------------------------------------------------
+ANYSCALE_REGIONS=(
+  eastus eastus2 westus2 westus3
+  southcentralus westeurope swedencentral uksouth
+  australiaeast southeastasia northeurope
+)
+
+MIN_CPU_VCPUS="${MIN_CPU_VCPUS:-24}"
+CPU_VM_SIZE="${CPU_VM_SIZE:-Standard_D8s_v5}"
+TFVARS_FILE="${TFVARS_FILE:-terraform.tfvars}"
+GPU_FAMILY_RE='Standard NC|Standard ND|Standard NV|Standard NG|NDISR'
+
+DETAILED=0
+WRITE=1
+for arg in "$@"; do
+  case "$arg" in
+    --detailed)  DETAILED=1 ;;
+    --no-write)  WRITE=0 ;;
+    -h|--help)   sed -n '2,24p' "$0"; exit 0 ;;
+    *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+  esac
+done
+
+if ! command -v az &>/dev/null || ! command -v jq &>/dev/null; then
+  echo "Requires: az (Azure CLI) and jq. Install with: brew install azure-cli jq" >&2
+  exit 1
+fi
+
+if ! az account show &>/dev/null; then
+  echo "Not signed in to Azure. Run ./azure-login.sh (or 'az login') first." >&2
+  exit 1
+fi
+
+SUBSCRIPTION="${AZURE_SUBSCRIPTION:-$(az account show --query id -o tsv)}"
+SUB_NAME="$(az account show --subscription "$SUBSCRIPTION" --query name -o tsv 2>/dev/null || echo "$SUBSCRIPTION")"
+
+# Map the CPU VM size to a quota-family regex (mirrors scan-regional-quotas.sh).
+CPU_FAMILY_PATTERN=""
+case "$CPU_VM_SIZE" in
+  Standard_D*s_v5|Standard_D*_v5) CPU_FAMILY_PATTERN='DSv5|Dsv5|Dv5' ;;
+  Standard_D*s_v6|Standard_D*_v6) CPU_FAMILY_PATTERN='DSv6|Dsv6|Dv6' ;;
+  Standard_E*s_v5|Standard_E*_v5) CPU_FAMILY_PATTERN='ESv5|Esv5|Ev5' ;;
+esac
+
+echo "=============================================================================="
+echo "ANYSCALE-SUPPORTED AZURE REGIONS"
+echo "=============================================================================="
+echo "Anyscale.Platform/clouds is supported only in these regions:"
+echo ""
+printf '  %s\n' "${ANYSCALE_REGIONS[@]}" | column 2>/dev/null || printf '  %s\n' "${ANYSCALE_REGIONS[@]}"
+echo ""
+echo "Subscription:    $SUB_NAME"
+echo "Subscription ID: $SUBSCRIPTION"
+echo "Deployable if:   >= ${MIN_CPU_VCPUS} free regional vCPUs"
+[[ -n "$CPU_FAMILY_PATTERN" ]] && echo "                 + headroom in the ${CPU_VM_SIZE} family (/${CPU_FAMILY_PATTERN}/)"
+echo ""
+echo "Scanning quota in ${#ANYSCALE_REGIONS[@]} regions (this takes a moment)..."
+echo ""
+
+# -----------------------------------------------------------------------------
+# Scan each supported region. Builds parallel arrays:
+#   DEPLOYABLE[]  — region names that meet the CPU requirement
+#   ROWS[]        — display rows (region | cpu usage | free | gpu summary)
+# -----------------------------------------------------------------------------
+declare -a DEPLOYABLE=()
+declare -a ROWS=()
+
+for region in "${ANYSCALE_REGIONS[@]}"; do
+  json="$(az vm list-usage -l "$region" --subscription "$SUBSCRIPTION" -o json 2>/dev/null)" || json=""
+  if [[ -z "$json" ]] || ! echo "$json" | jq -e . >/dev/null 2>&1; then
+    ROWS+=("$region|n/a|0|unavailable|0")
+    continue
+  fi
+
+  read -r ok usage avail gpu <<<"$(echo "$json" | jq -r \
+    --argjson min "$MIN_CPU_VCPUS" \
+    --arg gpu_re "$GPU_FAMILY_RE" \
+    --arg cpu_fam_re "$CPU_FAMILY_PATTERN" '
+    (.[] | select(.name.value == "cores")) as $cores |
+    (if $cores == null then 0
+     else (($cores.limit | tonumber) - ($cores.currentValue | tonumber)) end) as $cpu_avail |
+    (if $cores == null then "n/a"
+     else "\($cores.currentValue)/\($cores.limit)" end) as $cpu_usage |
+    # CPU family headroom (if a pattern was supplied)
+    (if ($cpu_fam_re | length) == 0 then $cpu_avail
+     else
+       ([ .[]
+          | select(.name.localizedValue | test($cpu_fam_re; "i"))
+          | select((.limit | tonumber) > 0)
+          | ((.limit | tonumber) - (.currentValue | tonumber)) ] | max // 0)
+     end) as $fam_avail |
+    # GPU families with any headroom
+    ([ .[]
+       | select((.limit | tonumber) > 0)
+       | select(.name.localizedValue | test($gpu_re; "i"))
+       | select(((.limit | tonumber) - (.currentValue | tonumber)) > 0) ] | length) as $gpu_count |
+    (($cpu_avail >= $min) and ($fam_avail >= $min)) as $ok |
+    "\(if $ok then 1 else 0 end) \($cpu_usage) \($cpu_avail) \($gpu_count)"
+  ')"
+
+  if [[ "$gpu" -gt 0 ]]; then
+    gpu_label="${gpu} GPU famil$([[ "$gpu" -eq 1 ]] && echo y || echo ies)"
+  else
+    gpu_label="no GPU"
+  fi
+
+  ROWS+=("$region|$usage|$avail|$gpu_label|$ok")
+  [[ "$ok" == "1" ]] && DEPLOYABLE+=("$region")
+done
+
+# -----------------------------------------------------------------------------
+# Print the scan results.
+# -----------------------------------------------------------------------------
+echo "QUOTA SCAN RESULTS"
+echo "------------------------------------------------------------------------------"
+printf "  %-3s %-16s %-14s %-8s %-16s %s\n" "#" "REGION" "CPU_USAGE" "FREE" "GPU" "DEPLOYABLE"
+idx=0
+for row in "${ROWS[@]}"; do
+  IFS='|' read -r region usage avail gpu ok <<<"$row"
+  if [[ "$ok" == "1" ]]; then
+    idx=$((idx + 1))
+    mark="$idx"
+    flag="yes"
+  else
+    mark="-"
+    flag="no"
+  fi
+  printf "  %-3s %-16s %-14s %-8s %-16s %s\n" "$mark" "$region" "$usage" "$avail" "$gpu" "$flag"
+done
+echo ""
+
+if [[ "$DETAILED" == "1" ]]; then
+  echo "Running full scan-regional-quotas.sh report on supported regions..."
+  echo ""
+  REGIONS="${ANYSCALE_REGIONS[*]}" NODE_VM_SIZE="$CPU_VM_SIZE" \
+    MIN_CPU_VCPUS="$MIN_CPU_VCPUS" AZURE_SUBSCRIPTION="$SUBSCRIPTION" \
+    "$(dirname "$0")/scan-regional-quotas.sh" || true
+  echo ""
+fi
+
+if [[ "${#DEPLOYABLE[@]}" -eq 0 ]]; then
+  echo "No Anyscale-supported region meets the ${MIN_CPU_VCPUS}-vCPU requirement." >&2
+  echo "Request a quota increase (Azure Portal > Subscriptions > Usage + quotas)," >&2
+  echo "or re-run with a lower threshold: MIN_CPU_VCPUS=12 ./select-region.sh" >&2
+  exit 1
+fi
+
+# -----------------------------------------------------------------------------
+# Prompt for a choice.
+# -----------------------------------------------------------------------------
+echo "=============================================================================="
+echo "SELECT A REGION"
+echo "=============================================================================="
+echo "Enter the number of a deployable region (1-${#DEPLOYABLE[@]}), or q to quit:"
+printf '  %2d) %s\n' $(for i in "${!DEPLOYABLE[@]}"; do echo $((i + 1)); echo "${DEPLOYABLE[$i]}"; done)
+echo ""
+
+choice=""
+while true; do
+  read -r -p "Region # > " choice
+  case "$choice" in
+    q|Q) echo "Aborted. No changes made."; exit 0 ;;
+    ''|*[!0-9]*) echo "  Please enter a number between 1 and ${#DEPLOYABLE[@]} (or q)." ;;
+    *)
+      if (( choice >= 1 && choice <= ${#DEPLOYABLE[@]} )); then
+        break
+      fi
+      echo "  Out of range. Enter 1-${#DEPLOYABLE[@]} (or q)."
+      ;;
+  esac
+done
+
+SELECTED="${DEPLOYABLE[$((choice - 1))]}"
+echo ""
+echo "Selected region: $SELECTED"
+
+if [[ "$WRITE" == "0" ]]; then
+  echo ""
+  echo "Skipping terraform.tfvars update (--no-write). To apply manually:"
+  echo "  terraform apply -var=\"azure_location=$SELECTED\""
+  exit 0
+fi
+
+# -----------------------------------------------------------------------------
+# Write azure_location into terraform.tfvars.
+# -----------------------------------------------------------------------------
+if [[ -f "$TFVARS_FILE" ]] && grep -qE '^[[:space:]]*azure_location[[:space:]]*=' "$TFVARS_FILE"; then
+  tmp="$(mktemp)"
+  sed -E "s|^([[:space:]]*azure_location[[:space:]]*=[[:space:]]*).*|\1\"$SELECTED\"|" "$TFVARS_FILE" >"$tmp"
+  mv "$tmp" "$TFVARS_FILE"
+  echo "Updated azure_location in $TFVARS_FILE"
+else
+  printf 'azure_location = "%s"\n' "$SELECTED" >>"$TFVARS_FILE"
+  echo "Appended azure_location to $TFVARS_FILE"
+fi
+
+echo ""
+echo "Next: review $TFVARS_FILE, then run:"
+echo "  terraform init"
+echo "  terraform apply"

--- a/examples/azure/anyscale-on-azure-aks-automatic/terraform.tfvars.example
+++ b/examples/azure/anyscale-on-azure-aks-automatic/terraform.tfvars.example
@@ -1,0 +1,73 @@
+# Copy to terraform.tfvars and fill in. The helper scripts seed some of these:
+#   ./azure-login.sh     → az login + subscription selection
+#   ./select-region.sh   → writes azure_location (quota-checked)
+#   ./select-gpu.sh      → writes gpu_nodepool_configs
+
+# ── required ────────────────────────────────────────────────────────────────
+azure_subscription_id = "00000000-0000-0000-0000-000000000000"
+
+# ── common ──────────────────────────────────────────────────────────────────
+# Must be supported by BOTH Anyscale and AKS Automatic. Run ./select-region.sh.
+# NOTE: westcentralus is valid in the `anyscale-on-azure-new-aks` sibling but
+# NOT here — Anyscale supports it, AKS Automatic does not.
+# azure_location    = "westus2"
+aks_cluster_name = "anyscale-auto"
+# azure_resource_group_name = null     # default: "<aks_cluster_name>-rg"
+# anyscale_cloud_name       = null     # default: "<aks_cluster_name>-cloud"
+# anyscale_cloud_location   = null     # default: azure_location (single-region)
+
+tags = {
+  Environment = "dev"
+}
+
+# ── compute ─────────────────────────────────────────────────────────────────
+# There is no system_vm_size / cpu_vm_size here. AKS Automatic manages the
+# system pool and provisions CPU capacity on demand through its built-in
+# Karpenter NodePool. Only GPU capacity is declared, and it is OPT-IN.
+#
+# Run ./select-gpu.sh, or e.g.:
+# gpu_nodepool_configs = {
+#   T4 = {
+#     name         = "gput4"
+#     vm_size      = "Standard_NC16as_T4_v3"
+#     product_name = "NVIDIA-T4"
+#     gpu_count    = "1"
+#     # enable_spot = true    # also create a spot NodePool (default true)
+#     # max_gpus    = 16      # ceiling on GPUs this NodePool may provision
+#   }
+# }
+
+# ── networking (three subnets — see variables.tf) ───────────────────────────
+# vnet_cidr                = "10.42.0.0/16"
+# apiserver_subnet_cidr    = "10.42.0.0/28"   # delegated, /28 minimum
+# nodes_subnet_cidr        = "10.42.1.0/24"   # Karpenter workload nodes
+# system_nodes_subnet_cidr = "10.42.2.0/24"   # AKS-managed system pool
+
+# ── feature switches ────────────────────────────────────────────────────────
+# enable_monitoring                      = true   # managed Prometheus + Container Insights (GA)
+# enable_otlp_app_insights               = false  # OTLP endpoints for Ray telemetry (PREVIEW)
+# internal_gateway                       = false  # true = VNet-only data plane (re-enables LB polling)
+# enable_nfs                             = false  # Premium NFS share, subnet-restricted
+# enable_default_nginx_ingress_controller = false # keep app routing's nginx controller too
+# enable_deployment_safeguards_exclusion  = true  # LEAVE ON — the operator is rejected without it
+
+# ── hardening (see the production-readiness table in the README) ────────────
+# api_server_authorized_ip_ranges = ["203.0.113.4/32"]   # must include YOUR egress IP
+#
+# There is no private_cluster_enabled: the in-cluster bootstrap needs data-plane
+# reach to the API server. For a private API server use the
+# anyscale-on-azure-private-aks example instead.
+
+# ── registry ────────────────────────────────────────────────────────────────
+enable_acr = true
+acr_sku    = "Standard" # Premium required for Private Link
+
+# ── cluster access (Entra RBAC; local accounts are disabled on Automatic) ───
+# assign_current_principal_cluster_access = true   # needed by the bootstrap
+# aks_cluster_admin_principal_ids = ["00000000-0000-0000-0000-000000000000"]
+
+# ── access to the Anyscale cloud (see variables.tf for why this is needed) ──
+# anyscale_platform_contributors = [
+#   { principal_id = "00000000-0000-0000-0000-000000000000", principal_type = "User" },
+# ]
+# assign_current_user_platform_roles = true

--- a/examples/azure/anyscale-on-azure-aks-automatic/variables.tf
+++ b/examples/azure/anyscale-on-azure-aks-automatic/variables.tf
@@ -1,0 +1,576 @@
+variable "azure_subscription_id" {
+  description = "(Required) Azure subscription ID"
+  type        = string
+}
+
+variable "azure_tenant_id" {
+  description = "(Optional) Azure tenant ID (`az account show --query tenantId -o tsv`). Accepted for tfvars compatibility with the helper scripts; not currently referenced by resources."
+  type        = string
+  nullable    = true
+  default     = null
+}
+
+variable "azure_location" {
+  description = <<-EOT
+    (Optional) Azure region for all Azure resources, including the AKS
+    Automatic cluster. Must be in the INTERSECTION of two lists: regions where
+    `Anyscale.Platform/clouds` is supported, and regions where AKS Automatic is
+    generally available.
+
+    That intersection is: eastus, eastus2, westus2, westus3, southcentralus,
+    westeurope, swedencentral, uksouth, australiaeast, southeastasia,
+    northeurope.
+
+    NOTE FOR USERS COMING FROM `anyscale-on-azure-new-aks`: `westcentralus` is
+    valid there but NOT here — Anyscale supports it, AKS Automatic does not.
+
+    Tip: run `./select-region.sh` to print the supported regions, scan your
+    subscription's CPU/GPU quota in each, and pick a deployable region.
+  EOT
+  type        = string
+  default     = "westus2"
+
+  # Single source of truth for the supported-region intersection. Keep in sync
+  # with select-region.sh, the README, and terraform.tfvars.example.
+  validation {
+    condition = contains([
+      "eastus", "eastus2", "westus2", "westus3",
+      "southcentralus", "westeurope", "swedencentral", "uksouth",
+      "australiaeast", "southeastasia", "northeurope",
+    ], var.azure_location)
+    error_message = <<-EOT
+      azure_location must be a region supported by BOTH Anyscale.Platform/clouds
+      and AKS Automatic: eastus, eastus2, westus2, westus3, southcentralus,
+      westeurope, swedencentral, uksouth, australiaeast, southeastasia,
+      northeurope. (westcentralus is Anyscale-supported but has no AKS
+      Automatic, so it is not valid in this example.) Run ./select-region.sh to
+      scan quota and pick one.
+    EOT
+  }
+}
+
+variable "anyscale_cloud_location" {
+  description = <<-EOT
+    (Optional) Region for the `Anyscale.Platform/clouds` resource, when it must
+    differ from `azure_location`. Defaults to `azure_location` — a single-region
+    deployment is the intended shape of this example.
+
+    This override exists because the upstream awesome-aks demo splits the two
+    (cluster in one region, Anyscale cloud in another) and that split is
+    occasionally necessary when AKS Automatic is available somewhere the
+    Anyscale RP is not, or vice versa. Note that the deterministic gateway
+    hostname is derived from `azure_location` (the load balancer's region), not
+    from this value.
+  EOT
+  type        = string
+  nullable    = true
+  default     = null
+}
+
+variable "tags" {
+  description = "(Optional) Tags applied to all taggable resources."
+  type        = map(string)
+  default = {
+    Environment = "dev"
+  }
+}
+
+variable "aks_cluster_name" {
+  description = "(Optional) Name of the AKS cluster (and related resources)."
+  type        = string
+  default     = "anyscale-auto"
+}
+
+variable "azure_resource_group_name" {
+  description = "(Optional) Resource group name. Defaults to \"<aks_cluster_name>-rg\"."
+  type        = string
+  nullable    = true
+  default     = null
+}
+
+variable "anyscale_cloud_name" {
+  description = "(Optional) Anyscale cloud name as it appears in the Anyscale console. Defaults to \"<aks_cluster_name>-cloud\"."
+  type        = string
+  nullable    = true
+  default     = null
+}
+
+variable "anyscale_operator_namespace" {
+  description = "(Optional) Kubernetes namespace for the Anyscale operator. This namespace is automatically added to the deployment-safeguards exclusion list — see enable_deployment_safeguards_exclusion."
+  type        = string
+  default     = "anyscale-operator"
+}
+
+variable "anyscale_operator_serviceaccount" {
+  description = "(Optional) Kubernetes service account name the Anyscale operator runs as. The federated identity credential in identity.tf is bound to this service account name."
+  type        = string
+  default     = "anyscale-operator"
+}
+
+###############################################################################
+# Networking
+#
+# AKS Automatic with a BYO VNet needs THREE subnets (the `new-aks` sibling
+# needs one). Azure CNI overlay is Automatic's default, so pods do not consume
+# addresses from any of them.
+###############################################################################
+variable "vnet_cidr" {
+  description = "(Optional) CIDR block for the VNet."
+  type        = string
+  nullable    = false
+  default     = "10.42.0.0/16"
+}
+
+variable "apiserver_subnet_cidr" {
+  description = <<-EOT
+    (Optional) CIDR for the API Server VNet Integration subnet. This subnet is
+    delegated to `Microsoft.ContainerService/managedClusters` and must be at
+    least a /28 — Azure rejects anything smaller. Nothing else may share it.
+  EOT
+  type        = string
+  nullable    = false
+  default     = "10.42.0.0/28"
+}
+
+variable "nodes_subnet_cidr" {
+  description = "(Optional) CIDR for the user node subnet. Karpenter provisions every workload node here."
+  type        = string
+  nullable    = false
+  default     = "10.42.1.0/24"
+}
+
+variable "system_nodes_subnet_cidr" {
+  description = "(Optional) CIDR for the AKS-managed system node pool subnet (CoreDNS, metrics-server, the Karpenter controller, the app-routing Istio controller)."
+  type        = string
+  nullable    = false
+  default     = "10.42.2.0/24"
+}
+
+variable "api_server_authorized_ip_ranges" {
+  description = <<-EOT
+    (Optional) CIDRs allowed to reach the AKS API server. Empty (the default)
+    means the API server accepts connections from anywhere — convenient for a
+    first deploy, and the first thing to change for a real one. Add at minimum
+    the egress IP of wherever Terraform and the gateway bootstrap run.
+  EOT
+  type        = set(string)
+  nullable    = false
+  default     = []
+}
+
+# NOTE: there is deliberately no `private_cluster_enabled` here. The in-cluster
+# bootstrap talks to the API server over the data plane, so a private API server
+# would leave the deployment half-built. See the long comment in aks.tf, and use
+# `anyscale-on-azure-private-aks` for private deployments.
+
+variable "internal_gateway" {
+  description = <<-EOT
+    (Optional) When true, the Anyscale gateway is exposed on an INTERNAL Azure
+    Standard LB (private IP in the node subnet) instead of a public LB. The
+    Anyscale data plane is then reachable only from the VNet.
+
+    Note: internal LBs have no public DNS label, so the deterministic-hostname
+    shortcut is unavailable — Terraform falls back to polling the Gateway for
+    its address, and the address registered with the Anyscale control plane is
+    a private IP.
+  EOT
+  type        = bool
+  nullable    = false
+  default     = false
+}
+
+variable "enable_default_nginx_ingress_controller" {
+  description = <<-EOT
+    (Optional) Keep the app-routing default nginx ingress controller. False by
+    default: this example routes all Anyscale traffic through the Istio
+    `Gateway`, so the nginx controller would only add a second public load
+    balancer. Set true if you also want app routing's nginx `Ingress` support
+    for your own non-Anyscale workloads.
+  EOT
+  type        = bool
+  nullable    = false
+  default     = false
+}
+
+###############################################################################
+# Cluster access (Entra RBAC)
+#
+# AKS Automatic disables local accounts. A kubeconfig alone authorizes nothing
+# — every caller needs an AKS RBAC role assignment.
+###############################################################################
+variable "assign_current_principal_cluster_access" {
+  description = <<-EOT
+    (Optional) Grant the principal running Terraform "Azure Kubernetes Service
+    RBAC Cluster Admin" and "Azure Kubernetes Service Cluster User Role" on the
+    cluster. Required for the in-cluster bootstrap in gateway.tf — without it
+    the first `kubectl apply` fails with a 403. Set false only if the deploying
+    principal already holds equivalent access.
+  EOT
+  type        = bool
+  nullable    = false
+  default     = true
+}
+
+variable "aks_cluster_admin_principal_ids" {
+  description = "(Optional) Additional Entra object IDs (users, groups, service principals) to grant \"Azure Kubernetes Service RBAC Cluster Admin\" on the cluster."
+  type        = set(string)
+  nullable    = false
+  default     = []
+}
+
+###############################################################################
+# GPU capacity (Karpenter NodePools)
+#
+# There is no `system_vm_size` / `cpu_vm_size` here, and no `gpu_driver_mode`,
+# `gpu_operator_chart_version`, `enable_node_auto_provisioning`, or
+# `nap_gpu_sku_name`. AKS Automatic manages the system pool, provisions CPU
+# capacity from its built-in Karpenter NodePool, and installs GPU drivers
+# itself. Only GPU NodePools need declaring.
+###############################################################################
+variable "gpu_nodepool_configs" {
+  description = <<-EOT
+    (Optional) Karpenter GPU NodePools to create. Empty by default — GPU is
+    OPT-IN so a plain `terraform apply` never asks for a GPU SKU (e.g. A100)
+    that has no quota or capacity in your region. CPU capacity always works via
+    Automatic's built-in default NodePool.
+
+    Each entry renders an `AKSNodeClass` (with the AKS-managed GPU driver tag)
+    plus an on-demand `NodePool`, and a spot `NodePool` when `enable_spot` is
+    true. Nodes carry the same Anyscale taints as the static GPU pools in the
+    `anyscale-on-azure-new-aks` sibling, so operator tolerations are identical.
+
+    The map key is a logical label (e.g. "T4", "A100"). `name` is used for the
+    AKSNodeClass and NodePool object names; the spot pool appends "spot".
+
+    Tip: run `./select-gpu.sh` to pick a GPU type from the Anyscale-supported
+    catalog — or scan your chosen region for GPU SKUs that are both available
+    AND have quota — and have it write this block into terraform.tfvars.
+
+    Example:
+      gpu_nodepool_configs = {
+        T4   = { name = "gput4",   vm_size = "Standard_NC16as_T4_v3",    product_name = "NVIDIA-T4",   gpu_count = "1" }
+        A100 = { name = "gpua100", vm_size = "Standard_NC24ads_A100_v4", product_name = "NVIDIA-A100", gpu_count = "1", max_gpus = 8 }
+      }
+  EOT
+  type = map(object({
+    name         = string
+    vm_size      = string
+    product_name = string
+    gpu_count    = string
+    # Also create a spot NodePool for this SKU.
+    enable_spot = optional(bool, true)
+    # Hard ceiling on GPUs this NodePool may provision. Karpenter scales to
+    # zero when idle, so this bounds a runaway workload, not idle cost.
+    max_gpus        = optional(number, 16)
+    image_family    = optional(string, "Ubuntu2204")
+    os_disk_size_gb = optional(number, 128)
+  }))
+  default = {}
+
+  validation {
+    condition = alltrue([
+      for k, v in var.gpu_nodepool_configs : can(regex("^[a-z0-9]([a-z0-9-]{0,10}[a-z0-9])?$", v.name))
+    ])
+    error_message = "gpu_nodepool_configs name must be a lowercase RFC-1123 label, max 12 characters (the spot NodePool appends 'spot')."
+  }
+
+  validation {
+    condition = alltrue([
+      for k, v in var.gpu_nodepool_configs : can(regex("^[1-9][0-9]*$", v.gpu_count))
+    ])
+    error_message = "gpu_nodepool_configs gpu_count must be a positive integer string (e.g. \"1\", \"8\")."
+  }
+}
+
+###############################################################################
+# Deployment safeguards (Azure Policy)
+#
+# AKS Automatic turns these on in Enforcement level. The Anyscale operator and
+# the Ray pods it creates do not satisfy them — see the long comment on the
+# patch in aks.tf.
+###############################################################################
+variable "enable_deployment_safeguards_exclusion" {
+  description = <<-EOT
+    (Optional) Patch the cluster's deployment safeguards to exclude the
+    Anyscale namespaces from Azure Policy enforcement.
+
+    LEAVE THIS ON. AKS Automatic runs deployment safeguards in Enforcement, and
+    the Anyscale operator's pods (elevated init container, no resource limits
+    on control-plane-shaped Ray pods) are rejected at admission without the
+    exclusion. The failure looks like an operator deployment stuck at 0/1, not
+    like a policy error.
+  EOT
+  type        = bool
+  nullable    = false
+  default     = true
+}
+
+variable "deployment_safeguards_excluded_namespaces" {
+  description = <<-EOT
+    (Optional) Extra namespaces to exclude from deployment safeguards, on top of
+    `anyscale_operator_namespace` (which is always included). Widen this if a
+    real workload run turns up pods being rejected in another namespace —
+    preferable to dropping the safeguards level cluster-wide.
+  EOT
+  type        = list(string)
+  nullable    = false
+  default     = []
+}
+
+variable "deployment_safeguards_level" {
+  description = "(Optional) Deployment safeguards level for namespaces that are NOT excluded. \"Enforcement\" (the AKS Automatic default) or \"Warning\"."
+  type        = string
+  nullable    = false
+  default     = "Enforcement"
+
+  validation {
+    condition     = contains(["Enforcement", "Warning"], var.deployment_safeguards_level)
+    error_message = "deployment_safeguards_level must be \"Enforcement\" or \"Warning\"."
+  }
+}
+
+variable "deployment_safeguards_api_version" {
+  description = <<-EOT
+    (Optional) ARM API version for the `Microsoft.ContainerService/deploymentSafeguards`
+    extension resource. Defaults to the GA version. Check what your subscription
+    offers with:
+      az provider show -n Microsoft.ContainerService \
+        --query "resourceTypes[?resourceType=='deploymentSafeguards'].apiVersions"
+  EOT
+  type        = string
+  nullable    = false
+  default     = "2025-07-01"
+}
+
+###############################################################################
+# Storage
+###############################################################################
+variable "storage_account_name" {
+  description = "(Optional) Name of the Azure Storage account to create for cloud storage. May be needed if generated name is already taken."
+  type        = string
+  nullable    = true
+  default     = null
+
+  validation {
+    condition     = var.storage_account_name == null || can(regex("^[a-z0-9]{3,24}$", var.storage_account_name))
+    error_message = "Storage account name must be between 3 and 24 characters long and contain only lowercase letters and numbers."
+  }
+}
+
+variable "enable_nfs" {
+  description = <<-EOT
+    (Optional) Enable provisioning of an Azure NFS (Network File System) storage account.
+    This NFS storage can be used for file-based persistent storage needs, mounting shared volumes to AKS nodes and pods.
+  EOT
+  type        = bool
+  nullable    = false
+  default     = false
+}
+
+variable "storage_account_name_nfs" {
+  description = "(Optional) Name of the Azure NFS storage account to create. May be needed if generated name is already taken."
+  type        = string
+  nullable    = true
+  default     = null
+
+  validation {
+    condition     = var.storage_account_name_nfs == null || can(regex("^[a-z0-9]{3,24}$", var.storage_account_name_nfs))
+    error_message = "NFS storage account name must be between 3 and 24 characters long and contain only lowercase letters and numbers."
+  }
+}
+
+variable "cors_rule" {
+  description = <<-EOT
+    (Optional)
+    Cross-Origin Resource Sharing rule on the blob service, used by the
+    Anyscale console to render logs and artifacts in the browser. The default
+    allows the Azure-hosted console (console.azure.anyscale.com) plus the
+    *.anyscale.com console domains.
+  EOT
+  type = object({
+    allowed_headers    = list(string)
+    allowed_methods    = list(string)
+    allowed_origins    = list(string)
+    expose_headers     = list(string)
+    max_age_in_seconds = optional(number, 0)
+  })
+  default = {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET", "POST", "PUT", "HEAD", "DELETE"]
+    allowed_origins = ["https://console.azure.anyscale.com", "https://*.anyscale.com"]
+    expose_headers  = ["Accept-Ranges", "Content-Range", "Content-Length"]
+  }
+}
+
+variable "storage_use_azuread" {
+  description = "(Optional) Determines whether the provider uses AzureAD or the SharedKey from the Storage Account to connect to the Storage Blob & Queue APIs"
+  type        = bool
+  nullable    = false
+  default     = false
+}
+
+###############################################################################
+# Azure Container Registry — for Anyscale workload images
+###############################################################################
+variable "enable_acr" {
+  description = "(Optional) Create a customer-owned ACR for Anyscale workload images and grant the AKS kubelet identity AcrPull. Disable if you supply your own registry out-of-band."
+  type        = bool
+  nullable    = false
+  default     = true
+}
+
+variable "acr_name" {
+  description = "(Optional) Override the generated ACR name. Globally unique; 5-50 alphanumeric chars."
+  type        = string
+  nullable    = true
+  default     = null
+
+  validation {
+    condition     = var.acr_name == null || can(regex("^[a-zA-Z0-9]{5,50}$", var.acr_name))
+    error_message = "ACR name must be 5-50 alphanumeric characters."
+  }
+}
+
+variable "acr_sku" {
+  description = "(Optional) ACR SKU. Premium is only required for Private Link / zone redundancy / customer-managed keys."
+  type        = string
+  nullable    = false
+  default     = "Standard"
+
+  validation {
+    condition     = contains(["Basic", "Standard", "Premium"], var.acr_sku)
+    error_message = "acr_sku must be one of Basic, Standard, or Premium."
+  }
+}
+
+variable "acr_zone_redundancy_enabled" {
+  description = "(Optional) Enable zone redundancy on the ACR. Premium SKU only; ignored on Basic/Standard."
+  type        = bool
+  nullable    = false
+  default     = false
+}
+
+###############################################################################
+# Observability
+###############################################################################
+variable "enable_monitoring" {
+  description = <<-EOT
+    (Optional) Deploy the Azure-managed observability stack: Azure Monitor
+    workspace + managed Prometheus (data-collection rules, recording rule
+    groups), Log Analytics + Container Insights, and the omsagent addon.
+
+    On this stack the cluster-side half arrives as an azapi PATCH rather than
+    typed `oms_agent` / `monitor_metrics` blocks — `azurerm_kubernetes_automatic_cluster`
+    exposes neither. Same end state; see aks.tf.
+  EOT
+  type        = bool
+  nullable    = false
+  default     = true
+}
+
+variable "enable_otlp_app_insights" {
+  description = <<-EOT
+    (Optional, PREVIEW) Create an Application Insights component with OTLP
+    logs/metrics/traces ingestion endpoints (Microsoft.Insights/components
+    preview API) for Ray application telemetry, and turn on the cluster's
+    appMonitoring profile. Requires enable_monitoring.
+  EOT
+  type        = bool
+  nullable    = false
+  default     = false
+}
+
+variable "log_analytics_retention_days" {
+  description = "(Optional) Log Analytics workspace retention in days."
+  type        = number
+  nullable    = false
+  default     = 30
+}
+
+###############################################################################
+# Anyscale platform (Azure-managed control plane)
+###############################################################################
+variable "anyscale_platform" {
+  description = "(Optional) Tunables for the Anyscale.Platform/clouds resources and the Anyscale.AKS.Operator AKS extension."
+  type = object({
+    extension_resource_name          = optional(string, "anyscaleoperator")
+    control_plane_url                = optional(string, "https://console.azure.anyscale.com")
+    auth_audience                    = optional(string, "api://086bc555-6989-4362-ba30-fded273e432b/.default")
+    extension_configuration_settings = optional(map(string), {})
+    plan_name                        = optional(string, "anyscale-operator")
+    plan_publisher                   = optional(string, "anyscale1750870039553")
+    plan_product                     = optional(string, "anyscale-operator-aks")
+    release_train                    = optional(string, "stable")
+    clouds_api_version               = optional(string, "2026-02-01-preview")
+  })
+  default = {}
+}
+
+variable "anyscale_platform_contributors" {
+  description = <<-EOT
+    (Optional) Principals (users, groups, or service principals) to grant the
+    "Anyscale Platform Contributor" role on the Anyscale cloud resource.
+
+    IMPORTANT: Subscription Owner/Contributor on the underlying Azure resources
+    does NOT carry over to the Anyscale resource provider. Creating Anyscale
+    workspaces, jobs, or services requires this explicit Anyscale platform role
+    on the cloud resource itself.
+
+    Each entry needs the principal's object (principal) ID and its type
+    (User | Group | ServicePrincipal). Example:
+
+      anyscale_platform_contributors = [
+        { principal_id = "00000000-0000-0000-0000-000000000000", principal_type = "User" },
+        { principal_id = "11111111-1111-1111-1111-111111111111", principal_type = "Group" },
+      ]
+  EOT
+  type = list(object({
+    principal_id   = string
+    principal_type = optional(string, "User")
+  }))
+  default = []
+
+  validation {
+    condition     = alltrue([for c in var.anyscale_platform_contributors : contains(["User", "Group", "ServicePrincipal"], c.principal_type)])
+    error_message = "principal_type must be one of: User, Group, ServicePrincipal."
+  }
+}
+
+variable "assign_current_user_platform_roles" {
+  description = <<-EOT
+    (Optional) When true (default), Terraform runs `az role assignment create`
+    during apply to grant the signed-in `az` user both the
+    "Anyscale Platform Contributor Role" and "Anyscale Platform Reader Role"
+    on the Anyscale cloud resource.
+
+    This lets whoever runs the deploy open the cloud in the Anyscale console and
+    create workspaces/jobs/services without first looking up their own object
+    ID. Set to false to skip (e.g. in CI where the service principal already has
+    access, or when you assign roles exclusively via
+    var.anyscale_platform_contributors). Requires the Azure CLI to be installed
+    and logged in (the same `az login` the rest of the deploy relies on).
+  EOT
+  type        = bool
+  default     = true
+}
+
+###############################################################################
+# Gateway
+#
+# No chart version, no release name, no GatewayClass name: AKS Automatic
+# installs and manages the app-routing Istio controller and registers the
+# `approuting-istio` GatewayClass. Only the Gateway object is ours.
+###############################################################################
+variable "gateway" {
+  description = "(Optional) Anyscale Gateway knobs. The class name is fixed at `approuting-istio` by AKS Automatic and is therefore not configurable here."
+  type = object({
+    name = optional(string, "gateway")
+    # How long the bootstrap waits for the Gateway API CRDs and the
+    # `approuting-istio` GatewayClass to appear after the ingress-profile patch
+    # reconciles. 10+ minutes is normal; the default leaves headroom.
+    api_ready_timeout_seconds = optional(number, 1200)
+    lb_wait_timeout_seconds   = optional(number, 600)
+    lb_poll_interval_seconds  = optional(number, 10)
+  })
+  default = {}
+}

--- a/examples/azure/anyscale-on-azure-aks-automatic/versions.tf
+++ b/examples/azure/anyscale-on-azure-aks-automatic/versions.tf
@@ -1,0 +1,63 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      # >= 4.81 for the typed `azurerm_kubernetes_automatic_cluster` resource.
+      # There is no earlier release that models AKS Automatic natively — before
+      # it, the only option was a raw azapi managedClusters body.
+      version = ">= 4.81.0, < 5.0.0"
+    }
+    # azapi creates the Anyscale.Platform/clouds + cloudResources resources
+    # natively (no ARM-template deployment wrapper), and patches the two
+    # surfaces the typed cluster resource does not expose: the monitoring
+    # profile and deployment safeguards.
+    azapi = {
+      source  = "azure/azapi"
+      version = "~> 2.0"
+    }
+    # external is only used on the internal-gateway path (internal LBs get a
+    # private IP, not a public DNS label, so the address must be read back
+    # from the Gateway status).
+    external = {
+      source  = "hashicorp/external"
+      version = "~> 2.3"
+    }
+    # random generates a small suffix appended to globally-unique resource
+    # names (storage account, ACR) so the default `aks_cluster_name` does
+    # not collide with another tenant's deployment.
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+    # local writes the rendered in-cluster manifests and the post-apply
+    # deployment summary (anyscale-aks-cloud.yaml).
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.5"
+    }
+  }
+}
+
+###############################################################################
+# NO helm / kubernetes / kubectl PROVIDERS.
+#
+# The `new-aks` sibling authenticates those providers from the cluster's
+# `kube_config` client certificate. AKS Automatic does not issue one: local
+# accounts are disabled and Entra RBAC is enforced, so the only way in is an
+# Entra token via `kubelogin`. Terraform providers cannot drive that exec
+# plugin from computed cluster attributes at plan time, so all in-cluster
+# objects here are applied by a `terraform_data` local-exec that shells out to
+# `az aks get-credentials` + `kubelogin` + `kubectl apply` (gateway.tf).
+###############################################################################
+
+provider "azurerm" {
+  features {}
+  subscription_id                 = var.azure_subscription_id
+  resource_provider_registrations = "none"
+  storage_use_azuread             = var.storage_use_azuread
+}
+
+provider "azapi" {
+  subscription_id = var.azure_subscription_id
+}


### PR DESCRIPTION
Re-cuts [`anyscale-on-azure-new-aks`](../tree/main/examples/azure/anyscale-on-azure-new-aks) onto **AKS Automatic**. Automatic removes most of what `new-aks` configures by hand — node pools, the Envoy Gateway chart, the NVIDIA GPU operator — and imposes constraints of its own: Entra-only cluster auth, enforced deployment safeguards, and a three-subnet BYO VNet.

## What changed vs. the `new-aks` sibling

| Concern | `new-aks` (Standard) | This example (Automatic) |
|---|---|---|
| Cluster resource | `azurerm_kubernetes_cluster` | `azurerm_kubernetes_automatic_cluster` (azurerm ≥ 4.81.0) |
| Compute | 5 hand-managed node pools | **No node pools.** Built-in Karpenter NodePool for CPU; `AKSNodeClass` + `NodePool` CRs for GPU |
| GPU drivers | NVIDIA GPU operator Helm chart | AKS-managed via `EnableManagedGPUExperience` |
| Ingress | Envoy Gateway chart + `EnvoyProxy` + `GatewayClass eg` | Built-in app-routing Istio (`approuting-istio`) |
| Networking | 1 node subnet | 3 subnets (delegated API-server `/28`, user nodes, system nodes) |
| Cluster auth | Admin certs drive helm/kubernetes/kubectl providers | Local accounts disabled → `kubelogin` + Entra RBAC |
| In-cluster apply | Terraform providers | Rendered YAML + `terraform_data` local-exec `kubectl apply` |
| Policy | none | Deployment safeguards in **Enforcement** → Anyscale namespace must be excluded |

`westcentralus` drops out of the supported-region list (Anyscale supports it, AKS Automatic does not).

## Verification

Verified end to end on a real subscription (westus2), from empty state:

- `Apply complete! Resources: 45 added, 0 changed, 0 destroyed` — zero errors.
- Anyscale operator `3/3 Running`; Gateway `PROGRAMMED=True`.
- Deterministic hostname resolves to the gateway LB.
- `anyscale job submit` reached **SUCCEEDED in 2m40s**, with Karpenter provisioning a node on demand.
- `Destroy complete! Resources: 45 destroyed` — no 409 wedge, no orphaned resource groups.

Four bugs surfaced only under a real apply; all are fixed and documented in `PLAN.md`:

1. `deploymentSafeguards` is an **extension** resource, not a child of `managedClusters`.
2. `web_app_routing_ingress { istio_enabled = true }` does **not** install the Gateway API CRDs — `ingressProfile.gatewayAPI.installation = "Standard"` is a separate field. The bootstrap also raced that patch.
3. Two azapi patches writing the same cluster concurrently → `409 EtagMismatch`; now serialized.
4. The Anyscale CLI's `--cloud` takes the **lowercased ARM resource ID**, not the Azure resource name — hence the new `anyscale_cloud_cli_name` output.

## Known gaps

Recorded in `PLAN.md` rather than papered over:

- **GPU drivers unproven.** The GPU NodePool/AKSNodeClass go `Ready` and CPU provisioning works, but no GPU node was provisioned — the smoke test's GPU branch needs a CUDA image this run did not build.
- **Spot unapplied.** Test subscription's `lowPriorityCores` limit was 3, too small for a 16-vCPU spot node.
- `internal_gateway`, `enable_nfs`, `enable_otlp_app_insights` left at defaults. `internal_gateway` registers a private LB IP but this example creates no private DNS zones.
- One region (westus2), one GPU SKU (T4).

There is deliberately **no `private_cluster_enabled`**: the bootstrap reaches the cluster over the data plane, so a private API server would leave the deployment half-built. `anyscale-on-azure-private-aks` covers that case with `az aks command invoke`.

A cold apply takes ~60 min (the ingress-profile reconcile alone is 16–25 min); measured per-resource timings are in `PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVKYkKgaF6hfmRpXiJVHA3
