### PR TITLE
fix: unblock EKS examples on fresh clones

### DIFF
--- a/examples/aws/eks-existing/deploy.sh.tftpl
+++ b/examples/aws/eks-existing/deploy.sh.tftpl
@@ -84,7 +84,7 @@ EG_CRD_DIR=$(mktemp -d)
 trap 'rm -rf "$${EG_CRD_DIR}"' EXIT
 helm pull oci://docker.io/envoyproxy/gateway-helm --version v1.7.0 \
   --untar --untardir "$${EG_CRD_DIR}"
-kubectl apply --server-side --force-conflicts -f "$${EG_CRD_DIR}/gateway-helm/crds/"
+kubectl apply --server-side --force-conflicts -R -f "$${EG_CRD_DIR}/gateway-helm/crds/"
 helm upgrade eg oci://docker.io/envoyproxy/gateway-helm \
   --version v1.7.0 \
   --namespace envoy-gateway-system \

--- a/examples/aws/eks-existing/main.tf
+++ b/examples/aws/eks-existing/main.tf
@@ -17,6 +17,7 @@ module "anyscale_s3" {
   module_enabled = true
 
   anyscale_bucket_name = "anyscale-eks-existing-${var.aws_region}"
+  bucket_namespace     = "global"
 
   tags = var.tags
 }

--- a/examples/aws/eks-existing/versions.tf
+++ b/examples/aws/eks-existing/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/examples/aws/eks-private/deploy.sh.tftpl
+++ b/examples/aws/eks-private/deploy.sh.tftpl
@@ -68,7 +68,7 @@ EG_CRD_DIR=$(mktemp -d)
 trap 'rm -rf "$${EG_CRD_DIR}"' EXIT
 helm pull oci://docker.io/envoyproxy/gateway-helm --version v1.7.0 \
   --untar --untardir "$${EG_CRD_DIR}"
-kubectl apply --server-side --force-conflicts -f "$${EG_CRD_DIR}/gateway-helm/crds/"
+kubectl apply --server-side --force-conflicts -R -f "$${EG_CRD_DIR}/gateway-helm/crds/"
 helm upgrade eg oci://docker.io/envoyproxy/gateway-helm \
   --version v1.7.0 \
   --namespace envoy-gateway-system \

--- a/examples/aws/eks-private/main.tf
+++ b/examples/aws/eks-private/main.tf
@@ -41,6 +41,7 @@ module "anyscale_s3" {
   module_enabled = true
 
   anyscale_bucket_name = "${var.eks_cluster_name}-${var.aws_region}"
+  bucket_namespace     = "global"
   force_destroy        = var.bucket_force_destroy
 
   tags = var.tags

--- a/examples/aws/eks-public/deploy.sh.tftpl
+++ b/examples/aws/eks-public/deploy.sh.tftpl
@@ -65,7 +65,7 @@ EG_CRD_DIR=$(mktemp -d)
 trap 'rm -rf "$${EG_CRD_DIR}"' EXIT
 helm pull oci://docker.io/envoyproxy/gateway-helm --version v1.7.0 \
   --untar --untardir "$${EG_CRD_DIR}"
-kubectl apply --server-side --force-conflicts -f "$${EG_CRD_DIR}/gateway-helm/crds/"
+kubectl apply --server-side --force-conflicts -R -f "$${EG_CRD_DIR}/gateway-helm/crds/"
 helm upgrade eg oci://docker.io/envoyproxy/gateway-helm \
   --version v1.7.0 \
   --namespace envoy-gateway-system \

--- a/examples/aws/eks-public/main.tf
+++ b/examples/aws/eks-public/main.tf
@@ -41,6 +41,7 @@ module "anyscale_s3" {
   module_enabled = true
 
   anyscale_bucket_name = "${var.eks_cluster_name}-${var.aws_region}"
+  bucket_namespace     = "global"
   force_destroy        = var.bucket_force_destroy
 
   tags = var.tags


### PR DESCRIPTION
- Set bucket_namespace = "global" on the anyscale_s3 module in all three examples. The unpinned aws-anyscale-s3 submodule defaults to account-regional since terraform-aws-anyscale-cloudfoundation-modules commit 0cc5259, which requires bucket names ending in -{account_id}-{region}-an; the computed names never match, so every fresh apply fails at bucket creation.

- Bump the eks-existing AWS provider pin to ~> 6.0. The cloudfoundation submodules now require >= 6.37.0, making init unsatisfiable against ~> 5.0 (eks-public and eks-private were already bumped in this PR; this file was missed).

- Add -R to the Envoy Gateway CRD apply in deploy.sh.tftpl. The chart keeps its own CRDs in crds/generated/, which a non-recursive kubectl apply skips, so step 5 failed on the EnvoyProxy resource with "no matches for kind EnvoyProxy".

Verified end to end on EKS in eu-west-1: infra provisioned, cloud registered, Envoy Gateway Programmed with NLB provisioned, operator installed with TLS secret created, S3 PVC bound, and a smoke job succeeded with mountpoint-s3 write/readback on shared storage.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] pre-commit has been run
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] All tests passing
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull Request Type

- [ ] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation change
- [ ] Other (please describe):

## Does this introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots. -->
