### PR TITLE
Support adopting an existing AKS cluster in the Azure control-plane example

### DIFF
--- a/examples/azure/aks-new-cluster-azure-controlplane/.gitignore
+++ b/examples/azure/aks-new-cluster-azure-controlplane/.gitignore
@@ -11,5 +11,9 @@ diagnostics/
 # Post-apply deployment summary (embeds ARM IDs / subscription ID)
 anyscale-aks-cloud.yaml
 
+# Generated Helm values for a manual operator install (embeds the cloud's
+# cldrsrc_ ID and the workload identity client ID)
+anyscale-operator-values.yaml
+
 # Local PR write-up (not part of the example)
 PR_DESCRIPTION.md

--- a/examples/azure/aks-new-cluster-azure-controlplane/README.md
+++ b/examples/azure/aks-new-cluster-azure-controlplane/README.md
@@ -255,7 +255,52 @@ Terraform checks all four during `plan` (see `terraform_data.existing_aks_prefli
 Two related flags work independently of `create_aks_cluster`, for creating a cluster inside infrastructure you already have:
 
 - `create_resource_group = false` — create everything except the resource group
-- `existing_node_subnet_id = "/subscriptions/…/subnets/…"` — create the cluster in an existing subnet instead of a new VNet
+- `existing_node_subnet_id = "/subscriptions/…/subnets/…"` — create the cluster in an existing subnet
+
+#### Reusing an existing Envoy Gateway install
+
+A cluster that already runs Envoy Gateway — because your platform team installed it, or because another Anyscale cloud on the same cluster brought it — doesn't need a second copy:
+
+```hcl
+create_envoy_gateway = false
+envoy_gateway = {
+  gateway_class_name = "their-existing-class"
+}
+```
+
+That skips the Helm release, the `EnvoyProxy` and the `GatewayClass`. The **`Gateway` is still created either way**: its HTTPS listeners reference TLS Secret names derived from this cloud's `cldrsrc_…` ID, so it can't be shared between Anyscale clouds even on one cluster.
+
+The class you point at must resolve to an `EnvoyProxy` whose `envoyService.type` is `LoadBalancer`. If it publishes the data plane some other way, the Gateway never gets a `status.addresses` entry, and the apply fails at `terraform_data.wait_for_gateway_lb` after `gateway_lb_wait_timeout_seconds` — the timeout handler dumps the GatewayClass and its EnvoyProxy so you can see which it is.
+
+Related, and easy to hit when adopting a cluster that has run an Anyscale operator before: `create_operator_namespace = false` skips creating the `anyscale-operator` namespace, which would otherwise fail the apply because it already exists. instead of a new VNet
+
+### Installing the operator yourself instead of via the AKS extension
+
+Set `install_operator_extension = false` and Terraform builds everything else — the cloud, storage, ACR, the workload identity, Envoy Gateway and the Gateway — but leaves the operator to you.
+
+Everything the operator needs is something the apply just produced: the cloud's `cldrsrc_…` ID, the identity's client ID, the Gateway's LB address. Rather than have you transcribe those, the apply writes a complete **`anyscale-operator-values.yaml`** (gitignored — it embeds those IDs) and prints the matching command:
+
+```bash
+az aks get-credentials --resource-group <rg> --name <cluster> --overwrite-existing   # or: terraform output aks_get_credentials_command
+
+helm repo add anyscale https://anyscale.github.io/helm-charts
+helm repo update anyscale
+
+terraform output -raw anyscale_operator_helm_command     # run what this prints
+```
+
+Then `kubectl get pods -n anyscale-operator` should show `3/3 Running`.
+
+The generated file (`local.anyscale_operator_helm_values` in `anyscale.tf`) mirrors the extension's `configuration_settings`, including two values that are easy to miss when writing it by hand:
+
+- **`global.auth.anyscaleCliToken: ""`** — must be present and empty, so the operator uses the Microsoft Entra workload-identity exchange rather than CLI-token auth.
+- **`networking.gateway`** — normally baked in by the extension from the Gateway's LB address. `envoy-gateway.tf` still provisions the Gateway and GatewayClass, but nothing else tells the operator where they are.
+
+It also carries `workloads.instanceTypes.enableDefaults` and the GPU tolerations matching the taints `aks.tf` puts on the GPU pools — omit those and GPU workloads won't schedule.
+
+Two caveats. The generated command drops `--create-namespace`, because `create_operator_namespace` defaults to `true` and Terraform already made the namespace; if you set that to `false`, the flag comes back automatically. And overrides passed through `anyscale_platform.extension_configuration_settings` apply to the **extension path only** — they're flat dotted keys and are not merged into the generated YAML, so edit the file directly if you need them.
+
+> `enable_operator_infrastructure` is a *different* flag and is **not** the one for this. See the note in `variables.tf`.
 
 ### Deployment summary file
 

--- a/examples/azure/aks-new-cluster-azure-controlplane/README.md
+++ b/examples/azure/aks-new-cluster-azure-controlplane/README.md
@@ -139,6 +139,8 @@ MIN_CPU_VCPUS=12 ./select-region.sh   # lower the deployable threshold
 
 `./select-region.sh` checks regional vCPU and CPU-family headroom for you across the supported regions. For a standalone, full quota report (CPU + per-GPU-family across all or specific regions) use `./scan-regional-quotas.sh` directly — e.g. `NODE_VM_SIZE=Standard_D16s_v5 ./scan-regional-quotas.sh`.
 
+Quota and capacity can also vary *within* a region. If only some availability zones can serve the VM sizes you picked, pin the pools with `node_pool_zones = ["3"]` (unset by default, which lets Azure place nodes without a zone constraint).
+
 #### Worked example — minimum quota to try this out
 
 The default `system_vm_size` (`Standard_D2s_v5`) and `cpu_vm_size` belong to the **DSv5** family, so both draw from the same *Standard DSv5 Family vCPUs* quota **and** the *Total Regional vCPUs* quota in your region. A minimal CPU-only deployment (no GPU pools) needs roughly:
@@ -222,6 +224,38 @@ terraform output anyscale_cloud_resource_id   # cldrsrc_…
 terraform output gateway_lb_hostname          # the public LB IP
 terraform output aks_get_credentials_command  # refresh kubeconfig manually
 ```
+
+### Use an existing AKS cluster
+
+By default this example creates the resource group, VNet, subnet, AKS cluster and node pools. To layer Anyscale onto a cluster you already run, set:
+
+```hcl
+create_aks_cluster        = false
+existing_aks_cluster_name = "my-existing-aks"
+azure_resource_group_name = "the-group-holding-that-cluster"
+```
+
+Everything else is unchanged — storage, ACR, the operator identity and federated credential, the Anyscale cloud, Envoy Gateway and the operator extension are all created against the adopted cluster.
+
+**The cluster must already have:**
+
+| Requirement | Why | Fix |
+| --- | --- | --- |
+| OIDC issuer enabled | The operator's federated identity credential federates against it | `az aks update -g <rg> -n <cluster> --enable-oidc-issuer --enable-workload-identity` |
+| Microsoft Entra workload identity enabled | The operator authenticates to the control plane with a workload-identity token, not a CLI token | same command |
+| Local accounts enabled | The `kubernetes`/`helm`/`kubectl` providers in `versions.tf` authenticate with the cluster's client certificate, which Azure only issues when local accounts are on | `az aks update -g <rg> -n <cluster> --enable-local-accounts`, or fork `versions.tf` to use an `exec` block running `kubelogin get-token` |
+| A region where `Anyscale.Platform/clouds` exists | The cloud, storage account, ACR and operator identity are all deployed there | move the cluster, or pick a different one |
+
+Terraform checks all four during `plan` (see `terraform_data.existing_aks_preflight` in `aks_existing.tf`) and fails with the relevant `az` command in the error, before creating anything.
+
+**Node pools.** `create_node_pools` defaults to `true`, so Terraform adds the Anyscale CPU and GPU pools to the adopted cluster, carrying the `node.anyscale.com/capacity-type`, `node.anyscale.com/accelerator-type` and `nvidia.com/gpu` taints the operator tolerates. Their subnet is read from the cluster's first agent pool; override with `existing_node_subnet_id`. Set `create_node_pools = false` if the cluster's own pools already carry those taints — if they carry a *different* taint scheme, override the tolerations via `anyscale_platform.extension_configuration_settings` instead, or Anyscale workloads will land on your system nodes.
+
+**Other notes for this mode.** `azure_location`, `vnet_cidr`, `nodes_subnet_cidr` and `aks_cluster_subnet_cidr` are unused — the adopted resource group's region and the cluster's own network win. `enable_nfs` needs the node subnet to carry the `Microsoft.Storage` service endpoint; Terraform adds it to subnets it creates, but not to one you bring. `terraform destroy` removes only what Terraform created: the Anyscale cloud, operator extension, gateway, storage, ACR, identity and any node pools it added. The cluster, its resource group and its network are left alone.
+
+Two related flags work independently of `create_aks_cluster`, for creating a cluster inside infrastructure you already have:
+
+- `create_resource_group = false` — create everything except the resource group
+- `existing_node_subnet_id = "/subscriptions/…/subnets/…"` — create the cluster in an existing subnet instead of a new VNet
 
 ### Deployment summary file
 

--- a/examples/azure/aks-new-cluster-azure-controlplane/README.md
+++ b/examples/azure/aks-new-cluster-azure-controlplane/README.md
@@ -300,7 +300,23 @@ It also carries `workloads.instanceTypes.enableDefaults` and the GPU tolerations
 
 Two caveats. The generated command drops `--create-namespace`, because `create_operator_namespace` defaults to `true` and Terraform already made the namespace; if you set that to `false`, the flag comes back automatically. And overrides passed through `anyscale_platform.extension_configuration_settings` apply to the **extension path only** — they're flat dotted keys and are not merged into the generated YAML, so edit the file directly if you need them.
 
-> `enable_operator_infrastructure` is a *different* flag and is **not** the one for this. See the note in `variables.tf`.
+> `enable_operator_infrastructure` is a *different* flag and is **not** the one for this — see below.
+
+### Who owns the operator's storage and identity
+
+`enable_operator_infrastructure` picks which side provisions the operator's blob storage, workload identity, federated credential and storage role assignment. Both modes produce the same working cloud.
+
+| | `true` (default) | `false` |
+| --- | --- | --- |
+| Created by | Terraform | the Anyscale.Platform ARM template |
+| ARM `storageMode` / `identityMode` | `existing` | `managed` |
+| Visible in the plan | yes | no — owned by the cloud resource |
+| Tagged with `var.tags` | yes | no |
+| Removed by `terraform destroy` | yes | with the cloud |
+
+Names are identical either way (`local.storage_account_name`, `local.storage_container_name`, `local.anyscale_operator_identity_name` are shared by both paths), and the operator's client and principal IDs are read back from the ARM deployment's outputs when the template owns them — so `anyscale_operator_client_id`, the generated Helm values and the operator install behave the same in both modes.
+
+Prefer `true` unless you specifically want the Anyscale resource provider to own that infrastructure's lifecycle.
 
 ### Deployment summary file
 

--- a/examples/azure/aks-new-cluster-azure-controlplane/acr.tf
+++ b/examples/azure/aks-new-cluster-azure-controlplane/acr.tf
@@ -20,8 +20,8 @@ resource "azurerm_container_registry" "acr" {
   count = var.enable_acr ? 1 : 0
 
   name                = local.acr_name
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
+  resource_group_name = local.rg_name
+  location            = local.rg_location
   sku                 = var.acr_sku
   admin_enabled       = false
   # Public network access — match the example's overall public-networking
@@ -46,5 +46,5 @@ resource "azurerm_role_assignment" "kubelet_acr_pull" {
 
   scope                = azurerm_container_registry.acr[0].id
   role_definition_name = "AcrPull"
-  principal_id         = azurerm_kubernetes_cluster.aks.kubelet_identity[0].object_id
+  principal_id         = local.aks_kubelet_object_id
 }

--- a/examples/azure/aks-new-cluster-azure-controlplane/aks.tf
+++ b/examples/azure/aks-new-cluster-azure-controlplane/aks.tf
@@ -1,10 +1,16 @@
 ###############################################################################
 # AKS CLUSTER – control-plane + "system" pool
 ###############################################################################
+moved {
+  from = azurerm_kubernetes_cluster.aks
+  to   = azurerm_kubernetes_cluster.aks[0]
+}
+
 #trivy:ignore:avd-azu-0040
 #trivy:ignore:avd-azu-0041
 #trivy:ignore:avd-azu-0042
 resource "azurerm_kubernetes_cluster" "aks" {
+  count = var.create_aks_cluster ? 1 : 0
 
   #checkov:skip=CKV_AZURE_170: "Ensure that AKS use the Paid Sku for its SLA"
   #checkov:skip=CKV_AZURE_172: "Ensure autorotation of Secrets Store CSI Driver secrets for AKS clusters"
@@ -21,8 +27,8 @@ resource "azurerm_kubernetes_cluster" "aks" {
   #checkov:skip=CKV_AZURE_227: "Ensure that the AKS cluster encrypt temp disks, caches, and data flows between Compute and Storage resources"
 
   name                = var.aks_cluster_name
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = local.rg_location
+  resource_group_name = local.rg_name
 
   # lets kubectl talk to the API over the public FQDN
   dns_prefix = "${var.aks_cluster_name}-dns"
@@ -37,9 +43,10 @@ resource "azurerm_kubernetes_cluster" "aks" {
   default_node_pool {
     name            = "sys"
     vm_size         = var.system_vm_size
-    vnet_subnet_id  = azurerm_subnet.nodes.id
+    vnet_subnet_id  = local.node_subnet_id
     os_disk_size_gb = 64
     type            = "VirtualMachineScaleSets"
+    zones           = var.node_pool_zones
 
     # autoscaler
     auto_scaling_enabled = true
@@ -76,18 +83,25 @@ resource "azurerm_kubernetes_cluster" "aks" {
 ###############################################################################
 # CPU NODE POOL – OnDemand
 ###############################################################################
+moved {
+  from = azurerm_kubernetes_cluster_node_pool.ondemand_cpu
+  to   = azurerm_kubernetes_cluster_node_pool.ondemand_cpu[0]
+}
+
 resource "azurerm_kubernetes_cluster_node_pool" "ondemand_cpu" {
+  count = local.create_node_pools ? 1 : 0
 
   #checkov:skip=CKV_AZURE_168: "Ensure Azure Kubernetes Cluster (AKS) nodes should use a minimum number of 50 pods"
   #checkov:skip=CKV_AZURE_227: "Ensure that the AKS cluster encrypt temp disks, caches, and data flows between Compute and Storage resources"
 
   name                        = "cpu16"
-  kubernetes_cluster_id       = azurerm_kubernetes_cluster.aks.id
+  kubernetes_cluster_id       = local.aks_id
   temporary_name_for_rotation = "cpu16tmp"
 
   vm_size        = var.cpu_vm_size
   mode           = "User"
-  vnet_subnet_id = azurerm_subnet.nodes.id
+  vnet_subnet_id = local.node_subnet_id
+  zones          = var.node_pool_zones
 
   auto_scaling_enabled = true
   min_count            = 0
@@ -107,18 +121,25 @@ resource "azurerm_kubernetes_cluster_node_pool" "ondemand_cpu" {
 ###############################################################################
 # CPU NODE POOL – Spot
 ###############################################################################
+moved {
+  from = azurerm_kubernetes_cluster_node_pool.spot_cpu
+  to   = azurerm_kubernetes_cluster_node_pool.spot_cpu[0]
+}
+
 resource "azurerm_kubernetes_cluster_node_pool" "spot_cpu" {
+  count = local.create_node_pools ? 1 : 0
 
   #checkov:skip=CKV_AZURE_168: "Ensure Azure Kubernetes Cluster (AKS) nodes should use a minimum number of 50 pods"
   #checkov:skip=CKV_AZURE_227: "Ensure that the AKS cluster encrypt temp disks, caches, and data flows between Compute and Storage resources"
 
   name                        = "cpu16spot"
-  kubernetes_cluster_id       = azurerm_kubernetes_cluster.aks.id
+  kubernetes_cluster_id       = local.aks_id
   temporary_name_for_rotation = "cpu16sptmp"
 
   vm_size        = var.cpu_vm_size
   mode           = "User"
-  vnet_subnet_id = azurerm_subnet.nodes.id
+  vnet_subnet_id = local.node_subnet_id
+  zones          = var.node_pool_zones
 
   auto_scaling_enabled = true
   min_count            = 0
@@ -152,14 +173,15 @@ resource "azurerm_kubernetes_cluster_node_pool" "gpu_ondemand" {
   #checkov:skip=CKV_AZURE_168
   #checkov:skip=CKV_AZURE_227
 
-  for_each = var.gpu_pool_configs
+  for_each = local.create_node_pools ? var.gpu_pool_configs : {}
 
   name                  = each.value.name
-  kubernetes_cluster_id = azurerm_kubernetes_cluster.aks.id
+  kubernetes_cluster_id = local.aks_id
 
   vm_size        = each.value.vm_size
   mode           = "User"
-  vnet_subnet_id = azurerm_subnet.nodes.id
+  vnet_subnet_id = local.node_subnet_id
+  zones          = var.node_pool_zones
 
   # ── autoscaling (shared across all pools) ───────────────────────────────────
   auto_scaling_enabled = true
@@ -196,14 +218,15 @@ resource "azurerm_kubernetes_cluster_node_pool" "gpu_spot" {
   #checkov:skip=CKV_AZURE_168
   #checkov:skip=CKV_AZURE_227
 
-  for_each = var.gpu_pool_configs
+  for_each = local.create_node_pools ? var.gpu_pool_configs : {}
 
   name                  = "${each.value.name}spot"
-  kubernetes_cluster_id = azurerm_kubernetes_cluster.aks.id
+  kubernetes_cluster_id = local.aks_id
 
   vm_size        = each.value.vm_size
   mode           = "User"
-  vnet_subnet_id = azurerm_subnet.nodes.id
+  vnet_subnet_id = local.node_subnet_id
+  zones          = var.node_pool_zones
 
   # ── autoscaling (shared across all pools) ───────────────────────────────────
   auto_scaling_enabled = true
@@ -245,8 +268,8 @@ moved {
 resource "azurerm_user_assigned_identity" "anyscale_operator" {
   count               = var.enable_operator_infrastructure ? 1 : 0
   name                = "${var.aks_cluster_name}-anyscale-operator-mi"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = local.rg_location
+  resource_group_name = local.rg_name
 }
 
 ###############################################################################
@@ -260,10 +283,10 @@ moved {
 resource "azurerm_federated_identity_credential" "anyscale_operator_fic" {
   count               = var.enable_operator_infrastructure ? 1 : 0
   name                = "anyscale-operator-fic"
-  resource_group_name = azurerm_resource_group.rg.name
+  resource_group_name = local.rg_name
 
   parent_id = azurerm_user_assigned_identity.anyscale_operator[0].id # user assigned identity
-  issuer    = azurerm_kubernetes_cluster.aks.oidc_issuer_url         # OIDC issuer from AKS
+  issuer    = local.aks_oidc_issuer_url                              # OIDC issuer from AKS
   subject   = "system:serviceaccount:${var.anyscale_operator_namespace}:${var.anyscale_operator_serviceaccount}"
   audience  = ["api://AzureADTokenExchange"] # fixed value for AAD tokens
 }

--- a/examples/azure/aks-new-cluster-azure-controlplane/aks.tf
+++ b/examples/azure/aks-new-cluster-azure-controlplane/aks.tf
@@ -267,7 +267,7 @@ moved {
 
 resource "azurerm_user_assigned_identity" "anyscale_operator" {
   count               = var.enable_operator_infrastructure ? 1 : 0
-  name                = "${var.aks_cluster_name}-anyscale-operator-mi"
+  name                = local.anyscale_operator_identity_name
   location            = local.rg_location
   resource_group_name = local.rg_name
 }

--- a/examples/azure/aks-new-cluster-azure-controlplane/aks_existing.tf
+++ b/examples/azure/aks-new-cluster-azure-controlplane/aks_existing.tf
@@ -1,0 +1,214 @@
+###############################################################################
+# Create-or-adopt resolution layer.
+#
+# This example defaults to creating everything it needs (`create_aks_cluster =
+# true`, the historical behaviour). Set `create_aks_cluster = false` and supply
+# `existing_aks_cluster_name` + `azure_resource_group_name` to layer Anyscale
+# onto an AKS cluster you already run.
+#
+# Every other file reads the cluster, resource group and node subnet through
+# the `local.aks_*` / `local.rg_*` / `local.node_subnet_id` values defined here,
+# so there is exactly one place that knows which mode is in effect.
+#
+#   create_aks_cluster = true
+#       -> new RG, VNet, subnet, cluster and node pools (the default)
+#   create_aks_cluster = true + existing_node_subnet_id
+#       -> new cluster in a subnet you already have
+#   create_aks_cluster = true + create_resource_group = false
+#       -> new cluster in a resource group you already have
+#   create_aks_cluster = false
+#       -> adopt an existing cluster, along with its resource group and subnet
+###############################################################################
+
+locals {
+  # Adopting a cluster implies adopting the resource group it lives in — there
+  # is nothing sensible to create alongside it.
+  create_resource_group = var.create_aks_cluster && var.create_resource_group
+
+  # The VNet/subnet pair is only ours to create when we are creating the
+  # cluster AND the caller has not pointed us at a subnet of their own.
+  create_network = var.create_aks_cluster && var.existing_node_subnet_id == null
+
+  create_node_pools = var.create_node_pools
+
+  # Interpolating a null into a string is an error, and this name is null in
+  # the (default) create path. Normalise once so the CLI probe and the
+  # precondition messages below can use it unconditionally.
+  existing_aks_cluster_name = var.existing_aks_cluster_name == null ? "" : var.existing_aks_cluster_name
+
+  # Keep in sync with the validation on var.azure_location, select-region.sh
+  # and the README. Used to check the region of an ADOPTED cluster, which the
+  # variable validation cannot see.
+  anyscale_supported_locations = [
+    "westcentralus", "eastus", "eastus2", "westus2", "westus3",
+    "southcentralus", "westeurope", "swedencentral", "uksouth",
+    "australiaeast", "southeastasia", "northeurope",
+  ]
+}
+
+###############################################################################
+# Existing resource group.
+###############################################################################
+data "azurerm_resource_group" "existing" {
+  count = local.create_resource_group ? 0 : 1
+
+  name = var.azure_resource_group_name
+
+  lifecycle {
+    precondition {
+      condition     = var.azure_resource_group_name != ""
+      error_message = "azure_resource_group_name must name an existing resource group when create_resource_group=false or create_aks_cluster=false. The \"<aks_cluster_name>-rg\" fallback only applies when Terraform creates the group."
+    }
+  }
+}
+
+###############################################################################
+# Existing AKS cluster.
+###############################################################################
+data "azurerm_kubernetes_cluster" "existing" {
+  count = var.create_aks_cluster ? 0 : 1
+
+  name                = var.existing_aks_cluster_name
+  resource_group_name = var.azure_resource_group_name
+
+  lifecycle {
+    precondition {
+      condition     = var.existing_aks_cluster_name != null && var.existing_aks_cluster_name != ""
+      error_message = "existing_aks_cluster_name must be set when create_aks_cluster=false."
+    }
+    precondition {
+      condition     = var.azure_resource_group_name != ""
+      error_message = "azure_resource_group_name must name the resource group holding existing_aks_cluster_name when create_aks_cluster=false."
+    }
+  }
+}
+
+###############################################################################
+# Microsoft Entra workload identity is not exposed by the azurerm data source,
+# so read it with the Azure CLI (already a hard dependency of this example —
+# see azure-login.sh and the gateway-LB steps in envoy-gateway.tf).
+#
+# Deliberately tolerant: an unreadable value yields "" rather than failing, and
+# the preflight precondition below only blocks on an explicit "false". This
+# mirrors how the Anyscale.Platform agreement status is read in anyscale.tf.
+###############################################################################
+data "external" "existing_aks_workload_identity" {
+  count = var.create_aks_cluster ? 0 : 1
+
+  program = [
+    "bash",
+    "-c",
+    "value=\"$(az aks show --resource-group '${var.azure_resource_group_name}' --name '${local.existing_aks_cluster_name}' --query 'securityProfile.workloadIdentity.enabled' -o tsv --only-show-errors 2>/dev/null || true)\"; printf '{\"enabled\":\"%s\"}' \"$value\"",
+  ]
+}
+
+###############################################################################
+# Preflight assertions for the adopt path.
+#
+# These live on a side-effect-free terraform_data rather than on the data
+# sources themselves because a precondition cannot reference the attributes of
+# the resource it is attached to. Failing here fails `terraform plan`, before
+# anything is created.
+###############################################################################
+resource "terraform_data" "existing_aks_preflight" {
+  count = var.create_aks_cluster ? 0 : 1
+
+  input = {
+    cluster_id = data.azurerm_kubernetes_cluster.existing[0].id
+  }
+
+  lifecycle {
+    precondition {
+      condition     = data.azurerm_kubernetes_cluster.existing[0].oidc_issuer_enabled
+      error_message = <<-EOT
+        The existing AKS cluster "${local.existing_aks_cluster_name}" does not have the OIDC issuer enabled, which the Anyscale operator's federated identity credential requires. Enable it with:
+
+          az aks update --resource-group ${var.azure_resource_group_name} --name ${local.existing_aks_cluster_name} --enable-oidc-issuer --enable-workload-identity
+      EOT
+    }
+
+    precondition {
+      condition     = try(data.external.existing_aks_workload_identity[0].result.enabled, "") != "false"
+      error_message = <<-EOT
+        The existing AKS cluster "${local.existing_aks_cluster_name}" does not have Microsoft Entra workload identity enabled. The Anyscale operator authenticates to the control plane with a workload-identity token, not a CLI token. Enable it with:
+
+          az aks update --resource-group ${var.azure_resource_group_name} --name ${local.existing_aks_cluster_name} --enable-oidc-issuer --enable-workload-identity
+      EOT
+    }
+
+    precondition {
+      condition     = length(data.azurerm_kubernetes_cluster.existing[0].kube_config) > 0
+      error_message = <<-EOT
+        The existing AKS cluster "${local.existing_aks_cluster_name}" returned no certificate-based kube_config. This example's kubernetes/helm/kubectl providers (versions.tf) authenticate with the cluster's client certificate, which Azure only issues when local accounts are enabled.
+
+        Either re-enable local accounts (az aks update --resource-group ${var.azure_resource_group_name} --name ${local.existing_aks_cluster_name} --enable-local-accounts), or fork versions.tf to authenticate the three in-cluster providers through an `exec` block running `kubelogin get-token`.
+      EOT
+    }
+
+    precondition {
+      condition     = contains(local.anyscale_supported_locations, lower(replace(data.azurerm_kubernetes_cluster.existing[0].location, " ", "")))
+      error_message = <<-EOT
+        The existing AKS cluster "${local.existing_aks_cluster_name}" is in region "${data.azurerm_kubernetes_cluster.existing[0].location}", where Anyscale.Platform/clouds is not available. Supported regions: ${join(", ", local.anyscale_supported_locations)}.
+      EOT
+    }
+
+    precondition {
+      condition     = local.node_subnet_id != null
+      error_message = <<-EOT
+        Could not determine a node subnet for the existing AKS cluster "${local.existing_aks_cluster_name}" — its first agent pool reports no vnet_subnet_id, which usually means the cluster uses kubenet rather than Azure CNI. Set existing_node_subnet_id explicitly, or set create_node_pools=false if the cluster already has pools carrying the Anyscale taints.
+      EOT
+    }
+  }
+}
+
+###############################################################################
+# Preflight assertion for an adopted resource group.
+#
+# `var.azure_location` only ever configures a resource group Terraform creates,
+# so its region validation does not cover an adopted one. That matters: the
+# Anyscale.Platform/clouds ARM deployment in anyscale.tf is submitted with
+# `location = local.rg_location`, and the storage account, ACR and operator
+# identity are created there too.
+###############################################################################
+resource "terraform_data" "existing_rg_preflight" {
+  count = local.create_resource_group ? 0 : 1
+
+  input = {
+    resource_group_id = local.rg_id
+  }
+
+  lifecycle {
+    precondition {
+      condition     = contains(local.anyscale_supported_locations, lower(replace(local.rg_location, " ", "")))
+      error_message = <<-EOT
+        The existing resource group "${var.azure_resource_group_name}" is in region "${local.rg_location}", where Anyscale.Platform/clouds is not available. The Anyscale cloud, storage account, ACR and operator identity are all deployed into this region.
+
+        Supported regions: ${join(", ", local.anyscale_supported_locations)}.
+      EOT
+    }
+  }
+}
+
+###############################################################################
+# Resolved values consumed by the rest of the example.
+###############################################################################
+locals {
+  rg_name     = local.create_resource_group ? azurerm_resource_group.rg[0].name : data.azurerm_resource_group.existing[0].name
+  rg_id       = local.create_resource_group ? azurerm_resource_group.rg[0].id : data.azurerm_resource_group.existing[0].id
+  rg_location = local.create_resource_group ? azurerm_resource_group.rg[0].location : data.azurerm_resource_group.existing[0].location
+
+  aks_id                = var.create_aks_cluster ? azurerm_kubernetes_cluster.aks[0].id : data.azurerm_kubernetes_cluster.existing[0].id
+  aks_name              = var.create_aks_cluster ? azurerm_kubernetes_cluster.aks[0].name : data.azurerm_kubernetes_cluster.existing[0].name
+  aks_oidc_issuer_url   = var.create_aks_cluster ? azurerm_kubernetes_cluster.aks[0].oidc_issuer_url : data.azurerm_kubernetes_cluster.existing[0].oidc_issuer_url
+  aks_kubelet_object_id = var.create_aks_cluster ? azurerm_kubernetes_cluster.aks[0].kubelet_identity[0].object_id : data.azurerm_kubernetes_cluster.existing[0].kubelet_identity[0].object_id
+  aks_kube_config       = var.create_aks_cluster ? azurerm_kubernetes_cluster.aks[0].kube_config[0] : data.azurerm_kubernetes_cluster.existing[0].kube_config[0]
+
+  # Precedence: explicit override -> the subnet we just created -> the subnet
+  # the adopted cluster's first agent pool already runs in. Null (a kubenet
+  # cluster, nothing to infer) is caught by the preflight precondition above.
+  node_subnet_id = try(coalesce(
+    var.existing_node_subnet_id,
+    one(azurerm_subnet.nodes[*].id),
+    try(one(data.azurerm_kubernetes_cluster.existing[*].agent_pool_profile[0].vnet_subnet_id), null),
+  ), null)
+}

--- a/examples/azure/aks-new-cluster-azure-controlplane/anyscale.tf
+++ b/examples/azure/aks-new-cluster-azure-controlplane/anyscale.tf
@@ -19,6 +19,11 @@
 locals {
   anyscale_cloud_name = coalesce(var.anyscale_cloud_name, "${var.aks_cluster_name}-cloud")
 
+  # Named here rather than inline on the resource because the ARM template
+  # needs the same name when it provisions the identity itself
+  # (enable_operator_infrastructure = false).
+  anyscale_operator_identity_name = "${var.aks_cluster_name}-anyscale-operator-mi"
+
   # ARM resource ID of the Anyscale.Platform/clouds resource the deployment
   # below creates. Used by the destroy-ordering hook so the cloud is removed
   # before the AKS cluster (see terraform_data.anyscale_cloud_predelete).
@@ -181,21 +186,30 @@ resource "azapi_resource" "anyscale_platform" {
   response_export_values = {
     cloud_deployment_id = "properties.outputs.cloudResourceId.value"
     provisioning_state  = "properties.provisioningState"
+    # Resolved from effectiveIdentityResourceId, so these are populated whether
+    # the identity was passed in as "existing" or provisioned as "managed".
+    managed_identity_client_id    = "properties.outputs.managedIdentityClientId.value"
+    managed_identity_principal_id = "properties.outputs.managedIdentityPrincipalId.value"
   }
   body = {
     properties = {
       mode     = "Incremental"
       template = jsondecode(file("${path.module}/templates/anyscale-platform-cloud.template.json"))
       parameters = {
-        location                 = { value = local.rg_location }
-        cloudName                = { value = local.anyscale_cloud_name }
-        storageAccountName       = { value = azurerm_storage_account.sa[0].name }
-        storageMode              = { value = "existing" }
-        storageAccountResourceId = { value = azurerm_storage_account.sa[0].id }
-        storageContainerName     = { value = azurerm_storage_container.blob[0].name }
-        workloadIdentityName     = { value = azurerm_user_assigned_identity.anyscale_operator[0].name }
-        identityMode             = { value = "existing" }
-        identityResourceId       = { value = azurerm_user_assigned_identity.anyscale_operator[0].id }
+        location  = { value = local.rg_location }
+        cloudName = { value = local.anyscale_cloud_name }
+        # enable_operator_infrastructure decides who owns the storage account,
+        # container and workload identity. When true (the default) Terraform
+        # creates them and binds the template to them as "existing"; when false
+        # the template provisions them itself in "managed" mode, and only needs
+        # the names to use.
+        storageAccountName       = { value = local.storage_account_name }
+        storageMode              = { value = var.enable_operator_infrastructure ? "existing" : "managed" }
+        storageAccountResourceId = { value = var.enable_operator_infrastructure ? azurerm_storage_account.sa[0].id : "" }
+        storageContainerName     = { value = local.storage_container_name }
+        workloadIdentityName     = { value = local.anyscale_operator_identity_name }
+        identityMode             = { value = var.enable_operator_infrastructure ? "existing" : "managed" }
+        identityResourceId       = { value = var.enable_operator_infrastructure ? azurerm_user_assigned_identity.anyscale_operator[0].id : "" }
         tagsByResource           = { value = var.anyscale_platform.tags_by_resource }
         acrMode                  = { value = var.enable_acr ? "existing" : "none" }
         acrName                  = { value = var.enable_acr ? azurerm_container_registry.acr[0].name : "" }
@@ -243,6 +257,18 @@ resource "azapi_resource" "anyscale_platform" {
 locals {
   anyscale_cloud_resource_id            = azapi_resource.anyscale_platform.output.cloud_deployment_id
   anyscale_cloud_resource_id_hyphenated = replace(local.anyscale_cloud_resource_id, "_", "-")
+
+  # Who owns the operator's workload identity depends on
+  # enable_operator_infrastructure, so read its IDs from whichever side made
+  # it: the resource below, or the ARM deployment's outputs.
+  anyscale_operator_client_id = (var.enable_operator_infrastructure
+    ? azurerm_user_assigned_identity.anyscale_operator[0].client_id
+    : azapi_resource.anyscale_platform.output.managed_identity_client_id
+  )
+  anyscale_operator_principal_id = (var.enable_operator_infrastructure
+    ? azurerm_user_assigned_identity.anyscale_operator[0].principal_id
+    : azapi_resource.anyscale_platform.output.managed_identity_principal_id
+  )
 
   anyscale_gateway_certificate_secret_name         = "anyscale-${local.anyscale_cloud_resource_id_hyphenated}-certificate"
   anyscale_gateway_service_certificate_secret_name = "anyscale-svc-${local.anyscale_cloud_resource_id_hyphenated}-certificate"
@@ -377,7 +403,7 @@ resource "azurerm_kubernetes_cluster_extension" "anyscale_operator" {
     {
       "global.cloudDeploymentId"      = local.anyscale_cloud_resource_id
       "global.controlPlaneURL"        = var.anyscale_platform.control_plane_url
-      "global.auth.iamIdentity"       = azurerm_user_assigned_identity.anyscale_operator[0].client_id
+      "global.auth.iamIdentity"       = local.anyscale_operator_client_id
       "global.auth.audience"          = var.anyscale_platform.auth_audience
       "workloads.serviceAccount.name" = var.anyscale_operator_serviceaccount
 
@@ -510,7 +536,7 @@ locals {
       cloudProvider     = "azure"
       controlPlaneURL   = var.anyscale_platform.control_plane_url
       auth = {
-        iamIdentity      = azurerm_user_assigned_identity.anyscale_operator[0].client_id
+        iamIdentity      = local.anyscale_operator_client_id
         audience         = var.anyscale_platform.auth_audience
         anyscaleCliToken = ""
       }

--- a/examples/azure/aks-new-cluster-azure-controlplane/anyscale.tf
+++ b/examples/azure/aks-new-cluster-azure-controlplane/anyscale.tf
@@ -70,9 +70,15 @@ locals {
 #   az rest --method GET  --url ".../Anyscale.Platform/agreements/default?api-version=..."
 #   az rest --method POST --url ".../Anyscale.Platform/agreements/default/accept?api-version=..."
 #
-# azurerm_resource_provider_registration (below) already polls internally
-# until the RP shows "Registered" (its own built-in timeout is 2h), so no
-# extra wait logic is needed for that half.
+# Both halves are done with the CLI rather than with resources that own the
+# subscription-wide state. azurerm_resource_provider_registration would be the
+# obvious fit for the first half, but it treats an already-registered RP as a
+# resource to import and fails the apply outright — and registration is
+# subscription-wide, so any subscription that has ever deployed Anyscale
+# (including a second cloud alongside a first) hits that. Its destroy would
+# also UNREGISTER the RP for every other deployment in the subscription. The
+# local-exec below is idempotent instead: it registers only if needed, polls
+# until Registered, and leaves the RP alone on destroy.
 #
 # The agreement half needs its own poll: POSTing /accept does not guarantee
 # the subscription is immediately Active afterward (same class of eventual-
@@ -92,10 +98,58 @@ locals {
 # — see that variable's description for the full text and links (terms of
 # use, privacy policy, Azure Marketplace billing/consent terms).
 ###############################################################################
-resource "azurerm_resource_provider_registration" "anyscale_platform" {
+# An earlier version of this example registered the RP with
+# azurerm_resource_provider_registration. Dropping that resource from the
+# configuration outright would make the next apply DESTROY it, and its destroy
+# unregisters Anyscale.Platform for every deployment in the subscription. This
+# forgets it instead, leaving the registration in place.
+removed {
+  from = azurerm_resource_provider_registration.anyscale_platform
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+resource "terraform_data" "anyscale_platform_rp_register" {
   count = var.register_anyscale_resource_provider ? 1 : 0
 
-  name = "Anyscale.Platform"
+  triggers_replace = {
+    subscription_id = var.azure_subscription_id
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-EOT
+      set -euo pipefail
+      SUB="${var.azure_subscription_id}"
+
+      state="$(az provider show --namespace Anyscale.Platform --subscription "$SUB" \
+        --query registrationState -o tsv 2>/dev/null || echo "")"
+      echo "[anyscale] Anyscale.Platform registration state: $${state:-<none>}"
+
+      if [ "$state" != "Registered" ]; then
+        echo "[anyscale] Registering the Anyscale.Platform resource provider..."
+        az provider register --namespace Anyscale.Platform --subscription "$SUB" >/dev/null
+      fi
+
+      deadline=$(( $(date +%s) + 900 ))
+      while :; do
+        state="$(az provider show --namespace Anyscale.Platform --subscription "$SUB" \
+          --query registrationState -o tsv 2>/dev/null || echo "")"
+        if [ "$state" = "Registered" ]; then
+          echo "[anyscale] Anyscale.Platform is Registered."
+          break
+        fi
+        if [ "$(date +%s)" -ge "$deadline" ]; then
+          echo "[anyscale] ERROR: Anyscale.Platform did not reach Registered within timeout (last state: $${state:-<none>})" >&2
+          exit 1
+        fi
+        echo "[anyscale] Waiting for Anyscale.Platform to reach Registered (current: $${state:-<none>})..."
+        sleep 10
+      done
+    EOT
+  }
 }
 
 locals {
@@ -143,7 +197,7 @@ resource "terraform_data" "anyscale_platform_agreement_accept" {
     EOT
   }
 
-  depends_on = [azurerm_resource_provider_registration.anyscale_platform]
+  depends_on = [terraform_data.anyscale_platform_rp_register]
 }
 
 # Read the agreement's current status for the output below and as a
@@ -166,7 +220,7 @@ data "external" "anyscale_platform_agreement" {
   ]
 
   depends_on = [
-    azurerm_resource_provider_registration.anyscale_platform,
+    terraform_data.anyscale_platform_rp_register,
     terraform_data.anyscale_platform_agreement_accept,
   ]
 }
@@ -208,13 +262,17 @@ resource "azapi_resource" "anyscale_platform" {
         storageAccountResourceId = { value = var.enable_operator_infrastructure ? azurerm_storage_account.sa[0].id : "" }
         storageContainerName     = { value = local.storage_container_name }
         workloadIdentityName     = { value = local.anyscale_operator_identity_name }
-        identityMode             = { value = var.enable_operator_infrastructure ? "existing" : "managed" }
-        identityResourceId       = { value = var.enable_operator_infrastructure ? azurerm_user_assigned_identity.anyscale_operator[0].id : "" }
-        tagsByResource           = { value = var.anyscale_platform.tags_by_resource }
-        acrMode                  = { value = var.enable_acr ? "existing" : "none" }
-        acrName                  = { value = var.enable_acr ? azurerm_container_registry.acr[0].name : "" }
-        acrResourceId            = { value = var.enable_acr ? azurerm_container_registry.acr[0].id : "" }
-        aksKubeletPrincipalId    = { value = local.aks_kubelet_object_id }
+        # Only read when identityMode = managed, i.e. enable_operator_infrastructure
+        # = false: the template builds the federated credential's issuer from this
+        # cluster's OIDC issuer URL.
+        aksClusterResourceId  = { value = local.aks_id }
+        identityMode          = { value = var.enable_operator_infrastructure ? "existing" : "managed" }
+        identityResourceId    = { value = var.enable_operator_infrastructure ? azurerm_user_assigned_identity.anyscale_operator[0].id : "" }
+        tagsByResource        = { value = var.anyscale_platform.tags_by_resource }
+        acrMode               = { value = var.enable_acr ? "existing" : "none" }
+        acrName               = { value = var.enable_acr ? azurerm_container_registry.acr[0].name : "" }
+        acrResourceId         = { value = var.enable_acr ? azurerm_container_registry.acr[0].id : "" }
+        aksKubeletPrincipalId = { value = local.aks_kubelet_object_id }
         # Terraform owns the kubelet AcrPull assignment (acr.tf). Tell the
         # ARM template not to create a duplicate one.
         manageAksKubeletAcrPullRoleAssignment = { value = false }
@@ -234,7 +292,7 @@ resource "azapi_resource" "anyscale_platform" {
     azurerm_role_assignment.anyscale_blob_contrib,
     azurerm_container_registry.acr,
     azurerm_role_assignment.kubelet_acr_pull,
-    azurerm_resource_provider_registration.anyscale_platform,
+    terraform_data.anyscale_platform_rp_register,
     terraform_data.anyscale_platform_agreement_accept,
     data.external.anyscale_platform_agreement,
   ]

--- a/examples/azure/aks-new-cluster-azure-controlplane/anyscale.tf
+++ b/examples/azure/aks-new-cluster-azure-controlplane/anyscale.tf
@@ -22,7 +22,7 @@ locals {
   # ARM resource ID of the Anyscale.Platform/clouds resource the deployment
   # below creates. Used by the destroy-ordering hook so the cloud is removed
   # before the AKS cluster (see terraform_data.anyscale_cloud_predelete).
-  anyscale_cloud_arm_id = "${azurerm_resource_group.rg.id}/providers/Anyscale.Platform/clouds/${local.anyscale_cloud_name}"
+  anyscale_cloud_arm_id = "${local.rg_id}/providers/Anyscale.Platform/clouds/${local.anyscale_cloud_name}"
 
   anyscale_deployments = {
     top_level    = "dep-anyscale-${var.aks_cluster_name}"
@@ -176,7 +176,7 @@ data "external" "anyscale_platform_agreement" {
 resource "azapi_resource" "anyscale_platform" {
   type                      = "Microsoft.Resources/deployments@2022-09-01"
   name                      = local.anyscale_deployments.top_level
-  parent_id                 = azurerm_resource_group.rg.id
+  parent_id                 = local.rg_id
   schema_validation_enabled = false
   response_export_values = {
     cloud_deployment_id = "properties.outputs.cloudResourceId.value"
@@ -187,7 +187,7 @@ resource "azapi_resource" "anyscale_platform" {
       mode     = "Incremental"
       template = jsondecode(file("${path.module}/templates/anyscale-platform-cloud.template.json"))
       parameters = {
-        location                 = { value = azurerm_resource_group.rg.location }
+        location                 = { value = local.rg_location }
         cloudName                = { value = local.anyscale_cloud_name }
         storageAccountName       = { value = azurerm_storage_account.sa[0].name }
         storageMode              = { value = "existing" }
@@ -200,7 +200,7 @@ resource "azapi_resource" "anyscale_platform" {
         acrMode                  = { value = var.enable_acr ? "existing" : "none" }
         acrName                  = { value = var.enable_acr ? azurerm_container_registry.acr[0].name : "" }
         acrResourceId            = { value = var.enable_acr ? azurerm_container_registry.acr[0].id : "" }
-        aksKubeletPrincipalId    = { value = azurerm_kubernetes_cluster.aks.kubelet_identity[0].object_id }
+        aksKubeletPrincipalId    = { value = local.aks_kubelet_object_id }
         # Terraform owns the kubelet AcrPull assignment (acr.tf). Tell the
         # ARM template not to create a duplicate one.
         manageAksKubeletAcrPullRoleAssignment = { value = false }
@@ -362,7 +362,7 @@ resource "azurerm_kubernetes_cluster_extension" "anyscale_operator" {
   count = var.install_operator_extension ? 1 : 0
 
   name              = var.anyscale_platform.extension_resource_name
-  cluster_id        = azurerm_kubernetes_cluster.aks.id
+  cluster_id        = local.aks_id
   extension_type    = "Anyscale.AKS.Operator"
   release_train     = local.anyscale_extension_release_train
   release_namespace = var.anyscale_operator_namespace

--- a/examples/azure/aks-new-cluster-azure-controlplane/anyscale.tf
+++ b/examples/azure/aks-new-cluster-azure-controlplane/anyscale.tf
@@ -475,3 +475,86 @@ resource "terraform_data" "anyscale_cloud_predelete" {
     azapi_resource.anyscale_platform,
   ]
 }
+
+###############################################################################
+# Manual Helm install support (install_operator_extension = false).
+#
+# When Terraform does not install the marketplace extension, the operator has
+# to be installed by hand — and every value it needs is something this apply
+# just produced (the cloud's cldrsrc_ ID, the workload identity's client ID,
+# the Envoy Gateway LB address). Transcribing those into a values.yaml by hand
+# is the step people get wrong, so write the file out instead.
+#
+# The nested structure below mirrors the flat dotted configuration_settings on
+# azurerm_kubernetes_cluster_extension.anyscale_operator above. Keep the two in
+# sync: anything added there that the operator needs at install time has to be
+# added here as well.
+#
+# Two values are easy to miss when hand-writing this file, and both are here:
+#
+#   global.auth.anyscaleCliToken   Must be present and empty so the operator
+#                                  uses the Microsoft Entra workload-identity
+#                                  exchange rather than CLI-token auth.
+#   networking.gateway             Normally baked in by the extension from the
+#                                  gateway LB address; nothing else tells the
+#                                  operator where the Gateway is.
+#
+# Note: overrides supplied through anyscale_platform.extension_configuration_
+# settings apply to the EXTENSION path only — they are flat dotted keys and are
+# not merged into this file. Edit the generated file if you need them here.
+###############################################################################
+locals {
+  anyscale_operator_helm_values = {
+    global = {
+      cloudDeploymentId = local.anyscale_cloud_resource_id
+      cloudProvider     = "azure"
+      controlPlaneURL   = var.anyscale_platform.control_plane_url
+      auth = {
+        iamIdentity      = azurerm_user_assigned_identity.anyscale_operator[0].client_id
+        audience         = var.anyscale_platform.auth_audience
+        anyscaleCliToken = ""
+      }
+    }
+    workloads = {
+      serviceAccount = { name = var.anyscale_operator_serviceaccount }
+      instanceTypes  = { enableDefaults = true }
+      accelerator = {
+        # Matches the taints aks.tf puts on the GPU pools.
+        tolerations = {
+          default = [
+            { key = "node.anyscale.com/accelerator-type", value = "GPU", effect = "NoSchedule" },
+            { key = "nvidia.com/gpu", operator = "Exists", effect = "NoSchedule" },
+          ]
+        }
+      }
+    }
+    networking = {
+      gateway = {
+        enabled    = true
+        name       = var.envoy_gateway.gateway_name
+        className  = var.envoy_gateway.gateway_class_name
+        namespace  = var.anyscale_operator_namespace
+        apiVersion = "gateway.networking.k8s.io/v1"
+        hostname   = data.external.gateway_lb.result.address
+      }
+    }
+  }
+
+  # Terraform already created the namespace unless create_operator_namespace
+  # is false, so only ask Helm to create it when it actually has to.
+  anyscale_operator_helm_command = join(" ", compact([
+    "helm install ${local.anyscale_cloud_name} anyscale/anyscale-operator",
+    "--namespace ${var.anyscale_operator_namespace}",
+    var.create_operator_namespace ? "" : "--create-namespace",
+    "--values anyscale-operator-values.yaml",
+    "--wait",
+  ]))
+}
+
+resource "local_file" "anyscale_operator_values" {
+  count = var.install_operator_extension ? 0 : 1
+
+  filename        = "${path.module}/anyscale-operator-values.yaml"
+  file_permission = "0600"
+  content         = yamlencode(local.anyscale_operator_helm_values)
+}

--- a/examples/azure/aks-new-cluster-azure-controlplane/envoy-gateway.tf
+++ b/examples/azure/aks-new-cluster-azure-controlplane/envoy-gateway.tf
@@ -71,7 +71,14 @@ resource "terraform_data" "aks_credentials" {
 ###############################################################################
 # Envoy Gateway Helm release (v1.7.0 from docker.io OCI registry).
 ###############################################################################
+moved {
+  from = helm_release.envoy_gateway
+  to   = helm_release.envoy_gateway[0]
+}
+
 resource "helm_release" "envoy_gateway" {
+  count = var.create_envoy_gateway ? 1 : 0
+
   name             = var.envoy_gateway.release_name
   repository       = "oci://docker.io/envoyproxy"
   chart            = "gateway-helm"
@@ -93,7 +100,14 @@ resource "helm_release" "envoy_gateway" {
 # `azure-load-balancer-internal: "false"` forces a public LB; flip to "true"
 # if you want the Anyscale data plane reachable only from the VNet.
 ###############################################################################
+moved {
+  from = kubectl_manifest.envoy_proxy
+  to   = kubectl_manifest.envoy_proxy[0]
+}
+
 resource "kubectl_manifest" "envoy_proxy" {
+  count = var.create_envoy_gateway ? 1 : 0
+
   yaml_body = yamlencode({
     apiVersion = "gateway.envoyproxy.io/v1alpha1"
     kind       = "EnvoyProxy"
@@ -122,7 +136,14 @@ resource "kubectl_manifest" "envoy_proxy" {
 ###############################################################################
 # GatewayClass — named `eg` to match the Anyscale quickstart.
 ###############################################################################
+moved {
+  from = kubectl_manifest.gateway_class
+  to   = kubectl_manifest.gateway_class[0]
+}
+
 resource "kubectl_manifest" "gateway_class" {
+  count = var.create_envoy_gateway ? 1 : 0
+
   yaml_body = yamlencode({
     apiVersion = "gateway.networking.k8s.io/v1"
     kind       = "GatewayClass"
@@ -147,7 +168,14 @@ resource "kubectl_manifest" "gateway_class" {
 # Operator namespace (the Gateway lives here, alongside the operator the
 # AKS extension is about to install).
 ###############################################################################
+moved {
+  from = kubernetes_namespace_v1.anyscale_operator
+  to   = kubernetes_namespace_v1.anyscale_operator[0]
+}
+
 resource "kubernetes_namespace_v1" "anyscale_operator" {
+  count = var.create_operator_namespace ? 1 : 0
+
   metadata {
     name = var.anyscale_operator_namespace
   }
@@ -238,6 +266,7 @@ resource "terraform_data" "wait_for_gateway_lb" {
     poll_interval    = var.envoy_gateway.gateway_lb_poll_interval_seconds
     kubeconfig       = "${path.module}/.kubeconfig"
     gateway_manifest = kubectl_manifest.gateway.id
+    gateway_class    = var.envoy_gateway.gateway_class_name
   }
 
   provisioner "local-exec" {
@@ -256,6 +285,20 @@ resource "terraform_data" "wait_for_gateway_lb" {
         if [ "$(date +%s)" -ge "$deadline" ]; then
           echo "Timed out waiting for Gateway LB address after ${self.input.timeout_seconds}s" >&2
           kubectl describe gateway ${self.input.gateway_name} -n ${self.input.namespace} >&2 || true
+
+          # The usual cause when reusing an Envoy Gateway install
+          # (create_envoy_gateway=false) is a GatewayClass whose EnvoyProxy
+          # publishes the data plane as something other than a LoadBalancer, so
+          # status.addresses never gets populated. Surface enough to see that.
+          echo "--- GatewayClass ${self.input.gateway_class} ---" >&2
+          kubectl describe gatewayclass ${self.input.gateway_class} >&2 || true
+          ref="$(kubectl get gatewayclass ${self.input.gateway_class}             -o jsonpath='{.spec.parametersRef.namespace}/{.spec.parametersRef.name}' 2>/dev/null || true)"
+          if [ -n "$ref" ] && [ "$ref" != "/" ]; then
+            echo "--- EnvoyProxy $ref (envoyService.type must be LoadBalancer) ---" >&2
+            kubectl get envoyproxy "$${ref#*/}" -n "$${ref%/*}"               -o jsonpath='{.spec.provider.kubernetes.envoyService.type}{"\n"}' >&2 || true
+          else
+            echo "GatewayClass ${self.input.gateway_class} has no parametersRef -> no EnvoyProxy pinning the service type." >&2
+          fi
           exit 1
         fi
         sleep ${self.input.poll_interval}

--- a/examples/azure/aks-new-cluster-azure-controlplane/envoy-gateway.tf
+++ b/examples/azure/aks-new-cluster-azure-controlplane/envoy-gateway.tf
@@ -46,7 +46,7 @@
 ###############################################################################
 resource "terraform_data" "aks_credentials" {
   triggers_replace = {
-    cluster_id = azurerm_kubernetes_cluster.aks.id
+    cluster_id = local.aks_id
   }
 
   provisioner "local-exec" {
@@ -54,8 +54,8 @@ resource "terraform_data" "aks_credentials" {
     command     = <<-EOT
       set -euo pipefail
       az aks get-credentials \
-        --resource-group "${azurerm_resource_group.rg.name}" \
-        --name "${azurerm_kubernetes_cluster.aks.name}" \
+        --resource-group "${local.rg_name}" \
+        --name "${local.aks_name}" \
         --file "${path.module}/.kubeconfig" \
         --overwrite-existing \
         --only-show-errors

--- a/examples/azure/aks-new-cluster-azure-controlplane/main.tf
+++ b/examples/azure/aks-new-cluster-azure-controlplane/main.tf
@@ -32,7 +32,14 @@ locals {
 ############################################
 # resource group
 ############################################
+moved {
+  from = azurerm_resource_group.rg
+  to   = azurerm_resource_group.rg[0]
+}
+
 resource "azurerm_resource_group" "rg" {
+  count = local.create_resource_group ? 1 : 0
+
   name     = coalesce(var.azure_resource_group_name, "${var.aks_cluster_name}-rg")
   location = var.azure_location
   tags     = var.tags
@@ -63,8 +70,8 @@ resource "azurerm_storage_account" "sa" {
   #checkov:skip=CKV2_AZURE_31: "Ensure VNET subnet is configured with a Network Security Group (NSG)"
 
   name                     = local.storage_account_name
-  resource_group_name      = azurerm_resource_group.rg.name
-  location                 = azurerm_resource_group.rg.location
+  resource_group_name      = local.rg_name
+  location                 = local.rg_location
   account_tier             = "Standard"
   account_replication_type = "LRS"
 
@@ -106,8 +113,8 @@ resource "azurerm_storage_account" "nfs" {
   count = var.enable_nfs ? 1 : 0
 
   name                       = local.storage_account_name_nfs
-  resource_group_name        = azurerm_resource_group.rg.name
-  location                   = azurerm_resource_group.rg.location
+  resource_group_name        = local.rg_name
+  location                   = local.rg_location
   account_kind               = "FileStorage"
   account_tier               = "Premium"
   account_replication_type   = "ZRS"
@@ -117,7 +124,7 @@ resource "azurerm_storage_account" "nfs" {
 
   network_rules {
     default_action             = "Deny"
-    virtual_network_subnet_ids = [azurerm_subnet.nodes.id]
+    virtual_network_subnet_ids = [local.node_subnet_id]
     bypass                     = ["AzureServices"]
   }
 
@@ -127,22 +134,35 @@ resource "azurerm_storage_account" "nfs" {
 ############################################
 # networking (vnet and subnet)
 ############################################
+moved {
+  from = azurerm_virtual_network.vnet
+  to   = azurerm_virtual_network.vnet[0]
+}
+
 resource "azurerm_virtual_network" "vnet" {
+  count = local.create_network ? 1 : 0
+
   name                = "${var.aks_cluster_name}-vnet"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = local.rg_location
+  resource_group_name = local.rg_name
   address_space       = [var.vnet_cidr]
   tags                = var.tags
 }
 
 # Subnet for AKS nodes
+moved {
+  from = azurerm_subnet.nodes
+  to   = azurerm_subnet.nodes[0]
+}
+
 resource "azurerm_subnet" "nodes" {
+  count = local.create_network ? 1 : 0
 
   #checkov:skip=CKV2_AZURE_31: "Ensure VNET subnet is configured with a Network Security Group (NSG)"
 
   name                 = "aks-nodes"
-  resource_group_name  = azurerm_resource_group.rg.name
-  virtual_network_name = azurerm_virtual_network.vnet.name
+  resource_group_name  = local.rg_name
+  virtual_network_name = azurerm_virtual_network.vnet[0].name
   address_prefixes     = [var.nodes_subnet_cidr]
   service_endpoints    = ["Microsoft.Storage"]
 }

--- a/examples/azure/aks-new-cluster-azure-controlplane/main.tf
+++ b/examples/azure/aks-new-cluster-azure-controlplane/main.tf
@@ -80,6 +80,22 @@ resource "azurerm_storage_account" "sa" {
   account_tier             = "Standard"
   account_replication_type = "LRS"
 
+  # Match the account the ARM template provisions when it owns storage
+  # (enable_operator_infrastructure = false), so the two ownership modes are
+  # actually equivalent rather than merely both "working".
+  #
+  # is_hns_enabled matters most: the cloud is registered with an
+  # abfss://<container>@<account>.dfs.core.windows.net URI, which is the ADLS
+  # Gen2 endpoint. The operator's own startup check passes without it because
+  # that talks to the blob endpoint with presigned URLs, so a flat-namespace
+  # account looks healthy until a workload uses abfss.
+  #
+  # NOTE: is_hns_enabled is immutable. Adding it to a deployment that already
+  # exists forces the storage account to be REPLACED — check the plan and move
+  # any data you care about first.
+  is_hns_enabled                  = true
+  default_to_oauth_authentication = true
+
   # still blocks "anonymous blob" catches
   allow_nested_items_to_be_public = false
   tags                            = var.tags

--- a/examples/azure/aks-new-cluster-azure-controlplane/main.tf
+++ b/examples/azure/aks-new-cluster-azure-controlplane/main.tf
@@ -27,6 +27,11 @@ locals {
   storage_account_name_base_nfs = length(local.storage_account_name_base) > 16 ? substr(local.storage_account_name_base, 0, 16) : local.storage_account_name_base
   storage_account_name          = coalesce(var.storage_account_name, "${local.storage_account_name_base_sa}sa${local.name_suffix}")
   storage_account_name_nfs      = coalesce(var.storage_account_name_nfs, "${local.storage_account_name_base_nfs}nfs${local.name_suffix}")
+
+  # Named here rather than inline on the resource because the ARM template
+  # needs the same name when it provisions the container itself
+  # (enable_operator_infrastructure = false).
+  storage_container_name = "${var.aks_cluster_name}-blob"
 }
 
 ############################################
@@ -101,7 +106,7 @@ resource "azurerm_storage_container" "blob" {
 
   #checkov:skip=CKV2_AZURE_21: "Ensure Storage logging is enabled for Blob service for read requests"
 
-  name                  = "${var.aks_cluster_name}-blob"
+  name                  = local.storage_container_name
   storage_account_id    = azurerm_storage_account.sa[0].id
   container_access_type = "private" # blobs are private but reachable via the public endpoint
 }

--- a/examples/azure/aks-new-cluster-azure-controlplane/outputs.tf
+++ b/examples/azure/aks-new-cluster-azure-controlplane/outputs.tf
@@ -2,7 +2,7 @@
 # Azure infra outputs (mirrors examples/azure/aks-new_cluster)
 ###############################################################################
 output "azure_resource_group_name" {
-  value       = azurerm_resource_group.rg.name
+  value       = local.rg_name
   description = "Name of the Azure Resource Group."
 }
 
@@ -22,12 +22,12 @@ output "azure_nfs_storage_account_name" {
 }
 
 output "azure_aks_cluster_name" {
-  value       = azurerm_kubernetes_cluster.aks.name
+  value       = local.aks_name
   description = "Name of the AKS cluster."
 }
 
 output "azure_aks_oidc_issuer_url" {
-  value       = azurerm_kubernetes_cluster.aks.oidc_issuer_url
+  value       = local.aks_oidc_issuer_url
   description = "OIDC issuer URL of the AKS cluster (used by workload-identity federation)."
 }
 
@@ -70,7 +70,7 @@ output "anyscale_cloud_name" {
 }
 
 output "anyscale_cloud_arm_id" {
-  value       = "${azurerm_resource_group.rg.id}/providers/Anyscale.Platform/clouds/${local.anyscale_cloud_name}"
+  value       = "${local.rg_id}/providers/Anyscale.Platform/clouds/${local.anyscale_cloud_name}"
   description = "Full ARM resource ID of the Anyscale.Platform/clouds resource."
 }
 
@@ -111,7 +111,7 @@ output "gateway_service_certificate_secret_name" {
 # Convenience commands
 ###############################################################################
 output "aks_get_credentials_command" {
-  value       = "az aks get-credentials --resource-group ${azurerm_resource_group.rg.name} --name ${azurerm_kubernetes_cluster.aks.name} --overwrite-existing"
+  value       = "az aks get-credentials --resource-group ${local.rg_name} --name ${local.aks_name} --overwrite-existing"
   description = "Refresh local kubeconfig against the deployed AKS cluster."
 }
 
@@ -137,15 +137,15 @@ resource "local_file" "cloud_summary" {
     anyscale_cloud = {
       name               = local.anyscale_cloud_name
       resource_id        = local.anyscale_cloud_resource_id
-      arm_id             = "${azurerm_resource_group.rg.id}/providers/Anyscale.Platform/clouds/${local.anyscale_cloud_name}"
+      arm_id             = "${local.rg_id}/providers/Anyscale.Platform/clouds/${local.anyscale_cloud_name}"
       console_url        = var.anyscale_platform.control_plane_url
       operator_namespace = var.anyscale_operator_namespace
       extension_id       = var.install_operator_extension ? azurerm_kubernetes_cluster_extension.anyscale_operator[0].id : null
     }
     azure = {
-      resource_group    = azurerm_resource_group.rg.name
-      aks_cluster       = azurerm_kubernetes_cluster.aks.name
-      oidc_issuer_url   = azurerm_kubernetes_cluster.aks.oidc_issuer_url
+      resource_group    = local.rg_name
+      aks_cluster       = local.aks_name
+      oidc_issuer_url   = local.aks_oidc_issuer_url
       storage_account   = var.enable_operator_infrastructure ? azurerm_storage_account.sa[0].name : null
       storage_container = var.enable_operator_infrastructure ? azurerm_storage_container.blob[0].name : null
       acr_login_server  = var.enable_acr ? azurerm_container_registry.acr[0].login_server : null
@@ -160,7 +160,7 @@ resource "local_file" "cloud_summary" {
       service_certificate_secret = local.anyscale_gateway_service_certificate_secret_name
     }
     commands = {
-      get_credentials = "az aks get-credentials --resource-group ${azurerm_resource_group.rg.name} --name ${azurerm_kubernetes_cluster.aks.name} --overwrite-existing"
+      get_credentials = "az aks get-credentials --resource-group ${local.rg_name} --name ${local.aks_name} --overwrite-existing"
     }
   })
 }

--- a/examples/azure/aks-new-cluster-azure-controlplane/outputs.tf
+++ b/examples/azure/aks-new-cluster-azure-controlplane/outputs.tf
@@ -160,7 +160,21 @@ resource "local_file" "cloud_summary" {
       service_certificate_secret = local.anyscale_gateway_service_certificate_secret_name
     }
     commands = {
-      get_credentials = "az aks get-credentials --resource-group ${local.rg_name} --name ${local.aks_name} --overwrite-existing"
+      get_credentials  = "az aks get-credentials --resource-group ${local.rg_name} --name ${local.aks_name} --overwrite-existing"
+      install_operator = var.install_operator_extension ? null : local.anyscale_operator_helm_command
     }
   })
+}
+
+###############################################################################
+# Manual Helm install outputs (install_operator_extension = false)
+###############################################################################
+output "anyscale_operator_values_file" {
+  value       = var.install_operator_extension ? null : local_file.anyscale_operator_values[0].filename
+  description = "Path to the generated Helm values file for a manual operator install. Null when install_operator_extension=true (the AKS extension installs the operator instead)."
+}
+
+output "anyscale_operator_helm_command" {
+  value       = var.install_operator_extension ? null : local.anyscale_operator_helm_command
+  description = "Ready-to-run `helm install` for the Anyscale operator, using the generated values file. Run `helm repo add anyscale https://anyscale.github.io/helm-charts && helm repo update anyscale` first. Null when install_operator_extension=true."
 }

--- a/examples/azure/aks-new-cluster-azure-controlplane/outputs.tf
+++ b/examples/azure/aks-new-cluster-azure-controlplane/outputs.tf
@@ -7,12 +7,12 @@ output "azure_resource_group_name" {
 }
 
 output "azure_storage_account_name" {
-  value       = var.enable_operator_infrastructure ? azurerm_storage_account.sa[0].name : null
+  value       = local.storage_account_name
   description = "Name of the Azure Storage Account."
 }
 
 output "azure_storage_container_name" {
-  value       = var.enable_operator_infrastructure ? azurerm_storage_container.blob[0].name : null
+  value       = local.storage_container_name
   description = "Name of the Azure Storage Container."
 }
 
@@ -47,12 +47,12 @@ output "acr_login_server" {
 }
 
 output "anyscale_operator_client_id" {
-  value       = var.enable_operator_infrastructure ? azurerm_user_assigned_identity.anyscale_operator[0].client_id : null
+  value       = local.anyscale_operator_client_id
   description = "Client ID of the Anyscale operator user-assigned managed identity."
 }
 
 output "anyscale_operator_principal_id" {
-  value       = var.enable_operator_infrastructure ? azurerm_user_assigned_identity.anyscale_operator[0].principal_id : null
+  value       = local.anyscale_operator_principal_id
   description = "Principal ID of the Anyscale operator user-assigned managed identity."
 }
 
@@ -146,13 +146,13 @@ resource "local_file" "cloud_summary" {
       resource_group    = local.rg_name
       aks_cluster       = local.aks_name
       oidc_issuer_url   = local.aks_oidc_issuer_url
-      storage_account   = var.enable_operator_infrastructure ? azurerm_storage_account.sa[0].name : null
-      storage_container = var.enable_operator_infrastructure ? azurerm_storage_container.blob[0].name : null
+      storage_account   = local.storage_account_name
+      storage_container = local.storage_container_name
       acr_login_server  = var.enable_acr ? azurerm_container_registry.acr[0].login_server : null
     }
     operator_identity = {
-      client_id    = var.enable_operator_infrastructure ? azurerm_user_assigned_identity.anyscale_operator[0].client_id : null
-      principal_id = var.enable_operator_infrastructure ? azurerm_user_assigned_identity.anyscale_operator[0].principal_id : null
+      client_id    = local.anyscale_operator_client_id
+      principal_id = local.anyscale_operator_principal_id
     }
     gateway = {
       lb_hostname                = data.external.gateway_lb.result.address

--- a/examples/azure/aks-new-cluster-azure-controlplane/templates/anyscale-platform-cloud.template.json
+++ b/examples/azure/aks-new-cluster-azure-controlplane/templates/anyscale-platform-cloud.template.json
@@ -143,6 +143,12 @@
       "metadata": {
         "description": "The name for the ACR role assignments nested deployment."
       }
+    },
+    "aksClusterResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "The full resource ID of the AKS cluster whose OIDC issuer the operator's federated identity credential federates against. Required when identityMode is 'managed'."
+      }
     }
   },
   "variables": {
@@ -166,7 +172,7 @@
     {
       "condition": "[equals(parameters('storageMode'), 'managed')]",
       "type": "Microsoft.Storage/storageAccounts",
-      "apiVersion": "2023-01-01",
+      "apiVersion": "2025-08-01",
       "name": "[parameters('storageAccountName')]",
       "location": "[parameters('location')]",
       "sku": {
@@ -185,7 +191,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[parameters('storageBlobServiceDeploymentName')]",
       "resourceGroup": "[variables('storageResourceGroup')]",
       "dependsOn": [
@@ -199,17 +205,17 @@
           "resources": [
             {
               "type": "Microsoft.Storage/storageAccounts/blobServices",
-              "apiVersion": "2023-01-01",
+              "apiVersion": "2025-08-01",
               "name": "[concat(parameters('storageAccountName'), '/default')]",
               "properties": {
                 "cors": {
-                  "corsRules": "[if(equals(parameters('storageMode'), 'existing'), if(contains(string(reference(variables('effectiveBlobServicesResourceId'), '2023-01-01').cors.corsRules), 'https://*.anyscale.com'), reference(variables('effectiveBlobServicesResourceId'), '2023-01-01').cors.corsRules, concat(reference(variables('effectiveBlobServicesResourceId'), '2023-01-01').cors.corsRules, createArray(createObject('allowedOrigins', createArray('https://*.anyscale.com'), 'allowedMethods', createArray('GET', 'HEAD', 'PUT', 'POST', 'DELETE'), 'allowedHeaders', createArray('*'), 'exposedHeaders', createArray('*'), 'maxAgeInSeconds', 3600)))), createArray(createObject('allowedOrigins', createArray('https://*.anyscale.com'), 'allowedMethods', createArray('GET', 'HEAD', 'PUT', 'POST', 'DELETE'), 'allowedHeaders', createArray('*'), 'exposedHeaders', createArray('*'), 'maxAgeInSeconds', 3600)))]"
+                  "corsRules": "[if(equals(parameters('storageMode'), 'existing'), if(contains(string(reference(variables('effectiveBlobServicesResourceId'), '2025-08-01').cors.corsRules), 'https://*.anyscale.com'), reference(variables('effectiveBlobServicesResourceId'), '2025-08-01').cors.corsRules, concat(reference(variables('effectiveBlobServicesResourceId'), '2025-08-01').cors.corsRules, createArray(createObject('allowedOrigins', createArray('https://*.anyscale.com'), 'allowedMethods', createArray('GET', 'HEAD', 'PUT', 'POST', 'DELETE'), 'allowedHeaders', createArray('*'), 'exposedHeaders', createArray('*'), 'maxAgeInSeconds', 3600)))), createArray(createObject('allowedOrigins', createArray('https://*.anyscale.com'), 'allowedMethods', createArray('GET', 'HEAD', 'PUT', 'POST', 'DELETE'), 'allowedHeaders', createArray('*'), 'exposedHeaders', createArray('*'), 'maxAgeInSeconds', 3600)))]"
                 }
               }
             },
             {
               "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
-              "apiVersion": "2023-01-01",
+              "apiVersion": "2025-08-01",
               "name": "[concat(parameters('storageAccountName'), '/default/', variables('containerName'))]",
               "dependsOn": [
                 "[variables('effectiveBlobServicesResourceId')]"
@@ -225,7 +231,7 @@
     {
       "condition": "[equals(parameters('identityMode'), 'managed')]",
       "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
-      "apiVersion": "2023-01-31",
+      "apiVersion": "2024-11-30",
       "name": "[parameters('workloadIdentityName')]",
       "location": "[parameters('location')]",
       "tags": "[union(if(contains(parameters('tagsByResource'), 'Microsoft.ManagedIdentity/userAssignedIdentities'), parameters('tagsByResource')['Microsoft.ManagedIdentity/userAssignedIdentities'], json('{}')), createObject('anyscale-cloud', parameters('cloudName')))]"
@@ -233,7 +239,7 @@
     {
       "condition": "[equals(parameters('identityMode'), 'managed')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[parameters('federatedIdentityDeploymentName')]",
       "resourceGroup": "[variables('identityResourceGroup')]",
       "properties": {
@@ -244,7 +250,7 @@
           "resources": [
             {
               "type": "Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials",
-              "apiVersion": "2023-01-31",
+              "apiVersion": "2024-11-30",
               "name": "[concat(parameters('workloadIdentityName'), '/kubernetes-federated-credential')]",
               "properties": {
                 "issuer": "[reference(parameters('aksClusterResourceId'), '2025-10-01').oidcIssuerProfile.issuerUrl]",
@@ -263,7 +269,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[parameters('storageRoleAssignmentDeploymentName')]",
       "resourceGroup": "[variables('storageResourceGroup')]",
       "dependsOn": [
@@ -283,7 +289,7 @@
               "scope": "[variables('effectiveStorageResourceId')]",
               "properties": {
                 "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('storageBlobDataOwnerRoleId'))]",
-                "principalId": "[reference(variables('effectiveIdentityResourceId'), '2023-01-31').principalId]",
+                "principalId": "[reference(variables('effectiveIdentityResourceId'), '2024-11-30').principalId]",
                 "principalType": "ServicePrincipal"
               }
             }
@@ -294,7 +300,7 @@
     {
       "condition": "[not(equals(parameters('acrMode'), 'none'))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[parameters('acrRoleAssignmentsDeploymentName')]",
       "resourceGroup": "[variables('acrResourceGroup')]",
       "dependsOn": [
@@ -314,7 +320,7 @@
               "scope": "[variables('acrResourceId')]",
               "properties": {
                 "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('acrPushRoleId'))]",
-                "principalId": "[reference(variables('effectiveIdentityResourceId'), '2023-01-31').principalId]",
+                "principalId": "[reference(variables('effectiveIdentityResourceId'), '2024-11-30').principalId]",
                 "principalType": "ServicePrincipal"
               }
             },
@@ -325,7 +331,7 @@
               "scope": "[variables('acrResourceId')]",
               "properties": {
                 "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('acrTaskContributorRoleId'))]",
-                "principalId": "[reference(variables('effectiveIdentityResourceId'), '2023-01-31').principalId]",
+                "principalId": "[reference(variables('effectiveIdentityResourceId'), '2024-11-30').principalId]",
                 "principalType": "ServicePrincipal"
               }
             },
@@ -348,7 +354,7 @@
     {
       "condition": "[equals(parameters('acrMode'), 'managed')]",
       "type": "Microsoft.ContainerRegistry/registries",
-      "apiVersion": "2023-07-01",
+      "apiVersion": "2025-11-01",
       "name": "[variables('acrSafeName')]",
       "location": "[parameters('location')]",
       "sku": {
@@ -387,7 +393,7 @@
         "computeStack": "K8S",
         "cloudStorageBucketName": "[variables('abfssUrl')]",
         "cloudStorageBucketEndpoint": "[variables('blobEndpoint')]",
-        "anyscaleOperatorIamIdentity": "[reference(variables('effectiveIdentityResourceId'), '2023-01-31').principalId]"
+        "anyscaleOperatorIamIdentity": "[reference(variables('effectiveIdentityResourceId'), '2024-11-30').principalId]"
       },
       "tags": "[union(if(contains(parameters('tagsByResource'), 'Anyscale.Platform/clouds/cloudResources'), parameters('tagsByResource')['Anyscale.Platform/clouds/cloudResources'], json('{}')), createObject('anyscale-cloud', parameters('cloudName')))]"
     }
@@ -403,11 +409,11 @@
     },
     "managedIdentityClientId": {
       "type": "string",
-      "value": "[reference(variables('effectiveIdentityResourceId'), '2023-01-31').clientId]"
+      "value": "[reference(variables('effectiveIdentityResourceId'), '2024-11-30').clientId]"
     },
     "managedIdentityPrincipalId": {
       "type": "string",
-      "value": "[reference(variables('effectiveIdentityResourceId'), '2023-01-31').principalId]"
+      "value": "[reference(variables('effectiveIdentityResourceId'), '2024-11-30').principalId]"
     },
     "abfssUrl": {
       "type": "string",
@@ -425,7 +431,7 @@
     "acrLoginServer": {
       "condition": "[equals(parameters('acrMode'), 'managed')]",
       "type": "string",
-      "value": "[if(equals(parameters('acrMode'), 'managed'), reference(resourceId('Microsoft.ContainerRegistry/registries', variables('acrSafeName')), '2023-07-01').loginServer, '')]"
+      "value": "[if(equals(parameters('acrMode'), 'managed'), reference(resourceId('Microsoft.ContainerRegistry/registries', variables('acrSafeName')), '2025-11-01').loginServer, '')]"
     }
   }
 }

--- a/examples/azure/aks-new-cluster-azure-controlplane/terraform.tfvars.example
+++ b/examples/azure/aks-new-cluster-azure-controlplane/terraform.tfvars.example
@@ -172,6 +172,21 @@ anyscale_platform_contributors = [
 #   gateway_lb_wait_timeout_seconds  = 600
 #   gateway_lb_poll_interval_seconds = 10
 # }
+#
+#   Reuse an Envoy Gateway install the cluster already has, rather than
+#   installing the Helm chart, EnvoyProxy and GatewayClass. The Gateway itself
+#   is always created — its listeners reference TLS Secret names derived from
+#   this cloud's cldrsrc_… ID, so it can't be shared between clouds. The class
+#   you point at must resolve to an EnvoyProxy with envoyService.type =
+#   LoadBalancer.
+# create_envoy_gateway = false
+# envoy_gateway = {
+#   gateway_class_name = "their-existing-class"
+# }
+#
+#   Skip creating the operator namespace when adopting a cluster that already
+#   has it (e.g. one that has run an Anyscale operator before).
+# create_operator_namespace = false
 
 # ---------------------------------------------------------------------------
 # CORS for blob storage (default allows Anyscale console access)

--- a/examples/azure/aks-new-cluster-azure-controlplane/terraform.tfvars.example
+++ b/examples/azure/aks-new-cluster-azure-controlplane/terraform.tfvars.example
@@ -46,12 +46,43 @@ tags = {
 }
 
 # ---------------------------------------------------------------------------
+# Create or adopt
+#   Defaults create a resource group, VNet, subnet, AKS cluster and node pools.
+#   To layer Anyscale onto a cluster you already run, uncomment the block
+#   below. The cluster must have the OIDC issuer and Microsoft Entra workload
+#   identity enabled, live in an Anyscale-supported region, and still issue a
+#   certificate-based kubeconfig (local accounts not disabled) — Terraform
+#   checks all four during plan. See "Use an existing AKS cluster" in README.md.
+#
+#   In this mode azure_resource_group_name must be the group holding the
+#   cluster, and azure_location is unused (the group's own region wins).
+# ---------------------------------------------------------------------------
+# create_aks_cluster        = false
+# existing_aks_cluster_name = "my-existing-aks"
+#
+#   Leave create_node_pools = true to have Terraform add the Anyscale-tainted
+#   CPU/GPU pools to the adopted cluster. Set it to false if the cluster's
+#   pools already carry those taints.
+# create_node_pools = true
+
+# ---------------------------------------------------------------------------
 # Networking (defaults are usually fine)
+#   The CIDRs below are ignored when adopting a cluster, or whenever
+#   existing_node_subnet_id is set.
 # ---------------------------------------------------------------------------
 # vnet_cidr               = "10.42.0.0/16"
 # nodes_subnet_cidr       = "10.42.1.0/24"
 # aks_cluster_subnet_cidr = "10.0.0.0/16"
 # aks_cluster_dns_address = null   # auto-derived from aks_cluster_subnet_cidr
+#
+#   Place resources in a resource group that already exists rather than
+#   creating one. Implied when create_aks_cluster = false.
+# create_resource_group   = false
+#   Use a subnet that already exists rather than creating a VNet and subnet.
+#   Add the Microsoft.Storage service endpoint to it yourself if enable_nfs.
+#   When adopting a cluster this is inferred from its first agent pool, so set
+#   it only to override that.
+# existing_node_subnet_id = "/subscriptions/.../subnets/aks-nodes"
 
 # ---------------------------------------------------------------------------
 # Storage
@@ -68,6 +99,11 @@ tags = {
 # ---------------------------------------------------------------------------
 system_vm_size = "Standard_D2s_v5"
 cpu_vm_size    = "Standard_D16s_v5"
+
+# Pin node pools to specific availability zones. Leave unset to let Azure
+# place nodes without a zone constraint. Useful when only some zones in the
+# region have capacity or quota for the VM sizes above.
+# node_pool_zones = ["3"]
 
 # GPU pools are opt-in (default is CPU-only). Each key creates one on-demand +
 # one spot pool. Easiest: run `./select-gpu.sh` to write this block for you.

--- a/examples/azure/aks-new-cluster-azure-controlplane/terraform.tfvars.example
+++ b/examples/azure/aks-new-cluster-azure-controlplane/terraform.tfvars.example
@@ -137,6 +137,11 @@ acr_zone_redundancy_enabled = false        # Premium SKU only
 # ---------------------------------------------------------------------------
 anyscale_operator_namespace      = "anyscale-operator"
 anyscale_operator_serviceaccount = "anyscale-operator"
+# true  = Terraform creates the operator's storage, identity, federated
+#         credential and role assignment, and the ARM template binds to them.
+# false = the ARM template provisions them itself, and they belong to the
+#         Anyscale cloud rather than to Terraform state. Same working result;
+#         see "Who owns the operator's storage and identity" in README.md.
 enable_operator_infrastructure   = true
 
 # Set to false to skip Terraform's automatic Anyscale.AKS.Operator extension

--- a/examples/azure/aks-new-cluster-azure-controlplane/variables.tf
+++ b/examples/azure/aks-new-cluster-azure-controlplane/variables.tf
@@ -60,9 +60,107 @@ variable "azure_resource_group_name" {
     prompts for it interactively unless you supply it via terraform.tfvars, -var,
     or TF_VAR_azure_resource_group_name. Enter an empty value to fall back to
     "<aks_cluster_name>-rg".
+
+    The empty-value fallback only applies when Terraform creates the group. When
+    create_resource_group=false or create_aks_cluster=false this must name a
+    resource group that already exists.
   EOT
   type        = string
   nullable    = false
+}
+
+###############################################################################
+# Create-or-adopt toggles.
+#
+# The defaults reproduce this example's original behaviour: create a resource
+# group, VNet, subnet, AKS cluster and the Anyscale node pools from scratch.
+# See aks_existing.tf for how these resolve, and the README for the
+# prerequisites an adopted cluster has to meet.
+###############################################################################
+variable "create_aks_cluster" {
+  description = <<-EOT
+    (Optional) Create the AKS cluster (and its VNet/subnet). Set to false to
+    layer Anyscale onto a cluster you already run — supply
+    `existing_aks_cluster_name` and `azure_resource_group_name` in that case.
+
+    An adopted cluster must have the OIDC issuer and Microsoft Entra workload
+    identity enabled, live in an Anyscale-supported region, and still issue a
+    certificate-based kubeconfig (i.e. local accounts not disabled). Terraform
+    checks all four before it changes anything.
+  EOT
+  type        = bool
+  nullable    = false
+  default     = true
+}
+
+variable "existing_aks_cluster_name" {
+  description = <<-EOT
+    (Optional) Name of an existing AKS cluster to adopt, in
+    `azure_resource_group_name`. Required when create_aks_cluster=false and
+    ignored otherwise.
+  EOT
+  type        = string
+  nullable    = true
+  default     = null
+}
+
+variable "create_resource_group" {
+  description = <<-EOT
+    (Optional) Create the resource group. Set to false to place the storage
+    account, ACR and operator identity into a resource group that already
+    exists. Forced to false when create_aks_cluster=false, since an adopted
+    cluster brings its own resource group.
+  EOT
+  type        = bool
+  nullable    = false
+  default     = true
+}
+
+variable "existing_node_subnet_id" {
+  description = <<-EOT
+    (Optional) Full resource ID of an existing subnet to place AKS nodes in.
+    When set, Terraform skips creating the VNet and subnet (and `vnet_cidr` /
+    `nodes_subnet_cidr` are unused).
+
+    When adopting a cluster (create_aks_cluster=false) this is normally left
+    null — the subnet is read from the cluster's first agent pool. Set it
+    explicitly if that pool is not in the subnet you want new pools to use.
+
+    Note: `enable_nfs` requires the subnet to carry the `Microsoft.Storage`
+    service endpoint. Terraform adds it to subnets it creates; on a subnet you
+    supply, add it yourself.
+  EOT
+  type        = string
+  nullable    = true
+  default     = null
+}
+
+variable "create_node_pools" {
+  description = <<-EOT
+    (Optional) Create the Anyscale CPU/GPU node pools (on-demand and spot).
+    Set to false when adopting a cluster whose pools already carry the
+    `node.anyscale.com/capacity-type`, `node.anyscale.com/accelerator-type` and
+    `nvidia.com/gpu` taints that the operator tolerates — see
+    `anyscale_platform.extension_configuration_settings` to adjust those
+    tolerations to a different scheme.
+  EOT
+  type        = bool
+  nullable    = false
+  default     = true
+}
+
+variable "node_pool_zones" {
+  description = <<-EOT
+    (Optional) Availability zones for the node pools Terraform creates, e.g.
+    ["3"]. Leave null to let Azure place nodes without a zone constraint.
+
+    Useful when only some zones in a region have capacity or quota for the VM
+    sizes you asked for — `./scan-regional-quotas.sh` and `./select-gpu.sh`
+    help identify that.
+  EOT
+  type        = list(string)
+  nullable    = true
+  default     = null
 }
 
 variable "anyscale_cloud_name" {

--- a/examples/azure/aks-new-cluster-azure-controlplane/variables.tf
+++ b/examples/azure/aks-new-cluster-azure-controlplane/variables.tf
@@ -247,9 +247,11 @@ variable "enable_operator_infrastructure" {
 variable "register_anyscale_resource_provider" {
   description = <<-EOT
     (Optional) Register the Anyscale.Platform resource provider on the
-    subscription via Terraform (azurerm_resource_provider_registration).
-    Set to false if the RP is already registered or your org registers
-    resource providers centrally and disallows registering them per-deploy.
+    subscription via Terraform (`az provider register`, then poll until the
+    RP reports Registered). Safe to leave true when the RP is already
+    registered — the step is a no-op in that case, and destroying does not
+    unregister it. Set to false if your org registers resource providers
+    centrally and disallows registering them per-deploy.
   EOT
   type        = bool
   nullable    = false

--- a/examples/azure/aks-new-cluster-azure-controlplane/variables.tf
+++ b/examples/azure/aks-new-cluster-azure-controlplane/variables.tf
@@ -219,7 +219,17 @@ variable "enable_operator_infrastructure" {
   description = <<-EOT
     (Optional) Enable blob storage, managed identity, federated identity credential,
     role assignment, and output registration/helm commands for the Anyscale operator.
-    Set to false when using the Azure control plane, which provisions these via ARM templates.
+
+    KNOWN BROKEN: setting this to false fails at plan. anyscale.tf references
+    azurerm_storage_account.sa[0], azurerm_storage_container.blob[0] and
+    azurerm_user_assigned_identity.anyscale_operator[0] without guarding on this
+    variable, so they resolve to an invalid index. It could not work as described
+    in any case — the ARM deployment passes storageMode/identityMode = "existing",
+    binding to the resources this flag would have skipped rather than creating its
+    own. Leave it at true.
+
+    If you want to install the operator yourself rather than via the AKS
+    marketplace extension, the flag you want is `install_operator_extension`.
   EOT
   type        = bool
   nullable    = false
@@ -538,8 +548,42 @@ variable "assign_current_user_platform_roles" {
 # Anyscale routes workspace and service traffic through an in-cluster Envoy
 # Gateway. Defaults match the upstream Anyscale quickstart for AKS.
 ###############################################################################
+variable "create_envoy_gateway" {
+  description = <<-EOT
+    (Optional) Install Envoy Gateway — the Helm release, the `EnvoyProxy` that
+    pins the data plane to an external Azure Standard LoadBalancer, and the
+    `GatewayClass`. Set to false to reuse an install the cluster already has,
+    and point `envoy_gateway.gateway_class_name` at the existing class.
+
+    The `Gateway` itself is always created: its HTTPS listeners reference TLS
+    Secret names derived from this cloud's `cldrsrc_…` ID, so it cannot be
+    shared between Anyscale clouds even on the same cluster.
+
+    The GatewayClass you reuse must resolve to an `EnvoyProxy` whose
+    `envoyService.type` is `LoadBalancer`. If it publishes the data plane any
+    other way, the Gateway never gets a `status.addresses` entry and the apply
+    fails at `terraform_data.wait_for_gateway_lb` — which dumps the
+    GatewayClass and its EnvoyProxy on timeout so the cause is visible.
+  EOT
+  type        = bool
+  nullable    = false
+  default     = true
+}
+
+variable "create_operator_namespace" {
+  description = <<-EOT
+    (Optional) Create the `anyscale_operator_namespace` Kubernetes namespace.
+    Set to false when adopting a cluster where that namespace already exists —
+    for example one that has run an Anyscale operator before — since creating
+    it again fails the apply.
+  EOT
+  type        = bool
+  nullable    = false
+  default     = true
+}
+
 variable "envoy_gateway" {
-  description = "(Optional) Envoy Gateway install knobs."
+  description = "(Optional) Envoy Gateway install knobs. `namespace`, `release_name` and `chart_version` apply only when create_envoy_gateway=true; `gateway_class_name` names the class to create or, when reusing, the existing one to bind the Gateway to."
   type = object({
     namespace                        = optional(string, "envoy-gateway-system")
     release_name                     = optional(string, "eg")

--- a/examples/azure/aks-new-cluster-azure-controlplane/variables.tf
+++ b/examples/azure/aks-new-cluster-azure-controlplane/variables.tf
@@ -217,19 +217,27 @@ variable "enable_blob_driver" {
 
 variable "enable_operator_infrastructure" {
   description = <<-EOT
-    (Optional) Enable blob storage, managed identity, federated identity credential,
-    role assignment, and output registration/helm commands for the Anyscale operator.
+    (Optional) Decides who provisions the operator's blob storage, workload
+    identity, federated identity credential and storage role assignment.
 
-    KNOWN BROKEN: setting this to false fails at plan. anyscale.tf references
-    azurerm_storage_account.sa[0], azurerm_storage_container.blob[0] and
-    azurerm_user_assigned_identity.anyscale_operator[0] without guarding on this
-    variable, so they resolve to an invalid index. It could not work as described
-    in any case — the ARM deployment passes storageMode/identityMode = "existing",
-    binding to the resources this flag would have skipped rather than creating its
-    own. Leave it at true.
+    true (default) — Terraform creates them, and the Anyscale.Platform ARM
+    deployment binds to them with storageMode/identityMode = "existing". You
+    keep them in Terraform state, so they are visible in the plan, tagged with
+    var.tags, and removed by `terraform destroy`.
 
-    If you want to install the operator yourself rather than via the AKS
-    marketplace extension, the flag you want is `install_operator_extension`.
+    false — the ARM template provisions them itself in "managed" mode, using
+    the same names Terraform would have used. They belong to the
+    Anyscale.Platform/clouds resource rather than to Terraform, so they do not
+    appear as separate resources in the plan. Their IDs are still surfaced:
+    the operator's client and principal IDs are read back from the ARM
+    deployment's outputs, so the outputs and the operator install work the
+    same either way.
+
+    Either mode produces the same working cloud. Prefer true unless you
+    specifically want the Anyscale RP to own that infrastructure's lifecycle.
+
+    Note this is NOT the flag for installing the operator yourself instead of
+    via the AKS marketplace extension — that is `install_operator_extension`.
   EOT
   type        = bool
   nullable    = false

--- a/examples/azure/aks-new-cluster-azure-controlplane/versions.tf
+++ b/examples/azure/aks-new-cluster-azure-controlplane/versions.tf
@@ -1,5 +1,8 @@
 terraform {
-  required_version = ">= 1.5.0"
+  # 1.7 for the `removed` block in anyscale.tf, which is what keeps an earlier
+  # apply's azurerm_resource_provider_registration from being destroyed (and
+  # thereby unregistering Anyscale.Platform subscription-wide) on upgrade.
+  required_version = ">= 1.7.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/azure/aks-new-cluster-azure-controlplane/versions.tf
+++ b/examples/azure/aks-new-cluster-azure-controlplane/versions.tf
@@ -69,25 +69,25 @@ provider "azapi" {
 # context (old cluster, Lens proxy, etc.) can never be picked up. True single
 # `terraform apply`, no `az aks get-credentials` for the providers.
 provider "kubernetes" {
-  host                   = azurerm_kubernetes_cluster.aks.kube_config[0].host
-  client_certificate     = base64decode(azurerm_kubernetes_cluster.aks.kube_config[0].client_certificate)
-  client_key             = base64decode(azurerm_kubernetes_cluster.aks.kube_config[0].client_key)
-  cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.aks.kube_config[0].cluster_ca_certificate)
+  host                   = local.aks_kube_config.host
+  client_certificate     = base64decode(local.aks_kube_config.client_certificate)
+  client_key             = base64decode(local.aks_kube_config.client_key)
+  cluster_ca_certificate = base64decode(local.aks_kube_config.cluster_ca_certificate)
 }
 
 provider "helm" {
   kubernetes = {
-    host                   = azurerm_kubernetes_cluster.aks.kube_config[0].host
-    client_certificate     = base64decode(azurerm_kubernetes_cluster.aks.kube_config[0].client_certificate)
-    client_key             = base64decode(azurerm_kubernetes_cluster.aks.kube_config[0].client_key)
-    cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.aks.kube_config[0].cluster_ca_certificate)
+    host                   = local.aks_kube_config.host
+    client_certificate     = base64decode(local.aks_kube_config.client_certificate)
+    client_key             = base64decode(local.aks_kube_config.client_key)
+    cluster_ca_certificate = base64decode(local.aks_kube_config.cluster_ca_certificate)
   }
 }
 
 provider "kubectl" {
-  host                   = azurerm_kubernetes_cluster.aks.kube_config[0].host
-  client_certificate     = base64decode(azurerm_kubernetes_cluster.aks.kube_config[0].client_certificate)
-  client_key             = base64decode(azurerm_kubernetes_cluster.aks.kube_config[0].client_key)
-  cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.aks.kube_config[0].cluster_ca_certificate)
+  host                   = local.aks_kube_config.host
+  client_certificate     = base64decode(local.aks_kube_config.client_certificate)
+  client_key             = base64decode(local.aks_kube_config.client_key)
+  cluster_ca_certificate = base64decode(local.aks_kube_config.cluster_ca_certificate)
   load_config_file       = false
 }


### PR DESCRIPTION
Stacked on #89 — that PR adds `examples/azure/aks-new-cluster-azure-controlplane/`, which doesn't exist on `main` yet, so this targets its branch rather than `main`.

## What

The example could only deploy Anyscale onto a cluster it created itself. This adds a create-or-adopt path so it can also layer onto an AKS cluster you already run. All defaults preserve today's behaviour.

`aks_existing.tf` is the single place that knows which mode is active — it resolves the cluster, resource group and node subnet into `local.aks_*`, `local.rg_*` and `local.node_subnet_id`, and every other file reads those. The resources that may or may not be created (cluster, RG, VNet, subnet, CPU pools) gain `count` with `moved` blocks, so existing state migrates to the `[0]` address with no diff.

```hcl
create_aks_cluster        = false
existing_aks_cluster_name = "my-existing-aks"
azure_resource_group_name = "the-group-holding-that-cluster"
```

## Preflight checks

Adoption only works if the cluster meets four requirements the operator depends on. These are asserted at plan time, each failure naming the `az` command that fixes it, rather than failing opaquely mid-apply:

| Requirement | Why |
| --- | --- |
| OIDC issuer enabled | the operator's federated identity credential federates against it |
| Workload identity enabled | the operator uses an Entra token, not a CLI token. Read via `az` — the azurerm data source doesn't expose it |
| Local accounts enabled | `versions.tf` authenticates the kubernetes/helm/kubectl providers with the cluster's client certificate |
| Anyscale-supported region | the cloud, storage, ACR and identity all deploy there |

A fifth catches a kubenet cluster, whose agent pool reports no subnet to place new pools in. A separate preflight covers an adopted **resource group** in an unsupported region — `var.azure_location`'s validation only ever sees a group Terraform creates, but `anyscale.tf` submits the ARM deployment with the group's region.

## New variables

| Variable | Default | Purpose |
| --- | --- | --- |
| `create_aks_cluster` | `true` | adopt instead of create |
| `existing_aks_cluster_name` | `null` | the cluster to adopt |
| `create_resource_group` | `true` | create the cluster in an existing group |
| `existing_node_subnet_id` | `null` | create the cluster in an existing subnet |
| `create_node_pools` | `true` | skip adding the Anyscale-tainted pools |
| `node_pool_zones` | `null` | pin pools to availability zones |

`node_pool_zones` is unrelated to adoption but needed alongside it: capacity and quota vary by zone within a region, and an unpinned pool can land where the requested VM size has none.

## Testing

Three plans against a live Azure subscription:

| Scenario | Result |
| --- | --- |
| Existing state (regression) | all 6 `moved` blocks are pure address migrations — no attribute diffs, no replacements |
| Create mode, clean state | 28 to add, 0 to change, 0 to destroy; `zones` applied to the system pool and both CPU pools |
| Adopt mode, live cluster | 22 to add, 0 to destroy; all 5 preflights passed, outputs read the cluster's real OIDC issuer URL |

The 22-vs-28 delta is exactly the cluster, RG, VNet, subnet and 2 CPU pools.

## Not included

- **kubelogin provider auth.** A cluster with local accounts disabled gets a clear error pointing at `--enable-local-accounts` or at forking `versions.tf`, rather than a speculative `exec`/`kubelogin` path. Happy to add if that's a real customer shape.
- **Adopting an existing storage account or ACR.** Who *provisions* them is now selectable (see `enable_operator_infrastructure` below), but pointing at ones that already exist is a separate set of flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: follow-up commits

**`create_envoy_gateway`** — the Helm release, `EnvoyProxy` and `GatewayClass` are cluster-level and not Anyscale-specific, so a cluster already running Envoy Gateway doesn't need a second copy. The `Gateway` stays unconditional: its listeners reference TLS Secret names derived from this cloud's `cldrsrc_…` ID, so it can't be shared between clouds even on one cluster. The reused class must resolve to an `EnvoyProxy` publishing the data plane as a `LoadBalancer` — if not, the Gateway never gets a `status.addresses` entry, so the `wait_for_gateway_lb` timeout now dumps the GatewayClass and its `envoyService.type`.

**`create_operator_namespace`** — fixes a real bug in the adopt path: `kubernetes_namespace_v1.anyscale_operator` was unconditional and fails outright on a cluster that has run an Anyscale operator before, which is exactly the cluster someone adopting is likely to bring.

**Generated Helm values** — `install_operator_extension = false` now writes `anyscale-operator-values.yaml` and prints a ready-to-run `helm install`. Every value the operator needs is something the apply just produced, and two are easy to miss by hand: an empty `global.auth.anyscaleCliToken` (without which the operator uses CLI-token auth instead of the Entra workload-identity exchange) and the whole `networking.gateway` block, which nothing else supplies once the extension is gone. The values live beside the extension's `configuration_settings` they mirror, rather than in a README that can drift.

**`enable_operator_infrastructure` now works.** It was inert — `false` failed at plan, and even guarded it couldn't have done what it promised, since the ARM deployment was hardcoded to `storageMode`/`identityMode = "existing"`. The template has supported `managed` all along. Wired it up: guarded the parameters, hoisted the names into locals shared by both paths, and exported `managedIdentityClientId`/`PrincipalId` off `effectiveIdentityResourceId` so the operator's client ID is readable whichever side owns the identity. Both modes now produce the same working cloud; the difference is ownership (plan visibility, `var.tags`, destroy behaviour), documented as a table in the README.

### Testing

Three plans, none with any change or destroy:

| Mode | Result |
| --- | --- |
| Create everything | 28 to add |
| Adopt an existing cluster | 22 to add |
| ARM-owned storage + identity | 23 to add — five fewer, exactly what the flag hands over |

### On #61

Not a duplicate. `sahil/aks-existing` adds `examples/azure/aks-existing/`, a separate example for the **self-registered** cloud flow — storage + identity + FIC against an existing cluster, then `helm install --set-string global.cloudDeploymentId=…` by hand, with no `Anyscale.Platform/clouds` resource at all. Different control plane; complementary to this one. No merging needed.
