### PR TITLE
Make Anyscale operator install optional; add subscription onboarding for Anyscale.Platform

### DIFF
--- a/examples/azure/aks-new-cluster-azure-controlplane/README.md
+++ b/examples/azure/aks-new-cluster-azure-controlplane/README.md
@@ -58,6 +58,7 @@ The `.tf` files are **not** run by hand or in filename order — Terraform build
 
 | # | Command | Purpose |
 |---|---|---|
+| 0 | `cp terraform.tfvars.example terraform.tfvars` | Create your local values file; fill in subscription ID, tenant ID, resource group, and cloud name |
 | 1 | `./azure-login.sh` | Authenticate `az` and select the target subscription |
 | 2 | `./select-region.sh` | Find a supported region with quota and write `azure_location` to `terraform.tfvars` |
 | 3 | `./select-gpu.sh` *(optional)* | Opt into GPU pools; writes `gpu_pool_configs` to `terraform.tfvars` |
@@ -69,7 +70,7 @@ The `.tf` files are **not** run by hand or in filename order — Terraform build
 
 ### How it works
 
-Steps 1–3 are a pre-flight: they make sure you're pointed at the right subscription and that the region you pick actually has the CPU/GPU **quota** to host the pools `aks.tf` will create — the most common first-apply failure is choosing a region with no capacity. They only edit `terraform.tfvars`; they create nothing.
+Step 0 seeds `terraform.tfvars` from the template (gitignored). Steps 1–3 are a pre-flight: they make sure you're pointed at the right subscription and that the region you pick actually has the CPU/GPU **quota** to host the pools `aks.tf` will create — the most common first-apply failure is choosing a region with no capacity. Steps 1–3 only edit `terraform.tfvars`; they create nothing.
 
 Step 5 is the whole deployment in one command. Terraform stands up the Azure infrastructure, then uses the new cluster's admin credentials to register the managed Anyscale cloud (`anyscale.tf`) and wire up ingress (`envoy-gateway.tf`) — all ordered automatically by resource dependencies. After it finishes, the cloud appears at `https://console.azure.anyscale.com` and you verify it (step 6). Step 7 is reactive: run it only when a workspace/job won't start, to capture exactly why the Ray head pod can't be scheduled.
 
@@ -180,6 +181,10 @@ Each GPU type you select becomes one **on-demand** pool and one **spot** pool (a
 
 ```bash
 # From the example directory
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars — at minimum: azure_subscription_id, azure_tenant_id,
+# azure_resource_group_name, anyscale_cloud_name
+
 terraform init
 terraform plan     # preview the change set; optionally save it: terraform plan -out=tfplan
 terraform apply    # or apply the saved plan exactly: terraform apply tfplan

--- a/examples/azure/aks-new-cluster-azure-controlplane/anyscale.tf
+++ b/examples/azure/aks-new-cluster-azure-controlplane/anyscale.tf
@@ -145,11 +145,20 @@ resource "terraform_data" "anyscale_platform_agreement_accept" {
 # fail-fast backstop (lifecycle.precondition on the cloud resource) in case
 # accept_anyscale_platform_agreement=false and the agreement was never
 # accepted out-of-band, or the poll above somehow didn't run.
-data "azapi_resource" "anyscale_platform_agreement" {
-  type        = "Anyscale.Platform/agreements@${var.anyscale_platform.agreement_api_version}"
-  resource_id = "/subscriptions/${var.azure_subscription_id}/providers/Anyscale.Platform/agreements/default"
-
-  response_export_values = ["properties.status"]
+#
+# This deliberately shells out instead of using a `data "azapi_resource"`:
+# on a subscription that has never accepted the agreement, GET
+# .../Anyscale.Platform/agreements/default returns
+# `422 Unprocessable Entity / ResourceReadFailed` rather than 404, which a
+# data source surfaces as a hard "Failed to retrieve resource" error and
+# aborts the run before the accept step can do anything about it. Here a
+# failed read is simply reported as an empty status.
+data "external" "anyscale_platform_agreement" {
+  program = ["/bin/bash", "-c", <<-EOT
+    status="$(az rest --method GET --url "${local.anyscale_platform_agreement_url}" --query properties.status -o tsv 2>/dev/null || true)"
+    printf '{"status":"%s"}\n' "$${status:-}"
+  EOT
+  ]
 
   depends_on = [
     azurerm_resource_provider_registration.anyscale_platform,
@@ -213,13 +222,17 @@ resource "azapi_resource" "anyscale_platform" {
     azurerm_role_assignment.kubelet_acr_pull,
     azurerm_resource_provider_registration.anyscale_platform,
     terraform_data.anyscale_platform_agreement_accept,
-    data.azapi_resource.anyscale_platform_agreement,
+    data.external.anyscale_platform_agreement,
   ]
 
   lifecycle {
     precondition {
-      condition     = try(data.azapi_resource.anyscale_platform_agreement.output.properties.status, "") == "Active"
-      error_message = "The Anyscale.Platform subscription agreement is not Active. Accept it (az rest --method POST --url \"${local.anyscale_platform_agreement_accept_url}\") or set accept_anyscale_platform_agreement=true, then re-apply."
+      # When accept_anyscale_platform_agreement=true the accept-and-poll step
+      # above is authoritative: it fails the apply unless the agreement
+      # reached Active. This check is the backstop for the opt-out path, and
+      # tolerates an unreadable status only in that authoritative case.
+      condition     = var.accept_anyscale_platform_agreement || try(data.external.anyscale_platform_agreement.result.status, "") == "Active"
+      error_message = "The Anyscale.Platform subscription agreement is not Active (or its status could not be read with the Azure CLI). Accept it (az rest --method POST --url \"${local.anyscale_platform_agreement_accept_url}\") or set accept_anyscale_platform_agreement=true, then re-apply."
     }
   }
 }

--- a/examples/azure/aks-new-cluster-azure-controlplane/anyscale.tf
+++ b/examples/azure/aks-new-cluster-azure-controlplane/anyscale.tf
@@ -53,6 +53,111 @@ locals {
 }
 
 ###############################################################################
+# Step 0: onboard the subscription to the Anyscale.Platform resource provider.
+#
+# A subscription that has never used Anyscale.Platform needs two one-time
+# things before Step 1 below can deploy the Anyscale.Platform/clouds ARM
+# resource: the RP registered, and its marketplace-style subscription
+# agreement accepted. This mirrors the manual bootstrap:
+#   az provider register --namespace Anyscale.Platform --subscription <sub>
+#   az provider show --namespace Anyscale.Platform --subscription <sub> \
+#     --query registrationState -o tsv   # repeat until "Registered"
+#   az rest --method GET  --url ".../Anyscale.Platform/agreements/default?api-version=..."
+#   az rest --method POST --url ".../Anyscale.Platform/agreements/default/accept?api-version=..."
+#
+# azurerm_resource_provider_registration (below) already polls internally
+# until the RP shows "Registered" (its own built-in timeout is 2h), so no
+# extra wait logic is needed for that half.
+#
+# The agreement half needs its own poll: POSTing /accept does not guarantee
+# the subscription is immediately Active afterward (same class of eventual-
+# consistency lag as the Entra principal-replication retries in
+# terraform_data.anyscale_platform_self_grant below), so this checks current
+# status, accepts only if needed, then polls GET until Active or timeout —
+# mirroring the manual steps exactly:
+#   az rest --method GET  --url ".../Anyscale.Platform/agreements/default?api-version=..."
+#   az rest --method POST --url ".../Anyscale.Platform/agreements/default/accept?api-version=..."
+#   az rest --method GET  --url ".../Anyscale.Platform/agreements/default?api-version=..." # repeat until status: Active
+#
+# Both steps are gated behind their own variables so you can skip either if
+# your org handles them centrally or requires human sign-off.
+#
+# Accepting the agreement (var.accept_anyscale_platform_agreement, default
+# true) means Terraform gives this consent on your behalf, non-interactively
+# — see that variable's description for the full text and links (terms of
+# use, privacy policy, Azure Marketplace billing/consent terms).
+###############################################################################
+resource "azurerm_resource_provider_registration" "anyscale_platform" {
+  count = var.register_anyscale_resource_provider ? 1 : 0
+
+  name = "Anyscale.Platform"
+}
+
+locals {
+  anyscale_platform_agreement_base_url   = "https://management.azure.com/subscriptions/${var.azure_subscription_id}/providers/Anyscale.Platform/agreements/default"
+  anyscale_platform_agreement_url        = "${local.anyscale_platform_agreement_base_url}?api-version=${var.anyscale_platform.agreement_api_version}"
+  anyscale_platform_agreement_accept_url = "${local.anyscale_platform_agreement_base_url}/accept?api-version=${var.anyscale_platform.agreement_api_version}"
+}
+
+resource "terraform_data" "anyscale_platform_agreement_accept" {
+  count = var.accept_anyscale_platform_agreement ? 1 : 0
+
+  triggers_replace = {
+    url = local.anyscale_platform_agreement_url
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-EOT
+      set -euo pipefail
+      GET_URL="${local.anyscale_platform_agreement_url}"
+      ACCEPT_URL="${local.anyscale_platform_agreement_accept_url}"
+
+      status="$(az rest --method GET --url "$GET_URL" --query properties.status -o tsv 2>/dev/null || echo "")"
+      echo "[anyscale] Agreement status: $${status:-<none>}"
+
+      if [ "$status" != "Active" ]; then
+        echo "[anyscale] Accepting Anyscale.Platform subscription agreement..."
+        az rest --method POST --url "$ACCEPT_URL" >/dev/null
+      fi
+
+      deadline=$(( $(date +%s) + 300 ))
+      while :; do
+        status="$(az rest --method GET --url "$GET_URL" --query properties.status -o tsv 2>/dev/null || echo "")"
+        if [ "$status" = "Active" ]; then
+          echo "[anyscale] Agreement is Active."
+          break
+        fi
+        if [ "$(date +%s)" -ge "$deadline" ]; then
+          echo "[anyscale] ERROR: agreement did not reach Active within timeout (last status: $${status:-<none>})" >&2
+          exit 1
+        fi
+        echo "[anyscale] Waiting for agreement to reach Active (current: $${status:-<none>})..."
+        sleep 10
+      done
+    EOT
+  }
+
+  depends_on = [azurerm_resource_provider_registration.anyscale_platform]
+}
+
+# Read the agreement's current status for the output below and as a
+# fail-fast backstop (lifecycle.precondition on the cloud resource) in case
+# accept_anyscale_platform_agreement=false and the agreement was never
+# accepted out-of-band, or the poll above somehow didn't run.
+data "azapi_resource" "anyscale_platform_agreement" {
+  type        = "Anyscale.Platform/agreements@${var.anyscale_platform.agreement_api_version}"
+  resource_id = "/subscriptions/${var.azure_subscription_id}/providers/Anyscale.Platform/agreements/default"
+
+  response_export_values = ["properties.status"]
+
+  depends_on = [
+    azurerm_resource_provider_registration.anyscale_platform,
+    terraform_data.anyscale_platform_agreement_accept,
+  ]
+}
+
+###############################################################################
 # Step 1: deploy the Anyscale.Platform/clouds ARM resource.
 # The body of the template is the exact JSON the Azure portal exports for the
 # managed cloud onboarding flow — see `templates/anyscale-platform-cloud.template.json`.
@@ -106,7 +211,17 @@ resource "azapi_resource" "anyscale_platform" {
     azurerm_role_assignment.anyscale_blob_contrib,
     azurerm_container_registry.acr,
     azurerm_role_assignment.kubelet_acr_pull,
+    azurerm_resource_provider_registration.anyscale_platform,
+    terraform_data.anyscale_platform_agreement_accept,
+    data.azapi_resource.anyscale_platform_agreement,
   ]
+
+  lifecycle {
+    precondition {
+      condition     = try(data.azapi_resource.anyscale_platform_agreement.output.properties.status, "") == "Active"
+      error_message = "The Anyscale.Platform subscription agreement is not Active. Accept it (az rest --method POST --url \"${local.anyscale_platform_agreement_accept_url}\") or set accept_anyscale_platform_agreement=true, then re-apply."
+    }
+  }
 }
 
 # The ARM template exports `cloudResourceId` (e.g. `cldrsrc_abcd…`). The
@@ -211,6 +326,12 @@ resource "terraform_data" "anyscale_platform_self_grant" {
 ###############################################################################
 # Step 2: install the Anyscale.AKS.Operator marketplace extension.
 #
+# Gated by var.install_operator_extension (default true). Set it to false to
+# skip this and install the Anyscale operator manually via `helm install`
+# instead — see the example README for the manual Helm values, which need to
+# set networking.gateway explicitly since that config normally comes from
+# this resource's configuration_settings below.
+#
 # The extension is installed AFTER the Envoy Gateway has an LB address
 # (see envoy-gateway.tf) so we can bake the gateway hostname directly into
 # the operator's configuration_settings. This avoids the
@@ -225,6 +346,8 @@ resource "terraform_data" "anyscale_platform_self_grant" {
 # registered as the cloud's operator principal by the ARM template above).
 ###############################################################################
 resource "azurerm_kubernetes_cluster_extension" "anyscale_operator" {
+  count = var.install_operator_extension ? 1 : 0
+
   name              = var.anyscale_platform.extension_resource_name
   cluster_id        = azurerm_kubernetes_cluster.aks.id
   extension_type    = "Anyscale.AKS.Operator"

--- a/examples/azure/aks-new-cluster-azure-controlplane/outputs.tf
+++ b/examples/azure/aks-new-cluster-azure-controlplane/outputs.tf
@@ -59,6 +59,11 @@ output "anyscale_operator_principal_id" {
 ###############################################################################
 # Anyscale Azure-managed cloud outputs
 ###############################################################################
+output "anyscale_platform_agreement_status" {
+  value       = try(data.azapi_resource.anyscale_platform_agreement.output.properties.status, null)
+  description = "Status of the Anyscale.Platform subscription agreement (expect \"Active\"), read after the accept-and-poll step (if it ran) completes."
+}
+
 output "anyscale_cloud_name" {
   value       = local.anyscale_cloud_name
   description = "Name of the registered Anyscale cloud (visible in console.azure.anyscale.com)."
@@ -75,8 +80,8 @@ output "anyscale_cloud_resource_id" {
 }
 
 output "anyscale_extension_resource_id" {
-  value       = azurerm_kubernetes_cluster_extension.anyscale_operator.id
-  description = "Full resource ID of the Anyscale.AKS.Operator AKS extension."
+  value       = var.install_operator_extension ? azurerm_kubernetes_cluster_extension.anyscale_operator[0].id : null
+  description = "Full resource ID of the Anyscale.AKS.Operator AKS extension. Null when install_operator_extension=false (manual Helm install)."
 }
 
 output "anyscale_operator_namespace" {
@@ -135,7 +140,7 @@ resource "local_file" "cloud_summary" {
       arm_id             = "${azurerm_resource_group.rg.id}/providers/Anyscale.Platform/clouds/${local.anyscale_cloud_name}"
       console_url        = var.anyscale_platform.control_plane_url
       operator_namespace = var.anyscale_operator_namespace
-      extension_id       = azurerm_kubernetes_cluster_extension.anyscale_operator.id
+      extension_id       = var.install_operator_extension ? azurerm_kubernetes_cluster_extension.anyscale_operator[0].id : null
     }
     azure = {
       resource_group    = azurerm_resource_group.rg.name

--- a/examples/azure/aks-new-cluster-azure-controlplane/outputs.tf
+++ b/examples/azure/aks-new-cluster-azure-controlplane/outputs.tf
@@ -60,7 +60,7 @@ output "anyscale_operator_principal_id" {
 # Anyscale Azure-managed cloud outputs
 ###############################################################################
 output "anyscale_platform_agreement_status" {
-  value       = try(data.azapi_resource.anyscale_platform_agreement.output.properties.status, null)
+  value       = try(data.external.anyscale_platform_agreement.result.status, null)
   description = "Status of the Anyscale.Platform subscription agreement (expect \"Active\"), read after the accept-and-poll step (if it ran) completes."
 }
 

--- a/examples/azure/aks-new-cluster-azure-controlplane/terraform.tfvars.example
+++ b/examples/azure/aks-new-cluster-azure-controlplane/terraform.tfvars.example
@@ -1,13 +1,17 @@
 ###############################################################################
 # Example terraform.tfvars for examples/azure/aks-new-cluster-azure-controlplane
 #
-# Copy to `terraform.tfvars` and edit. Everything *Required* must be filled in.
-# The two interactive prompts (azure_resource_group_name, anyscale_cloud_name)
-# are also marked Required below — set them here to skip the prompts.
+# Copy to `terraform.tfvars` and edit. Required variables must be filled in.
+# Set azure_resource_group_name and anyscale_cloud_name here to skip interactive
+# prompts during `terraform apply`.
 #
 # Look up IDs locally:
 #   az account show --query id       -o tsv   # azure_subscription_id
 #   az account show --query tenantId -o tsv   # azure_tenant_id
+#
+# Helper scripts (after copying this file):
+#   ./select-region.sh   # scan quota → write azure_location
+#   ./select-gpu.sh      # (optional) opt into GPU pools → write gpu_pool_configs
 ###############################################################################
 
 # ---------------------------------------------------------------------------
@@ -18,7 +22,7 @@ azure_tenant_id       = "11111111-1111-1111-1111-111111111111"
 
 # ---------------------------------------------------------------------------
 # Required — Interactively prompted unless set here
-#   - Empty string ("") falls back to "<aks_cluster_name>-rg" / "-cloud".
+#   Empty string ("") falls back to "<aks_cluster_name>-rg" / "-cloud".
 # ---------------------------------------------------------------------------
 azure_resource_group_name = "anyscale-demo-rg"
 anyscale_cloud_name       = "anyscale-demo-cloud"
@@ -26,12 +30,11 @@ anyscale_cloud_name       = "anyscale-demo-cloud"
 # ---------------------------------------------------------------------------
 # Region & naming
 #   azure_location MUST be one of the Anyscale.Platform/clouds-supported regions
-#   (enforced by a validation on var.azure_location):
+#   (enforced by validation on var.azure_location):
 #     westcentralus, eastus, eastus2, westus2, westus3, southcentralus,
 #     westeurope, swedencentral, uksouth, australiaeast, southeastasia,
 #     northeurope
-#   Tip: run ./select-region.sh to scan quota in these regions and have it set
-#   azure_location for you.
+#   Tip: run ./select-region.sh to scan quota and write azure_location for you.
 # ---------------------------------------------------------------------------
 azure_location   = "westus2"
 aks_cluster_name = "anyscale-demo"
@@ -52,11 +55,9 @@ tags = {
 
 # ---------------------------------------------------------------------------
 # Storage
-#   Auto-generated names append a 5-char random suffix for global uniqueness,
-#   so the defaults are safe even when multiple users deploy with the default
-#   aks_cluster_name. Override the *_name vars only if you need a fixed name.
+#   Auto-generated names append a 5-char random suffix for global uniqueness.
 # ---------------------------------------------------------------------------
-# storage_account_name     = null   # auto-generated with random suffix; override only when you need a fixed name
+# storage_account_name     = null
 # enable_blob_driver       = false
 # enable_nfs               = false
 # storage_account_name_nfs = null
@@ -68,24 +69,18 @@ tags = {
 system_vm_size = "Standard_D2s_v5"
 cpu_vm_size    = "Standard_D16s_v5"
 
-# GPU node pools are OPT-IN — left unset (empty), the cluster deploys CPU-only and
-# `terraform apply` never tries to create a GPU SKU that has no quota/capacity in
-# your region (the #1 cause of a failed apply, e.g. A100 in a region that has none).
+# GPU pools are opt-in (default is CPU-only). Each key creates one on-demand +
+# one spot pool. Easiest: run `./select-gpu.sh` to write this block for you.
 #
-# Easiest way to fill this in: run `./select-gpu.sh`. It lets you pick a GPU type
-# from the Anyscale-supported catalog — or scans your region for SKUs that are both
-# available AND have quota — and writes this block for you. Each entry becomes one
-# on-demand pool + one spot pool (autoscaling 0–10).
+# CPU-only (recommended for first apply):
+gpu_pool_configs = {}
 #
-# Before enabling, confirm the VM family has vCPU quota in azure_location:
-#   NODE_VM_SIZE=Standard_NC16as_T4_v3 ./scan-regional-quotas.sh
-#
-# --- Starter: a single, widely-available T4 pool (uncomment to enable) -------
+# Starter — single T4 pool (confirm quota in azure_location first):
 # gpu_pool_configs = {
 #   T4 = { name = "gput4", vm_size = "Standard_NC16as_T4_v3", product_name = "NVIDIA-T4", gpu_count = "1" }
 # }
 #
-# --- Full catalog: mix and match the GPU types you need ----------------------
+# Full catalog:
 # gpu_pool_configs = {
 #   T4   = { name = "gput4",   vm_size = "Standard_NC16as_T4_v3",    product_name = "NVIDIA-T4",   gpu_count = "1" }
 #   A10  = { name = "gpua10",  vm_size = "Standard_NV36ads_A10_v5",  product_name = "NVIDIA-A10",  gpu_count = "1" }
@@ -108,9 +103,14 @@ anyscale_operator_namespace      = "anyscale-operator"
 anyscale_operator_serviceaccount = "anyscale-operator"
 enable_operator_infrastructure   = true
 
+# Set to false to skip Terraform's automatic Anyscale.AKS.Operator extension
+# install and instead install the operator yourself via `helm install`
+# (e.g. to pin a chart version or stage the rollout). enable_operator_infrastructure
+# above still provisions the managed identity/federated credential either way.
+install_operator_extension = true
+
 # ---------------------------------------------------------------------------
 # Anyscale platform (control plane / AKS extension)
-#   Override only when targeting a non-default control plane.
 # ---------------------------------------------------------------------------
 # anyscale_platform = {
 #   control_plane_url                = "https://console.azure.anyscale.com"
@@ -118,15 +118,10 @@ enable_operator_infrastructure   = true
 #   extension_configuration_settings = {}
 # }
 
-# ---------------------------------------------------------------------------
-# Grant teammates access to the Anyscale cloud resource.
-# Subscription Owner/Contributor does NOT carry over — assign explicitly here.
-#
-# Look up object IDs:
-#   az ad user  show --id  <upn>          --query id -o tsv
-#   az ad group show --group <name>       --query id -o tsv
-#   az ad sp    show --id  <appId>        --query id -o tsv
-# ---------------------------------------------------------------------------
+# Grant the signed-in `az` user console access on the Anyscale cloud resource.
+assign_current_user_platform_roles = true
+
+# Additional principals (subscription Owner/Contributor does not carry over):
 anyscale_platform_contributors = [
   # { principal_id = "22222222-2222-2222-2222-222222222222", principal_type = "User" },
   # { principal_id = "33333333-3333-3333-3333-333333333333", principal_type = "Group" },
@@ -140,4 +135,14 @@ anyscale_platform_contributors = [
 #   chart_version                    = "v1.7.0"
 #   gateway_lb_wait_timeout_seconds  = 600
 #   gateway_lb_poll_interval_seconds = 10
+# }
+
+# ---------------------------------------------------------------------------
+# CORS for blob storage (default allows Anyscale console access)
+# ---------------------------------------------------------------------------
+# cors_rule = {
+#   allowed_headers = ["*"]
+#   allowed_methods = ["GET", "POST", "PUT", "HEAD", "DELETE"]
+#   allowed_origins = ["https://*.anyscale.com"]
+#   expose_headers  = ["Accept-Ranges", "Content-Range", "Content-Length"]
 # }

--- a/examples/azure/aks-new-cluster-azure-controlplane/variables.tf
+++ b/examples/azure/aks-new-cluster-azure-controlplane/variables.tf
@@ -128,6 +128,64 @@ variable "enable_operator_infrastructure" {
   default     = true
 }
 
+variable "register_anyscale_resource_provider" {
+  description = <<-EOT
+    (Optional) Register the Anyscale.Platform resource provider on the
+    subscription via Terraform (azurerm_resource_provider_registration).
+    Set to false if the RP is already registered or your org registers
+    resource providers centrally and disallows registering them per-deploy.
+  EOT
+  type        = bool
+  nullable    = false
+  default     = true
+}
+
+variable "accept_anyscale_platform_agreement" {
+  description = <<-EOT
+    (Optional) Accept the Anyscale.Platform marketplace-style subscription
+    agreement via Terraform (required once per subscription before
+    Anyscale.Platform/clouds can be deployed). Set to false if the agreement
+    has already been accepted, or if your org requires a human to review and
+    accept it out-of-band rather than have Terraform accept it automatically.
+
+    Terms of use:   https://catalogartifact.azureedge.net/publicartifacts/anyscale1750870039553.anyscale-operator-aks-73ba5252-dbbc-41fc-9f44-9a2171d23019/Artifacts/Documents/TermsOfUse.txt
+    Privacy policy: https://www.anyscale.com/privacy-policy
+
+    This mirrors the consent normally given by clicking "Create" on the
+    Marketplace offer in the Azure portal: "By clicking Create, I (a) agree
+    to the legal terms and privacy statement(s) associated with the
+    Marketplace offering(s) listed above; (b) authorize Microsoft to bill my
+    current payment method for the fees associated with the offering(s),
+    with the same billing frequency as my Azure subscription; and (c) agree
+    that Microsoft may share my contact, usage and transactional information
+    with the provider(s) of the offering(s) for support, billing and other
+    transactional activities. Microsoft does not provide rights for
+    third-party offerings." See the Azure Marketplace Terms for additional
+    details: https://azure.microsoft.com/support/legal/marketplace-terms/
+
+    Review all of the above before leaving this at its default (true) —
+    setting it to true means Terraform gives this consent on your behalf,
+    non-interactively, whenever the agreement isn't already Active.
+  EOT
+  type        = bool
+  nullable    = false
+  default     = true
+}
+
+variable "install_operator_extension" {
+  description = <<-EOT
+    (Optional) Install the Anyscale.AKS.Operator AKS extension via Terraform
+    (azurerm_kubernetes_cluster_extension). Set to false to skip this and install
+    the Anyscale operator manually via `helm install` instead — useful if you want
+    to control the Helm release yourself (custom values, staged rollout, pinned
+    chart version). enable_operator_infrastructure still provisions the managed
+    identity/federated credential/role assignment the operator needs either way.
+  EOT
+  type        = bool
+  nullable    = false
+  default     = true
+}
+
 variable "storage_account_name" {
   description = "(Optional) Name of the Azure Storage account to create for cloud storage. May be needed if generated name is already taken."
   type        = string
@@ -318,6 +376,7 @@ variable "anyscale_platform" {
     extension_resource_name          = optional(string, "anyscaleoperator")
     control_plane_url                = optional(string, "https://console.azure.anyscale.com")
     auth_audience                    = optional(string, "api://086bc555-6989-4362-ba30-fded273e432b/.default")
+    agreement_api_version            = optional(string, "2026-07-01-preview")
     extension_configuration_settings = optional(map(string), {})
     plan_name                        = optional(string, "anyscale-operator")
     plan_publisher                   = optional(string, "anyscale1750870039553")


### PR DESCRIPTION
## Summary
- Onboard the subscription to Anyscale.Platform automatically: register the resource provider and accept its subscription agreement via Terraform (each individually skippable with `register_anyscale_resource_provider` / `accept_anyscale_platform_agreement`), with a `lifecycle.precondition` fail-fast if the agreement isn't Active before the cloud resource is created.
- Make the `Anyscale.AKS.Operator` AKS extension install optional (`install_operator_extension`, default `true`) so users who want to control the Helm release themselves (custom values, staged rollout, pinned chart version) can skip Terraform's automatic install; `enable_operator_infrastructure` still provisions the managed identity/federated credential either way.
- Add an optional `cors_rule` variable for the blob storage account.
- Point the `deploy-azure-aks` skill and README at `terraform.tfvars.example` (copy-and-edit) instead of describing an ad hoc `terraform.tfvars`.

## Test plan
- [x] `terraform fmt -check` and `terraform validate` pass on the changed example
- [ ] `terraform apply` end-to-end on a subscription that has never used Anyscale.Platform (RP not registered, agreement not accepted) to confirm the onboarding steps succeed
- [ ] `install_operator_extension = false` path: confirm `terraform apply` skips the extension resource and outputs/`cloud_summary` handle the null case correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)