### PR TITLE
[azure example] gate cloud registration on accepted Anyscale agreement

### DIFF
--- a/examples/azure/anyscale-on-azure-new-aks/anyscale.tf
+++ b/examples/azure/anyscale-on-azure-new-aks/anyscale.tf
@@ -42,6 +42,24 @@ locals {
 }
 
 ###############################################################################
+# Step 1 (pre): the Anyscale terms & conditions agreement.
+#
+# `Anyscale.Platform/agreements/default` is a subscription-scoped agreement
+# that must be ACCEPTED before a cloud can be provisioned. Acceptance happens
+# out-of-band via ARM (POST .../agreements/default/accept) — this stack does
+# NOT accept on your behalf. We only READ it here so cloud registration
+# depends on it and fails fast with a clear message if it hasn't been signed.
+###############################################################################
+data "azapi_resource" "anyscale_agreement" {
+  type        = "Anyscale.Platform/agreements@${var.anyscale_platform.agreements_api_version}"
+  resource_id = "/subscriptions/${var.azure_subscription_id}/providers/Anyscale.Platform/agreements/default"
+
+  response_export_values = [
+    "properties.status",
+  ]
+}
+
+###############################################################################
 # Step 1a: the Anyscale.Platform/clouds resource.
 ###############################################################################
 resource "azapi_resource" "anyscale_cloud" {
@@ -65,8 +83,19 @@ resource "azapi_resource" "anyscale_cloud" {
     "properties.ssoUrl",
   ]
 
+  # Gate cloud registration on an accepted Anyscale agreement (accepted via ARM
+  # out-of-band). Fails the apply up front with a clear message rather than
+  # letting the RP reject the cloud PUT with an opaque error.
+  lifecycle {
+    precondition {
+      condition     = try(data.azapi_resource.anyscale_agreement.output.properties.status, "") == "Active"
+      error_message = "The Anyscale agreement for this subscription is not accepted. Accept it via ARM (POST Anyscale.Platform/agreements/default/accept) before deploying."
+    }
+  }
+
   depends_on = [
     azurerm_kubernetes_cluster.aks,
+    data.azapi_resource.anyscale_agreement,
   ]
 }
 

--- a/examples/azure/anyscale-on-azure-new-aks/variables.tf
+++ b/examples/azure/anyscale-on-azure-new-aks/variables.tf
@@ -419,6 +419,7 @@ variable "anyscale_platform" {
     plan_product                     = optional(string, "anyscale-operator-aks")
     release_train                    = optional(string, "stable")
     clouds_api_version               = optional(string, "2026-02-01-preview")
+    agreements_api_version           = optional(string, "2026-07-01-preview")
   })
   default = {}
 }


### PR DESCRIPTION
## What
Gate the Azure new-AKS example's Anyscale cloud registration on an **accepted Anyscale agreement** (`Anyscale.Platform/agreements/default`).

- Adds a `data "azapi_resource" "anyscale_agreement"` that **reads** the subscription-scoped agreement (it does **not** accept — acceptance happens out-of-band via ARM: `POST Anyscale.Platform/agreements/default/accept`).
- `azapi_resource.anyscale_cloud` now `depends_on` that data source, so cloud registration is ordered after the agreement.
- Adds a `lifecycle` **precondition** on the cloud that fails early with a clear message if the agreement isn't `Active`, instead of letting the RP reject the cloud PUT with an opaque error.
- New `anyscale_platform.agreements_api_version` tunable (default `2026-07-01-preview` — the version the agreements resource type is served at; distinct from `clouds_api_version`).

## Why
Once the RP-side agreement gate is enabled, cloud creation requires the subscription to have accepted Anyscale's terms. Surfacing that as a dependency + precondition gives a clean, early failure and correct create/destroy ordering.

## Notes
- The agreement read requires `Anyscale.Platform` registered on the subscription and the `agreements` resource type rolled out to the subscription's region.
- FDN-4288.
